### PR TITLE
feat: implement standard JSON response and error format (#105)

### DIFF
--- a/docs/api-response-format.md
+++ b/docs/api-response-format.md
@@ -1,0 +1,147 @@
+# Standard JSON Response & Error Format
+
+**Reference:** [#105 - Standard JSON Response & Error Format](https://github.com/Commitlabs-Org/Commitlabs-Frontend/issues/105)
+
+All API routes in this project return a consistent JSON envelope so that the frontend and any consumers can handle responses uniformly.
+
+---
+
+## Success shape
+
+```json
+{
+  "ok": true,
+  "data": { ... },
+  "meta": { "total": 42, "page": 1 }
+}
+```
+
+| Field  | Type                      | Always present | Description                              |
+|--------|---------------------------|----------------|------------------------------------------|
+| `ok`   | `true`                    | ✅              | Discriminant — always `true` on success  |
+| `data` | `T`                       | ✅              | The response payload                     |
+| `meta` | `Record<string, unknown>` | ❌              | Optional pagination / extra context      |
+
+---
+
+## Error shape
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Commitment not found.",
+    "details": { ... }
+  }
+}
+```
+
+| Field           | Type      | Always present | Description                                      |
+|-----------------|-----------|----------------|--------------------------------------------------|
+| `ok`            | `false`   | ✅              | Discriminant — always `false` on error           |
+| `error.code`    | `string`  | ✅              | Short machine-readable code (see table below)    |
+| `error.message` | `string`  | ✅              | Human-readable message safe for UI display       |
+| `error.details` | `unknown` | ❌              | Extra context (never expose sensitive data here) |
+
+---
+
+## Error codes
+
+| Code                   | HTTP status | Error class           |
+|------------------------|-------------|-----------------------|
+| `BAD_REQUEST`          | 400         | `BadRequestError`     |
+| `VALIDATION_ERROR`     | 400         | `ValidationError`     |
+| `UNAUTHORIZED`         | 401         | `UnauthorizedError`   |
+| `FORBIDDEN`            | 403         | `ForbiddenError`      |
+| `NOT_FOUND`            | 404         | `NotFoundError`       |
+| `CONFLICT`             | 409         | `ConflictError`       |
+| `TOO_MANY_REQUESTS`    | 429         | `TooManyRequestsError`|
+| `INTERNAL_ERROR`       | 500         | `InternalError`       |
+
+---
+
+## How to use
+
+### Returning a success response
+
+```ts
+import { ok } from '@/lib/backend/apiResponse';
+
+// Simple success
+return ok({ status: 'healthy' });
+// → { ok: true, data: { status: 'healthy' } }
+
+// With meta (e.g. pagination)
+return ok(items, { total: 100, page: 2, pageSize: 20 });
+// → { ok: true, data: [...], meta: { total: 100, page: 2, pageSize: 20 } }
+```
+
+### Returning an error response
+
+```ts
+import { fail } from '@/lib/backend/apiResponse';
+
+return fail('NOT_FOUND', 'Commitment not found.', undefined, 404);
+// → { ok: false, error: { code: 'NOT_FOUND', message: 'Commitment not found.' } }
+```
+
+### Using typed error classes (recommended)
+
+Throw a typed error inside any route wrapped with `withApiHandler` — it will be caught and converted into the correct error response automatically.
+
+```ts
+import { withApiHandler } from '@/lib/backend/withApiHandler';
+import { ok } from '@/lib/backend/apiResponse';
+import { NotFoundError, ValidationError } from '@/lib/backend/errors';
+
+export const GET = withApiHandler(async (req) => {
+    const commitment = await findCommitment(id);
+    if (!commitment) {
+        throw new NotFoundError('Commitment');
+        // → 404: { ok: false, error: { code: 'NOT_FOUND', message: 'Commitment not found.' } }
+    }
+    return ok(commitment);
+});
+```
+
+Available error classes (all from `@/lib/backend/errors`):
+
+| Class                 | Default status |
+|-----------------------|----------------|
+| `BadRequestError`     | 400            |
+| `ValidationError`     | 400            |
+| `UnauthorizedError`   | 401            |
+| `ForbiddenError`      | 403            |
+| `NotFoundError`       | 404            |
+| `ConflictError`       | 409            |
+| `TooManyRequestsError`| 429            |
+| `InternalError`       | 500            |
+
+### Full route example (health check)
+
+```ts
+// src/app/api/health/route.ts
+import { withApiHandler } from '@/lib/backend/withApiHandler';
+import { ok } from '@/lib/backend/apiResponse';
+
+export const GET = withApiHandler(async () => {
+    return ok({ status: 'healthy' });
+    // GET /api/health → 200 { ok: true, data: { status: 'healthy' } }
+});
+```
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/lib/backend/apiResponse.ts` | `ok()` and `fail()` response helpers |
+| `src/lib/backend/errors.ts`      | Typed error classes with HTTP status codes |
+| `src/lib/backend/withApiHandler.ts` | HOF that catches `ApiError` and calls `fail()` |
+| `docs/api-response-format.md`    | This document |
+
+---
+
+*Created as part of issue #105. Update this document when new error codes are introduced.*

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,13 +1,9 @@
-import { NextResponse, NextRequest } from 'next/server';
-import { attachSecurityHeaders } from '@/utils/response';
+import { withApiHandler } from '@/lib/backend/withApiHandler';
+import { ok } from '@/lib/backend/apiResponse';
 import { logInfo } from '@/lib/backend/logger';
