### PR TITLE
feat: implement Fee Generation tab for Health Metrics section

### DIFF
--- a/src/app/commitments/[id]/page.tsx
+++ b/src/app/commitments/[id]/page.tsx
@@ -7,6 +7,7 @@ import CommitmentHealthMetrics from '@/components/dashboard/CommitmentHealthMetr
 import CommitmentDetailAllocationConstraints from '@/components/CommitmentDetailAllocationConstraints';
 import { CommitmentDetailNftSection } from '@/components/dashboard/CommitmentDetailNftSection';
 import { CommitmentDetailParameters } from '@/components/CommitmentDetailParameters/CommitmentDetailParameters';
+import RecentAttestationsPanel from '@/components/RecentAttestationsPanel/RecentAttestationsPanel';
 
 // Mock Commitments
 const MOCK_COMMITMENTS: Record<
@@ -43,6 +44,63 @@ const MOCK_VALUE_HISTORY_DATA = [
     { date: 'Jan 25', currentValue: 53000, initialAmount: 50000 },
     { date: 'Jan 28', currentValue: 54000, initialAmount: 50000 },
 ];
+
+const MOCK_FEE_GENERATION_DATA = [
+    { date: 'Jan 10', feeAmount: 25 },
+    { date: 'Jan 15', feeAmount: 45 },
+    { date: 'Jan 20', feeAmount: 78 },
+    { date: 'Jan 25', feeAmount: 92 },
+    { date: 'Jan 28', feeAmount: 125 },
+];
+
+const MOCK_ATTESTATIONS = [
+    {
+        id: '1',
+        title: 'Daily Compliance Check',
+        description: 'All parameters within acceptable ranges. No violations detected.',
+        txHash: '0xabcdef1234567890abcdef1234567890',
+        timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000),
+        severity: 'ok' as const,
+    },
+    {
+        id: '2',
+        title: 'Allocation Verified',
+        description: 'Portfolio allocation meets all constraints. Safe protocol usage confirmed.',
+        txHash: '0x123456789abcdef123456789abcdef',
+        timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        severity: 'ok' as const,
+    },
+    {
+        id: '3',
+        title: 'Increased Volatility',
+        description: 'Market volatility increased. Monitoring drawdown levels closely.',
+        txHash: '0x567890abcdef1234567890abcdef1234',
+        timestamp: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
+        severity: 'warning' as const,
+    },
+    {
+        id: '4',
+        title: 'Weekly Review',
+        description: 'Commitment performing well. All rules followed consistently.',
+        txHash: '0x90abcd1234567890abcd345678',
+        timestamp: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
+        severity: 'ok' as const,
+    },
+    {
+        id: '5',
+        title: 'Commitment Created',
+        description: 'Initial commitment parameters set and validated on-chain.',
+        txHash: '0xdef1234567890abcdef890abc',
+        timestamp: new Date(Date.now() - 18 * 24 * 60 * 60 * 1000),
+        severity: 'ok' as const,
+    },
+];
+
+const MOCK_ATTESTATION_SUMMARY = {
+    complianceCount: 4,
+    warningCount: 1,
+    violationCount: 0,
+};
 
 // Mock data for the NFT section
 const MOCK_NFT_DATA = {
@@ -128,8 +186,16 @@ export default function CommitmentDetailPage({
                             complianceData={MOCK_COMPLIANCE_DATA}
                             drawdownData={MOCK_DRAWDOWN_DATA}
                             valueHistoryData={MOCK_VALUE_HISTORY_DATA}
+                            feeGenerationData={MOCK_FEE_GENERATION_DATA}
                             thresholdPercent={0.5}
-                            volatilityPercent={65}
+                            volatilityPercent={35}
+                        />
+
+                        <RecentAttestationsPanel
+                            attestations={MOCK_ATTESTATIONS}
+                            summary={MOCK_ATTESTATION_SUMMARY}
+                            onSelectAttestation={(id) => console.log('Selected attestation:', id)}
+                            onViewAll={() => console.log('View all attestations')}
                         />
                         
                         <CommitmentDetailAllocationConstraints 

--- a/src/components/dashboard/CommitmentHealthMetrics.tsx
+++ b/src/components/dashboard/CommitmentHealthMetrics.tsx
@@ -6,8 +6,8 @@ import { twMerge } from 'tailwind-merge';
 import { HealthMetricsComplianceChart } from './HealthMetricsComplianceChart';
 import { HealthMetricsDrawdownChart } from './HealthMetricsDrawdownChart';
 import { HealthMetricsValueHistoryChart } from './HealthMetricsValueHistoryChart';
-
-
+import { HealthMetricsFeeGenerationChart } from './HealthMetricsFeeGenerationChart';
+import { TrendingUp, TrendingDown, DollarSign, CheckCircle } from 'lucide-react';
 
 function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
@@ -15,10 +15,18 @@ function cn(...inputs: ClassValue[]) {
 
 type TabType = 'value' | 'drawdown' | 'fee' | 'compliance';
 
+const tabIcons: Record<TabType, React.ReactNode> = {
+    value: <TrendingUp className="w-4 h-4" />,
+    drawdown: <TrendingDown className="w-4 h-4" />,
+    fee: <DollarSign className="w-4 h-4" />,
+    compliance: <CheckCircle className="w-4 h-4" />,
+};
+
 interface CommitmentHealthMetricsProps {
     complianceData: Array<{ date: string; complianceScore: number }>;
     drawdownData: Array<{ date: string; drawdownPercent: number }>;
     valueHistoryData: Array<{ date: string; currentValue: number; initialAmount?: number }>;
+    feeGenerationData: Array<{ date: string; feeAmount: number }>;
     thresholdPercent?: number;
     volatilityPercent?: number;
 }
@@ -27,6 +35,7 @@ export default function CommitmentHealthMetrics({
     complianceData,
     drawdownData,
     valueHistoryData,
+    feeGenerationData,
     thresholdPercent,
     volatilityPercent,
 }: CommitmentHealthMetricsProps) {
@@ -50,12 +59,13 @@ export default function CommitmentHealthMetrics({
                             key={tab.id}
                             onClick={() => setActiveTab(tab.id)}
                             className={cn(
-                                'px-4 py-2 text-sm font-medium rounded-md transition-all duration-200',
+                                'flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-all duration-200',
                                 activeTab === tab.id
-                                    ? 'bg-[#222] text-[#4ADE80] shadow-sm'
+                                    ? 'bg-[#222] text-[#0ff0fc] shadow-sm'
                                     : 'text-[#666] hover:text-[#99a1af] hover:bg-[#1a1a1a]'
                             )}
                         >
+                            {tabIcons[tab.id]}
                             {tab.label}
                         </button>
                     ))}
@@ -76,15 +86,14 @@ export default function CommitmentHealthMetrics({
                         volatilityPercent={volatilityPercent}
                     />
                 )}
+                {activeTab === 'fee' && (
+                    <HealthMetricsFeeGenerationChart 
+                        data={feeGenerationData}
+                        volatilityPercent={volatilityPercent}
+                    />
+                )}
                 {activeTab === 'compliance' && (
                     <HealthMetricsComplianceChart data={complianceData} />
-                )}
-                {activeTab !== 'value' && activeTab !== 'compliance' && activeTab !== 'drawdown' && (
-                    <div className="flex items-center justify-center h-[300px] border border-[#222] border-dashed rounded-xl">
-                        <p className="text-[#666]">
-                            {tabs.find((t) => t.id === activeTab)?.label} chart placeholder
-                        </p>
-                    </div>
                 )}
             </div>
         </div>

--- a/src/components/dashboard/HealthMetricsFeeGenerationChart.tsx
+++ b/src/components/dashboard/HealthMetricsFeeGenerationChart.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import React from 'react';
+import {
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    ResponsiveContainer,
+    Legend,
+    Cell,
+} from 'recharts';
+
+import VolatilityExposureMeter from '../VolatilityExposureMeter/VolatilityExposureMeter';
+
+interface HealthMetricsFeeGenerationChartProps {
+    data: Array<{ date: string; feeAmount: number }>;
+    volatilityPercent?: number;
+}
+
+interface TooltipPayload {
+    active?: boolean;
+    payload?: Array<{
+        value: number;
+        dataKey: string;
+        payload: { date: string; feeAmount: number };
+    }>;
+    label?: string;
+}
+
+const CustomTooltip = ({ active, payload, label }: TooltipPayload) => {
+    if (active && payload && payload.length) {
+        return (
+            <div className="bg-[#1a1a1a] border border-[#333] p-3 rounded-lg shadow-lg">
+                <p className="text-[#99a1af] text-sm mb-1">{label}</p>
+                <p className="text-[#0ff0fc] text-sm font-medium">
+                    Fees: ${payload[0].value.toLocaleString()}
+                </p>
+            </div>
+        );
+    }
+    return null;
+};
+
+export const HealthMetricsFeeGenerationChart: React.FC<HealthMetricsFeeGenerationChartProps> = ({
+    data,
+    volatilityPercent,
+}) => {
+    return (
+        <>
+            <div className="w-full h-full min-h-[350px] bg-[#111] rounded-xl p-4 sm:p-6 border border-[#222] shadow-[inset_0_1px_1px_rgba(255,255,255,0.03)]">
+                <ResponsiveContainer width="100%" height={300}>
+                    <BarChart
+                        data={data}
+                        margin={{ top: 10, right: 10, left: -10, bottom: 0 }}
+                        barCategoryGap="20%"
+                    >
+                        <defs>
+                            <linearGradient id="feeBarGradient" x1="0" y1="0" x2="0" y2="1">
+                                <stop offset="0%" stopColor="#0ff0fc" stopOpacity={1} />
+                                <stop offset="100%" stopColor="#0ff0fc" stopOpacity={0.7} />
+                            </linearGradient>
+                            <filter id="feeBarGlow" x="-20%" y="-20%" width="140%" height="140%">
+                                <feGaussianBlur stdDeviation="3" result="blur" />
+                                <feComposite in="SourceGraphic" in2="blur" operator="over" />
+                            </filter>
+                        </defs>
+                        <CartesianGrid
+                            strokeDasharray="3 3"
+                            stroke="#333"
+                            vertical={false}
+                        />
+                        <XAxis
+                            dataKey="date"
+                            stroke="#666"
+                            tick={{ fill: '#666', fontSize: 12 }}
+                            tickLine={false}
+                            axisLine={false}
+                            dy={10}
+                        />
+                        <YAxis
+                            stroke="#666"
+                            tick={{ fill: '#666', fontSize: 12 }}
+                            tickLine={false}
+                            axisLine={false}
+                            tickFormatter={(value) => `${value}`}
+                        />
+                        <Tooltip 
+                            content={<CustomTooltip />} 
+                            cursor={{ fill: 'rgba(255, 255, 255, 0.03)' }} 
+                        />
+                        <Legend
+                            verticalAlign="bottom"
+                            height={36}
+                            content={() => (
+                                <div className="flex items-center justify-center gap-2 mt-4">
+                                    <div className="w-3 h-3 rounded-sm bg-[#0ff0fc]" />
+                                    <span className="text-[#0ff0fc] text-sm">
+                                        Fees ($)
+                                    </span>
+                                </div>
+                            )}
+                        />
+                        <Bar
+                            dataKey="feeAmount"
+                            fill="url(#feeBarGradient)"
+                            radius={[4, 4, 0, 0]}
+                            maxBarSize={60}
+                        >
+                            {data.map((_, index) => (
+                                <Cell 
+                                    key={`cell-${index}`} 
+                                    filter="url(#feeBarGlow)"
+                                />
+                            ))}
+                        </Bar>
+                    </BarChart>
+                </ResponsiveContainer>
+                <div className="mt-4 pt-4 border-t border-[#222]">
+                    <p className="text-[#99a1af] text-sm leading-relaxed text-center sm:text-left">
+                        View fees generated over the commitment period from yield and protocol incentives.
+                    </p>
+                </div>
+            </div>
+
+            {volatilityPercent !== undefined && (
+                <div className="mt-4">
+                    <VolatilityExposureMeter
+                        valuePercent={volatilityPercent}
+                        description="Current exposure to volatile assets based on allocation and market conditions."
+                    />
+                </div>
+            )}
+        </>
+    );
+};


### PR DESCRIPTION
## Summary

Implements the Fee Generation tab for the Health Metrics section on the Commitment Detail page.

## Changes

- Added `HealthMetricsFeeGenerationChart` component with vertical bar chart using Recharts
- Updated `CommitmentHealthMetrics` to include the new tab with icon
- Added mock fee generation data and Recent Attestations panel to the detail page

## Screenshots

<img width="865" height="587" alt="image" src="https://github.com/user-attachments/assets/27670a98-6b75-4647-9ab3-9f03361586d4" />

## Implementation Details

**Chart Features:**
- Teal/cyan bars with gradient fill and subtle glow effect
- Custom tooltip showing date and fee amount on hover
- Legend displaying "Fees ($)" indicator
- Description text explaining the data source

**Technical:**
- Props: `data: Array<{ date: string; feeAmount: number }>`
- Fully responsive across desktop, tablet, and mobile
- Follows existing patterns from other Health Metrics tabs

## Testing

- [x] Tab switching works correctly between all 4 tabs
- [x] Bar chart renders with correct data
- [x] Tooltip displays on hover
- [x] Responsive layout on different screen sizes

Closes #58