### PR TITLE
feat: implement marketplace listing endpoints for Commitment NFTs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1707,6 +1707,7 @@
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1722,6 +1723,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1783,6 +1785,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.54.0.tgz",
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2368,6 +2371,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3485,6 +3489,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3647,6 +3652,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5840,6 +5846,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5954,6 +5961,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5965,6 +5973,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5991,6 +6000,7 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6038,7 +6048,8 @@
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7083,6 +7094,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7198,6 +7210,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8536,6 +8549,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "undici-types": "~6.21.0"
       }
@@ -8551,6 +8565,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -8597,6 +8612,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.54.0.tgz",
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -8936,7 +8952,8 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -9727,6 +9744,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9848,6 +9866,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11256,7 +11275,8 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "possible-typed-array-names": {
       "version": "1.1.0",
@@ -11327,6 +11347,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -11335,6 +11356,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11356,6 +11378,7 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "peer": true,
       "requires": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -11382,7 +11405,8 @@
     "redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "peer": true
     },
     "redux-thunk": {
       "version": "3.1.0",
@@ -12102,7 +12126,8 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "unbox-primitive": {
       "version": "1.1.0",
@@ -12196,6 +12221,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/src/app/api/marketplace/README.md
+++ b/src/app/api/marketplace/README.md
@@ -1,0 +1,88 @@
+# Marketplace API Endpoints
+
+## Create Listing
+
+**POST** `/api/marketplace/listings`
+
+Create a new marketplace listing for a Commitment NFT.
+
+### Request Body
+
+```json
+{
+  "commitmentId": "commitment_123",
+  "price": "1000.50",
+  "currencyAsset": "USDC",
+  "sellerAddress": "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}
+```
+
+### Response (201 Created)
+
+```json
+{
+  "success": true,
+  "data": {
+    "listing": {
+      "id": "listing_1_1234567890",
+      "commitmentId": "commitment_123",
+      "price": "1000.50",
+      "currencyAsset": "USDC",
+      "sellerAddress": "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "status": "Active",
+      "createdAt": "2026-02-25T10:00:00.000Z",
+      "updatedAt": "2026-02-25T10:00:00.000Z"
+    }
+  }
+}
+```
+
+### Error Responses
+
+- **400 Bad Request**: Invalid input data
+- **409 Conflict**: Commitment is already listed
+
+---
+
+## Cancel Listing
+
+**DELETE** `/api/marketplace/listings/[id]?sellerAddress=GXXX...`
+
+Cancel an existing marketplace listing.
+
+### URL Parameters
+
+- `id`: Listing ID (required)
+
+### Query Parameters
+
+- `sellerAddress`: Address of the seller (required)
+
+### Response (200 OK)
+
+```json
+{
+  "success": true,
+  "data": {
+    "listingId": "listing_1_1234567890",
+    "cancelled": true,
+    "message": "Listing cancelled successfully"
+  }
+}
+```
+
+### Error Responses
+
+- **400 Bad Request**: Missing required parameters or invalid seller
+- **404 Not Found**: Listing not found
+- **409 Conflict**: Listing is not active
+
+---
+
+## Implementation Notes
+
+- Currently uses in-memory stub storage
+- Will be replaced with actual Soroban smart contract calls
+- All responses follow the standard API response format
+- Input validation is performed at both the endpoint and service layers
+- Proper error handling with typed error classes

--- a/src/app/api/marketplace/listings/[id]/route.test.ts
+++ b/src/app/api/marketplace/listings/[id]/route.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DELETE } from './route';
+import { NextRequest } from 'next/server';
+import { marketplaceService } from '@/lib/backend/services/marketplace';
+import { NotFoundError, ValidationError, ConflictError } from '@/lib/backend/errors';
+
+// Mock the marketplace service
+vi.mock('@/lib/backend/services/marketplace', () => ({
+  marketplaceService: {
+    cancelListing: vi.fn(),
+  },
+}));
+
+describe('DELETE /api/marketplace/listings/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should cancel a listing successfully', async () => {
+    vi.mocked(marketplaceService.cancelListing).mockResolvedValue(undefined);
+
+    const listingId = 'listing_1_1234567890';
+    const sellerAddress = 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/marketplace/listings/${listingId}?sellerAddress=${sellerAddress}`,
+      {
+        method: 'DELETE',
+      }
+    );
+
+    const response = await DELETE(request, { params: { id: listingId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.listingId).toBe(listingId);
+    expect(data.data.cancelled).toBe(true);
+    expect(data.data.message).toBe('Listing cancelled successfully');
+    expect(marketplaceService.cancelListing).toHaveBeenCalledWith(
+      listingId,
+      sellerAddress
+    );
+  });
+
+  it('should return 400 when listing ID is missing', async () => {
+    const sellerAddress = 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/marketplace/listings/?sellerAddress=${sellerAddress}`,
+      {
+        method: 'DELETE',
+      }
+    );
+
+    const response = await DELETE(request, { params: {} });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+    expect(data.error.message).toBe('Listing ID is required');
+  });
+
+  it('should return 400 when sellerAddress query parameter is missing', async () => {
+    const listingId = 'listing_1_1234567890';
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/marketplace/listings/${listingId}`,
+      {
+        method: 'DELETE',
+      }
+    );
+
+    const response = await DELETE(request, { params: { id: listingId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+    expect(data.error.message).toBe('sellerAddress query parameter is required');
+  });
+
+  it('should return 404 when listing does not exist', async () => {
+    const notFoundError = new NotFoundError('Listing');
+
+    vi.mocked(marketplaceService.cancelListing).mockRejectedValue(notFoundError);
+
+    const listingId = 'nonexistent_listing';
+    const sellerAddress = 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/marketplace/listings/${listingId}?sellerAddress=${sellerAddress}`,
+      {
+        method: 'DELETE',
+      }
+    );
+
+    const response = await DELETE(request, { params: { id: listingId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe('NOT_FOUND');
+  });
+
+  it('should return 400 when seller address does not match', async () => {
+    const validationError = new ValidationError('Only the seller can cancel this listing.');
+
+    vi.mocked(marketplaceService.cancelListing).mockRejectedValue(validationError);
+
+    const listingId = 'listing_1_1234567890';
+    const wrongSellerAddress = 'GWRONGSELLERXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/marketplace/listings/${listingId}?sellerAddress=${wrongSellerAddress}`,
+      {
+        method: 'DELETE',
+      }
+    );
+
+    const response = await DELETE(request, { params: { id: listingId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 409 when listing is not active', async () => {
+    const conflictError = new ConflictError('Only active listings can be cancelled.');
+
+    vi.mocked(marketplaceService.cancelListing).mockRejectedValue(conflictError);
+
+    const listingId = 'listing_already_cancelled';
+    const sellerAddress = 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/marketplace/listings/${listingId}?sellerAddress=${sellerAddress}`,
+      {
+        method: 'DELETE',
+      }
+    );
+
+    const response = await DELETE(request, { params: { id: listingId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe('CONFLICT');
+  });
+});

--- a/src/app/api/marketplace/listings/[id]/route.ts
+++ b/src/app/api/marketplace/listings/[id]/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest } from 'next/server';
+import { withApiHandler } from '@/lib/backend/withApiHandler';
+import { ok } from '@/lib/backend/apiResponse';
+import { ValidationError } from '@/lib/backend/errors';
+import { marketplaceService } from '@/lib/backend/services/marketplace';
+import type { CancelListingResponse } from '@/types/marketplace';
+
+/**
+ * DELETE /api/marketplace/listings/[id]
+ *
+ * Cancel an existing marketplace listing
+ *
+ * Query parameters:
+ *   sellerAddress: string (required) - Address of the seller cancelling the listing
+ */
+export const DELETE = withApiHandler(
+  async (req: NextRequest, { params }: { params: Record<string, string> }) => {
+    const listingId = params.id;
+
+    if (!listingId) {
+      throw new ValidationError('Listing ID is required');
+    }
+
+    // Get sellerAddress from query params
+    const { searchParams } = new URL(req.url);
+    const sellerAddress = searchParams.get('sellerAddress');
+
+    if (!sellerAddress) {
+      throw new ValidationError('sellerAddress query parameter is required');
+    }
+
+    // Cancel listing via service
+    await marketplaceService.cancelListing(listingId, sellerAddress);
+
+    const response: CancelListingResponse = {
+      listingId,
+      cancelled: true,
+      message: 'Listing cancelled successfully',
+    };
+
+    return ok(response);
+  }
+);

--- a/src/app/api/marketplace/listings/route.test.ts
+++ b/src/app/api/marketplace/listings/route.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from './route';
+import { NextRequest } from 'next/server';
+import { marketplaceService } from '@/lib/backend/services/marketplace';
+import { ValidationError, ConflictError } from '@/lib/backend/errors';
+import type { MarketplaceListing } from '@/types/marketplace';
+
+// Mock the marketplace service
+vi.mock('@/lib/backend/services/marketplace', () => ({
+  marketplaceService: {
+    createListing: vi.fn(),
+  },
+}));
+
+describe('POST /api/marketplace/listings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create a listing successfully', async () => {
+    const mockListing: MarketplaceListing = {
+      id: 'listing_1_1234567890',
+      commitmentId: 'commitment_123',
+      price: '1000.50',
+      currencyAsset: 'USDC',
+      sellerAddress: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      status: 'Active',
+      createdAt: '2026-02-25T10:00:00.000Z',
+      updatedAt: '2026-02-25T10:00:00.000Z',
+    };
+
+    vi.mocked(marketplaceService.createListing).mockResolvedValue(mockListing);
+
+    const requestBody = {
+      commitmentId: 'commitment_123',
+      price: '1000.50',
+      currencyAsset: 'USDC',
+      sellerAddress: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    };
+
+    const request = new NextRequest('http://localhost:3000/api/marketplace/listings', {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request, { params: {} });
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.success).toBe(true);
+    expect(data.data.listing).toEqual(mockListing);
+    expect(marketplaceService.createListing).toHaveBeenCalledWith(requestBody);
+  });
+
+  it('should return 400 when request body is invalid JSON', async () => {
+    const request = new NextRequest('http://localhost:3000/api/marketplace/listings', {
+      method: 'POST',
+      body: 'invalid json',
+    });
+
+    const response = await POST(request, { params: {} });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 when request body is not an object', async () => {
+    const request = new NextRequest('http://localhost:3000/api/marketplace/listings', {
+      method: 'POST',
+      body: JSON.stringify('string instead of object'),
+    });
+
+    const response = await POST(request, { params: {} });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 when request body is null', async () => {
+    const request = new NextRequest('http://localhost:3000/api/marketplace/listings', {
+      method: 'POST',
+      body: JSON.stringify(null),
+    });
+
+    const response = await POST(request, { params: {} });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should propagate validation errors from service', async () => {
+    const validationError = new ValidationError('Invalid listing request', {
+      errors: ['price must be a positive number'],
+    });
+
+    vi.mocked(marketplaceService.createListing).mockRejectedValue(validationError);
+
+    const requestBody = {
+      commitmentId: 'commitment_123',
+      price: '-100',
+      currencyAsset: 'USDC',
+      sellerAddress: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    };
+
+    const request = new NextRequest('http://localhost:3000/api/marketplace/listings', {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request, { params: {} });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should propagate conflict errors from service', async () => {
+    const conflictError = new ConflictError('Commitment is already listed on the marketplace.');
+
+    vi.mocked(marketplaceService.createListing).mockRejectedValue(conflictError);
+
+    const requestBody = {
+      commitmentId: 'commitment_duplicate',
+      price: '1000.50',
+      currencyAsset: 'USDC',
+      sellerAddress: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    };
+
+    const request = new NextRequest('http://localhost:3000/api/marketplace/listings', {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request, { params: {} });
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe('CONFLICT');
+  });
+});

--- a/src/app/api/marketplace/listings/route.ts
+++ b/src/app/api/marketplace/listings/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest } from 'next/server';
+import { withApiHandler } from '@/lib/backend/withApiHandler';
+import { ok } from '@/lib/backend/apiResponse';
+import { ValidationError } from '@/lib/backend/errors';
+import { marketplaceService } from '@/lib/backend/services/marketplace';
+import type { CreateListingRequest, CreateListingResponse } from '@/types/marketplace';
+
+/**
+ * POST /api/marketplace/listings
+ *
+ * Create a new marketplace listing for a Commitment NFT
+ *
+ * Request body:
+ * {
+ *   commitmentId: string;
+ *   price: string;
+ *   currencyAsset: string;
+ *   sellerAddress: string;
+ * }
+ */
+export const POST = withApiHandler(async (req: NextRequest) => {
+  let body: unknown;
+
+  try {
+    body = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON in request body');
+  }
+
+  // Validate body structure
+  if (!body || typeof body !== 'object') {
+    throw new ValidationError('Request body must be an object');
+  }
+
+  const request = body as CreateListingRequest;
+
+  // Create listing via service
+  const listing = await marketplaceService.createListing(request);
+
+  const response: CreateListingResponse = {
+    listing,
+  };
+
+  return ok(response, 201);
+});

--- a/src/lib/backend/services/marketplace.test.ts
+++ b/src/lib/backend/services/marketplace.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { marketplaceService } from './marketplace';
+import { ValidationError, ConflictError, NotFoundError } from '../errors';
+import type { CreateListingRequest } from '@/types/marketplace';
+
+describe('MarketplaceService', () => {
+  // Reset service state before each test
+  beforeEach(() => {
+    // Clear internal state by creating listings and then accessing private members
+    // Since we can't directly access private members, we'll work with the public API
+  });
+
+  describe('createListing', () => {
+    it('should create a valid listing', async () => {
+      const request: CreateListingRequest = {
+        commitmentId: 'commitment_123',
+        price: '1000.50',
+        currencyAsset: 'USDC',
+        sellerAddress: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      };
+
+      const listing = await marketplaceService.createListing(request);
+
+      expect(listing).toBeDefined();
+      expect(listing.id).toBeTruthy();
+      expect(listing.commitmentId).toBe(request.commitmentId);
+      expect(listing.price).toBe(request.price);
+      expect(listing.currencyAsset).toBe(request.currencyAsset);
+      expect(listing.sellerAddress).toBe(request.sellerAddress);
+      expect(listing.status).toBe('Active');
+      expect(listing.createdAt).toBeTruthy();
+      expect(listing.updatedAt).toBeTruthy();
+    });
+
+    it('should throw ValidationError when commitmentId is missing', async () => {
+      const request = {
+        price: '1000.50',
+        currencyAsset: 'USDC',
+        sellerAddress: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      } as CreateListingRequest;
+
+      await expect(marketplaceService.createListing(request)).rejects.toThrow(
+        ValidationError
+      );
+    });
+
+    it('should throw ValidationError when price is missing', async () => {
+      const request = {
+        commitmentId: 'commitment_123',
+        currencyAsset: 'USDC',
+        sellerAddress: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      } as CreateListingRequest;
+
+      await expect(marketplaceService.createListing(request)).rejects.toThrow(
+        ValidationError
+      );
+    });
+
+    it('should throw ValidationError when price is not a positive number', async () => {
+      const request: CreateListingRequest = {
+        commitmentId: 'commitment_123',
+        price: '-100',
+        currencyAsset: 'USDC',
+        sellerAddress: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      };
+
+      await expect(marketplaceService.createListing(request)).rejects.toThrow(
+        ValidationError
+      );
+    });
+
+    it('should throw ValidationError when price is zero', async () => {
+      const request: CreateListingRequest = {
+        commitmentId: 'commitment_123',
+        price: '0',
+        currencyAsset: 'USDC',
+        sellerAddress: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      };
+
+      await expect(marketplaceService.createListing(request)).rejects.toThrow(
+        ValidationError
+      );
+    });
+
+    it('should throw ValidationError when price is not a valid number', async () => {
+      const request: CreateListingRequest = {
+        commitmentId: 'commitment_123',
+        price: 'invalid',
+        currencyAsset: 'USDC',
+        sellerAddress: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      };
+
+      await expect(marketplaceService.createListing(request)).rejects.toThrow(
+        ValidationError
+      );
+    });
+
+    it('should throw ValidationError when currencyAsset is missing', async () => {
+      const request = {
+        commitmentId: 'commitment_123',
+        price: '1000.50',
+        sellerAddress: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      } as CreateListingRequest;
+
+      await expect(marketplaceService.createListing(request)).rejects.toThrow(
+        ValidationError
+      );
+    });
+
+    it('should throw ValidationError when sellerAddress is missing', async () => {
+      const request = {
+        commitmentId: 'commitment_123',
+        price: '1000.50',
+        currencyAsset: 'USDC',
+      } as CreateListingRequest;
+
+      await expect(marketplaceService.createListing(request)).rejects.toThrow(
+        ValidationError
+      );
+    });
+
+    it('should throw ConflictError when commitment is already listed', async () => {
+      const request: CreateListingRequest = {
+        commitmentId: 'commitment_duplicate',
+        price: '1000.50',
+        currencyAsset: 'USDC',
+        sellerAddress: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      };
+
+      // Create first listing
+      await marketplaceService.createListing(request);
+
+      // Try to create duplicate listing
+      await expect(marketplaceService.createListing(request)).rejects.toThrow(
+        ConflictError
+      );
+    });
+  });
+
+  describe('cancelListing', () => {
+    it('should cancel an active listing', async () => {
+      const request: CreateListingRequest = {
+        commitmentId: 'commitment_cancel_test',
+        price: '500.00',
+        currencyAsset: 'XLM',
+        sellerAddress: 'GSELLERXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      };
+
+      const listing = await marketplaceService.createListing(request);
+
+      await expect(
+        marketplaceService.cancelListing(listing.id, request.sellerAddress)
+      ).resolves.not.toThrow();
+
+      // Verify listing is cancelled
+      const cancelledListing = await marketplaceService.getListing(listing.id);
+      expect(cancelledListing?.status).toBe('Cancelled');
+    });
+
+    it('should throw NotFoundError when listing does not exist', async () => {
+      await expect(
+        marketplaceService.cancelListing('nonexistent_listing', 'GXXXXXXX')
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('should throw ValidationError when seller address does not match', async () => {
+      const request: CreateListingRequest = {
+        commitmentId: 'commitment_wrong_seller',
+        price: '750.00',
+        currencyAsset: 'USDC',
+        sellerAddress: 'GSELLERXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      };
+
+      const listing = await marketplaceService.createListing(request);
+
+      await expect(
+        marketplaceService.cancelListing(listing.id, 'GWRONGSELLER')
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('should throw ConflictError when trying to cancel a non-active listing', async () => {
+      const request: CreateListingRequest = {
+        commitmentId: 'commitment_already_cancelled',
+        price: '300.00',
+        currencyAsset: 'USDC',
+        sellerAddress: 'GSELLERXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      };
+
+      const listing = await marketplaceService.createListing(request);
+
+      // Cancel once
+      await marketplaceService.cancelListing(listing.id, request.sellerAddress);
+
+      // Try to cancel again
+      await expect(
+        marketplaceService.cancelListing(listing.id, request.sellerAddress)
+      ).rejects.toThrow(ConflictError);
+    });
+  });
+
+  describe('getListing', () => {
+    it('should return a listing by ID', async () => {
+      const request: CreateListingRequest = {
+        commitmentId: 'commitment_get_test',
+        price: '1500.00',
+        currencyAsset: 'USDC',
+        sellerAddress: 'GSELLERXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      };
+
+      const createdListing = await marketplaceService.createListing(request);
+      const retrievedListing = await marketplaceService.getListing(createdListing.id);
+
+      expect(retrievedListing).toBeDefined();
+      expect(retrievedListing?.id).toBe(createdListing.id);
+      expect(retrievedListing?.commitmentId).toBe(request.commitmentId);
+    });
+
+    it('should return null when listing does not exist', async () => {
+      const listing = await marketplaceService.getListing('nonexistent_id');
+      expect(listing).toBeNull();
+    });
+  });
+});

--- a/src/lib/backend/services/marketplace.ts
+++ b/src/lib/backend/services/marketplace.ts
@@ -1,0 +1,158 @@
+import { logger } from '../logger';
+import { ConflictError, NotFoundError, ValidationError } from '../errors';
+import type {
+  MarketplaceListing,
+  CreateListingRequest,
+  ListingStatus,
+} from '@/types/marketplace';
+
+/**
+ * MarketplaceService
+ *
+ * Abstracts marketplace operations for Commitment NFT listings.
+ * Currently uses in-memory stub data. Will be replaced with actual
+ * on-chain contract calls in the future.
+ */
+class MarketplaceService {
+  // In-memory stub storage (replace with contract calls)
+  private listings: Map<string, MarketplaceListing> = new Map();
+  private listingCounter = 0;
+
+  /**
+   * Create a new marketplace listing for a Commitment NFT
+   */
+  async createListing(request: CreateListingRequest): Promise<MarketplaceListing> {
+    logger.info('[MarketplaceService] Creating listing', { request });
+
+    // Validate request
+    this.validateCreateListingRequest(request);
+
+    // Check if commitment is already listed
+    const existingListing = Array.from(this.listings.values()).find(
+      (listing) =>
+        listing.commitmentId === request.commitmentId && listing.status === 'Active'
+    );
+
+    if (existingListing) {
+      throw new ConflictError(
+        'Commitment is already listed on the marketplace.',
+        { commitmentId: request.commitmentId, existingListingId: existingListing.id }
+      );
+    }
+
+    // Generate listing ID
+    this.listingCounter++;
+    const listingId = `listing_${this.listingCounter}_${Date.now()}`;
+
+    // Create listing object
+    const listing: MarketplaceListing = {
+      id: listingId,
+      commitmentId: request.commitmentId,
+      price: request.price,
+      currencyAsset: request.currencyAsset,
+      sellerAddress: request.sellerAddress,
+      status: 'Active',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    // Store listing (stub - replace with contract call)
+    this.listings.set(listingId, listing);
+
+    logger.info('[MarketplaceService] Listing created', { listingId });
+
+    // TODO: Replace with actual contract interaction
+    // await marketplaceContract.createListing({
+    //   commitmentId: request.commitmentId,
+    //   price: request.price,
+    //   currencyAsset: request.currencyAsset,
+    //   seller: request.sellerAddress,
+    // });
+
+    return listing;
+  }
+
+  /**
+   * Cancel an existing marketplace listing
+   */
+  async cancelListing(listingId: string, sellerAddress: string): Promise<void> {
+    logger.info('[MarketplaceService] Cancelling listing', { listingId, sellerAddress });
+
+    // Retrieve listing
+    const listing = this.listings.get(listingId);
+
+    if (!listing) {
+      throw new NotFoundError('Listing', { listingId });
+    }
+
+    // Verify seller
+    if (listing.sellerAddress !== sellerAddress) {
+      throw new ValidationError('Only the seller can cancel this listing.', {
+        listingId,
+        expectedSeller: listing.sellerAddress,
+        providedSeller: sellerAddress,
+      });
+    }
+
+    // Check if listing is active
+    if (listing.status !== 'Active') {
+      throw new ConflictError('Only active listings can be cancelled.', {
+        listingId,
+        currentStatus: listing.status,
+      });
+    }
+
+    // Update listing status
+    listing.status = 'Cancelled';
+    listing.updatedAt = new Date().toISOString();
+    this.listings.set(listingId, listing);
+
+    logger.info('[MarketplaceService] Listing cancelled', { listingId });
+
+    // TODO: Replace with actual contract interaction
+    // await marketplaceContract.cancelListing(listingId, sellerAddress);
+  }
+
+  /**
+   * Get a listing by ID (helper method for future use)
+   */
+  async getListing(listingId: string): Promise<MarketplaceListing | null> {
+    return this.listings.get(listingId) || null;
+  }
+
+  /**
+   * Validate create listing request
+   */
+  private validateCreateListingRequest(request: CreateListingRequest): void {
+    const errors: string[] = [];
+
+    if (!request.commitmentId || typeof request.commitmentId !== 'string') {
+      errors.push('commitmentId is required and must be a string');
+    }
+
+    if (!request.price || typeof request.price !== 'string') {
+      errors.push('price is required and must be a string');
+    } else {
+      // Validate price is a positive number
+      const priceNum = parseFloat(request.price);
+      if (isNaN(priceNum) || priceNum <= 0) {
+        errors.push('price must be a positive number');
+      }
+    }
+
+    if (!request.currencyAsset || typeof request.currencyAsset !== 'string') {
+      errors.push('currencyAsset is required and must be a string');
+    }
+
+    if (!request.sellerAddress || typeof request.sellerAddress !== 'string') {
+      errors.push('sellerAddress is required and must be a string');
+    }
+
+    if (errors.length > 0) {
+      throw new ValidationError('Invalid listing request', { errors });
+    }
+  }
+}
+
+// Export singleton instance
+export const marketplaceService = new MarketplaceService();

--- a/src/types/marketplace.ts
+++ b/src/types/marketplace.ts
@@ -1,0 +1,29 @@
+export type ListingStatus = 'Active' | 'Sold' | 'Cancelled';
+
+export interface MarketplaceListing {
+  id: string;
+  commitmentId: string;
+  price: string;
+  currencyAsset: string;
+  sellerAddress: string;
+  status: ListingStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateListingRequest {
+  commitmentId: string;
+  price: string;
+  currencyAsset: string;
+  sellerAddress: string;
+}
+
+export interface CreateListingResponse {
+  listing: MarketplaceListing;
+}
+
+export interface CancelListingResponse {
+  listingId: string;
+  cancelled: boolean;
+  message: string;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
Add POST and DELETE endpoints to create and cancel marketplace listings
for Commitment NFTs with comprehensive validation and error handling.

Changes:
- Created marketplace types (MarketplaceListing, CreateListingRequest, etc.)
- Implemented MarketplaceService with in-memory stub storage
  - createListing: validates input and prevents duplicate active listings
  - cancelListing: verifies seller and listing status before cancellation
  - getListing: helper method for retrieving listings by ID
- Added POST /api/marketplace/listings endpoint to create listings
- Added DELETE /api/marketplace/listings/[id] endpoint to cancel listings
- Both endpoints use shared API response format and error handling
- Service layer abstracts on-chain calls (ready for future contract integration)
- Added comprehensive test coverage (27 tests, all passing)
- Created API documentation in src/app/api/marketplace/README.md


Validation:
- Required fields: commitmentId, price, currencyAsset, sellerAddress
- Price must be a positive number
- Prevents duplicate active listings for same commitment
- Seller verification on cancellation
- Only active listings can be cancelled

Error Handling:
- 400 Bad Request: Invalid input or validation errors
- 404 Not Found: Listing not found
- 409 Conflict: Duplicate listing or invalid status

How to Test:
1. Run all marketplace tests:
   npm test -- marketplace

2. Run individual test suites:
   npm test -- src/lib/backend/services/marketplace.test.ts
   npm test -- src/app/api/marketplace/listings/route.test.ts
   npm test -- src/app/api/marketplace/listings/[id]/route.test.ts

closes #118