+import { NextRequest } from 'next/server';
 
-export async function GET(req: NextRequest) {
-  logInfo(req, 'Healthcheck requested');
-import { logger } from '@/lib/backend';
-
-export async function GET() {
-  logger.info('Health check requested');
-  const response = NextResponse.json({ status: 'ok', timestamp: new Date().toISOString() });
-  return attachSecurityHeaders(response);
-}
+export const GET = withApiHandler(async (req: NextRequest) => {
+    logInfo(req, 'Health check requested');
+    return ok({ status: 'healthy' });
+});

--- a/src/lib/backend/errors.ts
+++ b/src/lib/backend/errors.ts
@@ -1,3 +1,102 @@
+// ─── Base API error ───────────────────────────────────────────────────────────
+
+export class ApiError extends Error {
+    constructor(
+        public readonly message: string,
+        public readonly code: string,
+        public readonly statusCode: number,
+        public readonly details?: unknown
+    ) {
+        super(message);
+        this.name = 'ApiError';
+    }
+}
+
+// ─── Named subclasses ─────────────────────────────────────────────────────────
+
+/** 400 — malformed or invalid request input. */
+export class BadRequestError extends ApiError {
+    constructor(message = 'Bad request.', details?: unknown) {
+        super(message, 'BAD_REQUEST', 400, details);
+        this.name = 'BadRequestError';
+    }
+}
+
+/** 400 — request body / query params failed validation. */
+export class ValidationError extends ApiError {
+    constructor(message = 'Invalid request data.', details?: unknown) {
+        super(message, 'VALIDATION_ERROR', 400, details);
+        this.name = 'ValidationError';
+    }
+}
+
+/** 401 — missing or invalid authentication credentials. */
+export class UnauthorizedError extends ApiError {
+    constructor(message = 'Authentication required.', details?: unknown) {
+        super(message, 'UNAUTHORIZED', 401, details);
+        this.name = 'UnauthorizedError';
+    }
+}
+
+/** 403 — authenticated but not permitted to perform the action. */
+export class ForbiddenError extends ApiError {
+    constructor(message = 'You do not have permission to perform this action.', details?: unknown) {
+        super(message, 'FORBIDDEN', 403, details);
+        this.name = 'ForbiddenError';
+    }
+}
+
+/** 404 — requested resource does not exist. */
+export class NotFoundError extends ApiError {
+    constructor(resource = 'Resource', details?: unknown) {
+        super(`${resource} not found.`, 'NOT_FOUND', 404, details);
+        this.name = 'NotFoundError';
+    }
+}
+
+/** 409 — request conflicts with current state (e.g. duplicate). */
+export class ConflictError extends ApiError {
+    constructor(message = 'A conflict occurred.', details?: unknown) {
+        super(message, 'CONFLICT', 409, details);
+        this.name = 'ConflictError';
+    }
+}
+
+/** 429 — client has exceeded the allowed request rate. */
+export class TooManyRequestsError extends ApiError {
+    constructor(message = 'Too many requests. Please try again later.', details?: unknown) {
+        super(message, 'TOO_MANY_REQUESTS', 429, details);
+        this.name = 'TooManyRequestsError';
+    }
+}
+
+/** 500 — unexpected server-side failure. */
+export class InternalError extends ApiError {
+    constructor(message = 'An unexpected error occurred. Please try again later.', details?: unknown) {
+        super(message, 'INTERNAL_ERROR', 500, details);
+        this.name = 'InternalError';
+    }
+}
+
+// ─── HTTP status → error code mapping ────────────────────────────────────────
+
+/** Map of HTTP status codes to their canonical error code strings. */
+export const HTTP_ERROR_CODES: Record<number, string> = {
+    400: 'BAD_REQUEST',
+    401: 'UNAUTHORIZED',
+    403: 'FORBIDDEN',
+    404: 'NOT_FOUND',
+    409: 'CONFLICT',
+    422: 'UNPROCESSABLE_ENTITY',
+    429: 'TOO_MANY_REQUESTS',
+    500: 'INTERNAL_ERROR',
+    502: 'BAD_GATEWAY',
+    503: 'SERVICE_UNAVAILABLE',
+    504: 'GATEWAY_TIMEOUT',
+};
+
+// ─── Legacy BackendError (kept for backward compatibility) ────────────────────
+
 export type BackendErrorCode =
   | 'BAD_REQUEST'
   | 'NOT_FOUND'
@@ -48,11 +147,7 @@ export function normalizeBackendError(
   if (isBackendError(error)) {
     return error;
   }
-
-  return new BackendError({
-    ...fallback,
-    cause: error
-  });
+  return new BackendError({ ...fallback, cause: error });
 }
 
 export function toBackendErrorResponse(error: BackendError): BackendErrorResponseBody {
@@ -60,60 +155,7 @@ export function toBackendErrorResponse(error: BackendError): BackendErrorRespons
     error: {
       code: error.code,
       message: error.message,
-      details: error.details
-    }
+      details: error.details,
+    },
   };
-}
-export class ApiError extends Error {
-    constructor(
-        public readonly message: string,
-        public readonly code: string,
-        public readonly statusCode: number,
-        public readonly details?: unknown
-    ) {
-        super(message);
-        this.name = 'ApiError';
-    }
-}
-
-export class NotFoundError extends ApiError {
-    constructor(resource = 'Resource', details?: unknown) {
-        super(`${resource} not found.`, 'NOT_FOUND', 404, details);
-        this.name = 'NotFoundError';
-    }
-}
-
-export class ValidationError extends ApiError {
-    constructor(message = 'Invalid request data.', details?: unknown) {
-        super(message, 'VALIDATION_ERROR', 400, details);
-        this.name = 'ValidationError';
-    }
-}
-
-export class UnauthorizedError extends ApiError {
-    constructor(message = 'Authentication required.', details?: unknown) {
-        super(message, 'UNAUTHORIZED', 401, details);
-        this.name = 'UnauthorizedError';
-    }
-}
-
-export class ForbiddenError extends ApiError {
-    constructor(message = 'You do not have permission to perform this action.', details?: unknown) {
-        super(message, 'FORBIDDEN', 403, details);
-        this.name = 'ForbiddenError';
-    }
-}
-
-export class ConflictError extends ApiError {
-    constructor(message = 'A conflict occurred.', details?: unknown) {
-        super(message, 'CONFLICT', 409, details);
-        this.name = 'ConflictError';
-    }
-}
-
-export class TooManyRequestsError extends ApiError {
-    constructor(message = 'Too many requests. Please try again later.', details?: unknown) {
-        super(message, 'TOO_MANY_REQUESTS', 429, details);
-        this.name = 'TooManyRequestsError';
-    }
 }

--- a/src/lib/backend/index.ts
+++ b/src/lib/backend/index.ts
@@ -1,6 +1,6 @@
 export { logger } from './logger';
 export { ok, fail } from './apiResponse';
-export type { ApiSuccess, ApiError as ApiErrorResponse, ApiResponse } from './apiResponse';
+export type { OkResponse, FailResponse, ApiResponse } from './apiResponse';
 export { getBackendConfig } from './config';
 export {
     createCommitmentOnChain,
@@ -16,10 +16,14 @@ export {
 } from './validation';
 export {
     ApiError,
-    NotFoundError,
+    BadRequestError,
     ValidationError,
     UnauthorizedError,
     ForbiddenError,
+    NotFoundError,
     ConflictError,
+    TooManyRequestsError,
+    InternalError,
+    HTTP_ERROR_CODES,
 } from './errors';
 export { withApiHandler } from './withApiHandler';

--- a/src/lib/backend/withApiHandler.ts
+++ b/src/lib/backend/withApiHandler.ts
@@ -45,7 +45,7 @@ export function withApiHandler(handler: RouteHandler): RouteHandler {
                     method: req.method,
                 });
 
-                return fail(err.message, err.code, err.statusCode, err.details);
+                return fail(err.code, err.message, err.details, err.statusCode);
             }
 
             const error = err instanceof Error ? err : new Error(String(err));
@@ -56,8 +56,9 @@ export function withApiHandler(handler: RouteHandler): RouteHandler {
             });
 
             return fail(
-                'An unexpected error occurred. Please try again later.',
                 'INTERNAL_ERROR',
+                'An unexpected error occurred. Please try again later.',
+                undefined,
                 500
             );
         }


### PR DESCRIPTION
## Summary

- Rewrote `src/lib/backend/apiResponse.ts` with a standard `{ ok: true/false }` JSON envelope — `ok<T>(data, meta?, status?)` for successes and `fail(code, message, details?, status?)` for errors — backed by `NextResponse.json()` internally
- Extended `src/lib/backend/errors.ts` with `BadRequestError` (400) and `InternalError` (500), added an `HTTP_ERROR_CODES` map (status → error code string), and preserved the legacy `BackendError` for backward compatibility
- Fixed the broken `src/app/api/health/route.ts` (had duplicate/conflicting imports); it now returns `{ ok: true, data: { status: 'healthy' } }` via `withApiHandler`
- Updated `src/lib/backend/withApiHandler.ts` call sites to use the new `fail(code, message, details, status)` signature
- Exported all new types (`OkResponse`, `FailResponse`, `BadRequestError`, `InternalError`, `HTTP_ERROR_CODES`) from `src/lib/backend/index.ts`
- Added `docs/api-response-format.md` documenting the response shapes, full error codes reference table, and usage examples

## Response shapes

**Success**
```json
{ "ok": true, "data": { ... }, "meta": { "total": 42 } }
```

**Error**
```json
{ "ok": false, "error": { "code": "NOT_FOUND", "message": "Commitment not found." } }
```

## Test plan

- [ ] `GET /api/health` returns `200 { ok: true, data: { status: 'healthy' } }`
- [ ] Throwing `NotFoundError` inside a `withApiHandler` route returns `404 { ok: false, error: { code: 'NOT_FOUND', ... } }`
- [ ] Throwing `ValidationError` returns `400 { ok: false, error: { code: 'VALIDATION_ERROR', ... } }`
- [ ] Unhandled exceptions inside `withApiHandler` return `500 { ok: false, error: { code: 'INTERNAL_ERROR', ... } }`
- [ ] `ok(data, 201)` returns the correct HTTP status with the standard success envelope
- [ ] `ok(data, { total: 10 })` includes `meta` in the response body
- [ ] TypeScript compiles with no errors in the changed files

Closes #105
