### PR TITLE
fix: Backend - Add JSON body size limits and return 413 for oversized payloads

### DIFF
--- a/src/app/api/attestations/route.ts
+++ b/src/app/api/attestations/route.ts
@@ -7,11 +7,13 @@ import {
 import {
   normalizeBackendError,
   toBackendErrorResponse,
+  ApiError,
   ValidationError,
   TooManyRequestsError,
 } from '@/lib/backend/errors';
 import { withApiHandler } from '@/lib/backend/withApiHandler';
 import { ok } from '@/lib/backend/apiResponse';
+import { parseJsonWithLimit, JSON_BODY_LIMITS } from '@/lib/backend/jsonBodyLimit';
 import { getMockData } from '@/lib/backend/mockDb';
 import type { RecordAttestationOnChainParams } from '@/lib/backend/services/contracts';
 
@@ -180,10 +182,14 @@ export const POST = withApiHandler(async (req: NextRequest) => {
 
   let body: RecordAttestationRequestBody;
   try {
-    const raw = await req.json();
+    const raw = await parseJsonWithLimit(req, {
+      limitBytes: JSON_BODY_LIMITS.attestationsCreate,
+    });
     body = parseAndValidateBody(raw);
   } catch (err) {
-    if (err instanceof ValidationError) throw err;
+    // Preserve 413 / 400 / other ApiError semantics; only generic failures
+    // are remapped to a 400 "Invalid JSON" error.
+    if (err instanceof ApiError) throw err;
     throw new ValidationError('Invalid JSON in request body.');
   }
 

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 import { checkRateLimit } from '@/lib/backend/rateLimit';
 import { withApiHandler } from '@/lib/backend/withApiHandler';
 import { ok } from '@/lib/backend/apiResponse';
-import { TooManyRequestsError, ValidationError, UnauthorizedError } from '@/lib/backend/errors';
+import { ApiError, TooManyRequestsError, ValidationError, UnauthorizedError } from '@/lib/backend/errors';
+import { parseJsonWithLimit, JSON_BODY_LIMITS } from '@/lib/backend/jsonBodyLimit';
 import { verifySignatureWithNonce, createSessionToken } from '@/lib/backend/auth';
 
 // Request validation schema
@@ -22,11 +23,14 @@ export const POST = withApiHandler(async (req: NextRequest) => {
         throw new TooManyRequestsError();
     }
 
-    // Parse and validate request body
-    let body;
+    // Parse and validate request body (with payload size enforcement)
+    let body: unknown;
     try {
-        body = await req.json();
-    } catch (error) {
+        body = await parseJsonWithLimit(req, {
+            limitBytes: JSON_BODY_LIMITS.authVerify,
+        });
+    } catch (err) {
+        if (err instanceof ApiError) throw err;
         throw new ValidationError('Invalid JSON in request body');
     }
 

--- a/src/app/api/commitments/route.ts
+++ b/src/app/api/commitments/route.ts
@@ -3,6 +3,7 @@ import { checkRateLimit } from "@/lib/backend/rateLimit";
 import { withApiHandler } from "@/lib/backend/withApiHandler";
 import { ok, fail } from "@/lib/backend/apiResponse";
 import { TooManyRequestsError } from "@/lib/backend/errors";
+import { parseJsonWithLimit, JSON_BODY_LIMITS } from "@/lib/backend/jsonBodyLimit";
 import { getUserCommitmentsFromChain, createCommitmentOnChain } from "@/lib/backend/services/contracts";
 
 interface CreateCommitmentRequestBody {
@@ -75,7 +76,10 @@ export const POST = withApiHandler(async (req: NextRequest) => {
     throw new TooManyRequestsError();
   }
 
-  const body = (await req.json()) as CreateCommitmentRequestBody;
+  const parsed = await parseJsonWithLimit(req, {
+    limitBytes: JSON_BODY_LIMITS.commitmentsCreate,
+  });
+  const body = (parsed ?? {}) as Partial<CreateCommitmentRequestBody>;
 
   const {
     ownerAddress,

--- a/src/app/api/marketplace/listings/route.ts
+++ b/src/app/api/marketplace/listings/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { ok } from '@/lib/backend/apiResponse';
 import { checkRateLimit } from '@/lib/backend/rateLimit';
 import { withApiHandler } from '@/lib/backend/withApiHandler';
-import { ValidationError } from '@/lib/backend/errors';
+import { ApiError, ValidationError } from '@/lib/backend/errors';
+import { parseJsonWithLimit, JSON_BODY_LIMITS } from '@/lib/backend/jsonBodyLimit';
 import {
     getMarketplaceSortKeys,
     isMarketplaceSortBy,
@@ -129,8 +130,11 @@ export const POST = withApiHandler(async (req: NextRequest) => {
         let body: unknown;
 
         try {
-                body = await req.json();
-        } catch {
+                body = await parseJsonWithLimit(req, {
+                        limitBytes: JSON_BODY_LIMITS.marketplaceListingsCreate,
+                });
+        } catch (err) {
+                if (err instanceof ApiError) throw err;
                 throw new ValidationError('Invalid JSON in request body');
         }
 

--- a/src/lib/backend/errors.ts
+++ b/src/lib/backend/errors.ts
@@ -62,6 +62,14 @@ export class ConflictError extends ApiError {
     }
 }
 
+/** 413 — request entity is larger than the server is willing to process. */
+export class PayloadTooLargeError extends ApiError {
+    constructor(message = 'Request body is too large.', details?: unknown) {
+        super(message, 'PAYLOAD_TOO_LARGE', 413, details);
+        this.name = 'PayloadTooLargeError';
+    }
+}
+
 /** 429 — client has exceeded the allowed request rate. */
 export class TooManyRequestsError extends ApiError {
     constructor(message = 'Too many requests. Please try again later.', details?: unknown) {
@@ -87,6 +95,7 @@ export const HTTP_ERROR_CODES: Record<number, string> = {
     403: 'FORBIDDEN',
     404: 'NOT_FOUND',
     409: 'CONFLICT',
+    413: 'PAYLOAD_TOO_LARGE',
     422: 'UNPROCESSABLE_ENTITY',
     429: 'TOO_MANY_REQUESTS',
     500: 'INTERNAL_ERROR',

--- a/src/lib/backend/index.ts
+++ b/src/lib/backend/index.ts
@@ -25,8 +25,15 @@ export {
   ForbiddenError,
   NotFoundError,
   ConflictError,
+  PayloadTooLargeError,
   TooManyRequestsError,
   InternalError,
   HTTP_ERROR_CODES,
 } from "./errors";
 export { withApiHandler } from "./withApiHandler";
+export {
+  parseJsonWithLimit,
+  DEFAULT_JSON_BODY_LIMIT_BYTES,
+  JSON_BODY_LIMITS,
+} from "./jsonBodyLimit";
+export type { ParseJsonWithLimitOptions } from "./jsonBodyLimit";

--- a/src/lib/backend/jsonBodyLimit.test.ts
+++ b/src/lib/backend/jsonBodyLimit.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+import {
+    parseJsonWithLimit,
+    DEFAULT_JSON_BODY_LIMIT_BYTES,
+    JSON_BODY_LIMITS,
+} from './jsonBodyLimit';
+import { PayloadTooLargeError, ValidationError } from './errors';
+
+function makeRequest(body: string, headers: Record<string, string> = {}): NextRequest {
+    return new NextRequest('http://localhost/test', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            ...headers,
+        },
+        body,
+    });
+}
+
+describe('parseJsonWithLimit', () => {
+    it('parses a well-formed JSON body under the default limit', async () => {
+        const payload = { hello: 'world', n: 42 };
+        const req = makeRequest(JSON.stringify(payload));
+
+        await expect(parseJsonWithLimit(req)).resolves.toEqual(payload);
+    });
+
+    it('honours an explicit limitBytes option', async () => {
+        const payload = { hello: 'world' };
+        const req = makeRequest(JSON.stringify(payload));
+
+        await expect(
+            parseJsonWithLimit(req, { limitBytes: 1024 })
+        ).resolves.toEqual(payload);
+    });
+
+    it('throws PayloadTooLargeError when Content-Length advertises oversized body', async () => {
+        const req = makeRequest(JSON.stringify({ x: 'y' }), {
+            'content-length': String(DEFAULT_JSON_BODY_LIMIT_BYTES + 1),
+        });
+
+        await expect(parseJsonWithLimit(req)).rejects.toBeInstanceOf(
+            PayloadTooLargeError
+        );
+    });
+
+    it('throws PayloadTooLargeError when actual body exceeds the limit', async () => {
+        const big = 'a'.repeat(200);
+        const req = makeRequest(JSON.stringify({ data: big }));
+
+        const err = await parseJsonWithLimit(req, { limitBytes: 50 }).catch((e) => e);
+
+        expect(err).toBeInstanceOf(PayloadTooLargeError);
+        expect((err as PayloadTooLargeError).statusCode).toBe(413);
+        expect((err as PayloadTooLargeError).code).toBe('PAYLOAD_TOO_LARGE');
+        const details = (err as PayloadTooLargeError).details as {
+            limitBytes: number;
+            receivedBytes: number;
+        };
+        expect(details.limitBytes).toBe(50);
+        expect(details.receivedBytes).toBeGreaterThan(50);
+    });
+
+    it('throws ValidationError for malformed JSON within the limit', async () => {
+        const req = makeRequest('not valid json');
+
+        await expect(parseJsonWithLimit(req)).rejects.toBeInstanceOf(ValidationError);
+    });
+
+    it('throws ValidationError for an empty body', async () => {
+        const req = makeRequest('');
+
+        await expect(parseJsonWithLimit(req)).rejects.toBeInstanceOf(ValidationError);
+    });
+
+    it('ignores a non-numeric Content-Length and falls back to byte-length check', async () => {
+        const payload = { ok: true };
+        const req = makeRequest(JSON.stringify(payload), {
+            'content-length': 'not-a-number',
+        });
+
+        await expect(parseJsonWithLimit(req)).resolves.toEqual(payload);
+    });
+
+    it('rejects a non-positive limit option', async () => {
+        const req = makeRequest('{}');
+
+        await expect(parseJsonWithLimit(req, { limitBytes: 0 })).rejects.toThrow(
+            /positive finite number/
+        );
+        await expect(parseJsonWithLimit(req, { limitBytes: -1 })).rejects.toThrow(
+            /positive finite number/
+        );
+    });
+
+    it('accepts JSON that is exactly at the configured limit', async () => {
+        // Make a JSON body whose UTF-8 byte length equals the limit.
+        const limit = 64;
+        // `{"d":"..."}` — 8 non-payload chars, pad the rest with 'a'.
+        const padLength = limit - 8;
+        const payload = `{"d":"${'a'.repeat(padLength)}"}`;
+        expect(Buffer.byteLength(payload, 'utf8')).toBe(limit);
+
+        const req = makeRequest(payload);
+
+        await expect(
+            parseJsonWithLimit(req, { limitBytes: limit })
+        ).resolves.toEqual({ d: 'a'.repeat(padLength) });
+    });
+
+    it('exposes sensible per-route limits', () => {
+        expect(JSON_BODY_LIMITS.commitmentsCreate).toBeGreaterThan(0);
+        expect(JSON_BODY_LIMITS.attestationsCreate).toBeGreaterThan(0);
+        expect(JSON_BODY_LIMITS.marketplaceListingsCreate).toBeGreaterThan(0);
+        expect(JSON_BODY_LIMITS.authVerify).toBeGreaterThan(0);
+
+        // Sanity — limits should not be absurdly large.
+        for (const v of Object.values(JSON_BODY_LIMITS)) {
+            expect(v).toBeLessThanOrEqual(1024 * 1024);
+        }
+    });
+});

--- a/src/lib/backend/jsonBodyLimit.ts
+++ b/src/lib/backend/jsonBodyLimit.ts
@@ -1,0 +1,107 @@
+import type { NextRequest } from 'next/server';
+import { PayloadTooLargeError, ValidationError } from './errors';
+
+/**
+ * Default maximum JSON body size, in bytes, enforced for write endpoints.
+ *
+ * Kept deliberately small — the JSON bodies accepted by Commitlabs routes are
+ * tiny (addresses, ids, numbers, a short metadata object). Anything larger is
+ * almost certainly abusive or malformed.
+ */
+export const DEFAULT_JSON_BODY_LIMIT_BYTES = 16 * 1024; // 16 KiB
+
+/**
+ * Per-route recommended JSON body size limits, in bytes.
+ *
+ * Exported so individual routes can opt into a specific limit and so the
+ * limits are visible in one place for documentation / auditing.
+ */
+export const JSON_BODY_LIMITS = {
+    commitmentsCreate: 8 * 1024, // 8 KiB — small set of fields + optional metadata
+    attestationsCreate: 16 * 1024, // 16 KiB — data object may carry attestation details
+    marketplaceListingsCreate: 4 * 1024, // 4 KiB — a handful of short fields
+    authVerify: 4 * 1024, // 4 KiB — address + signature + short message
+} as const;
+
+export interface ParseJsonWithLimitOptions {
+    /** Maximum allowed body size in bytes. Defaults to {@link DEFAULT_JSON_BODY_LIMIT_BYTES}. */
+    limitBytes?: number;
+}
+
+/**
+ * Safely parse a JSON request body, rejecting payloads that exceed a
+ * configurable byte limit.
+ *
+ * Security behaviour:
+ *  - If the `Content-Length` header is present and advertises a size greater
+ *    than the limit, the request is rejected immediately without reading the
+ *    body (cheap DoS protection).
+ *  - The body is otherwise read as text and its UTF-8 byte length is checked
+ *    against the limit. This guards against clients that omit or lie about
+ *    `Content-Length`.
+ *  - On overflow, a {@link PayloadTooLargeError} is thrown, which is mapped to
+ *    HTTP 413 by {@link withApiHandler}.
+ *  - Malformed JSON raises a {@link ValidationError} (HTTP 400), matching the
+ *    behaviour previously inlined in each route handler.
+ *
+ * The return type is `unknown` — callers are expected to validate the shape
+ * of the parsed value (e.g. with zod or hand-written guards) before use.
+ */
+export async function parseJsonWithLimit(
+    req: NextRequest | Request,
+    options: ParseJsonWithLimitOptions = {},
+): Promise<unknown> {
+    const limit = options.limitBytes ?? DEFAULT_JSON_BODY_LIMIT_BYTES;
+
+    if (!Number.isFinite(limit) || limit <= 0) {
+        throw new Error('parseJsonWithLimit: limitBytes must be a positive finite number.');
+    }
+
+    const contentLengthHeader = req.headers.get('content-length');
+    if (contentLengthHeader !== null) {
+        const advertised = Number(contentLengthHeader);
+        if (Number.isFinite(advertised) && advertised > limit) {
+            throw new PayloadTooLargeError(
+                `Request body exceeds maximum allowed size of ${limit} bytes.`,
+                { limitBytes: limit, receivedBytes: advertised },
+            );
+        }
+    }
+
+    let text: string;
+    try {
+        text = await req.text();
+    } catch {
+        throw new ValidationError('Failed to read request body.');
+    }
+
+    const actualBytes = byteLength(text);
+    if (actualBytes > limit) {
+        throw new PayloadTooLargeError(
+            `Request body exceeds maximum allowed size of ${limit} bytes.`,
+            { limitBytes: limit, receivedBytes: actualBytes },
+        );
+    }
+
+    if (text.length === 0) {
+        throw new ValidationError('Request body is empty.');
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch {
+        throw new ValidationError('Invalid JSON in request body.');
+    }
+}
+
+/**
+ * Compute the UTF-8 byte length of a string, falling back to `Buffer` when
+ * `TextEncoder` is not available (very old runtimes / odd test shims).
+ */
+function byteLength(value: string): number {
+    if (typeof TextEncoder !== 'undefined') {
+        return new TextEncoder().encode(value).byteLength;
+    }
+    // Node.js fallback — always available server-side.
+    return Buffer.byteLength(value, 'utf8');
+}

--- a/tests/api/payloadLimits.test.ts
+++ b/tests/api/payloadLimits.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { JSON_BODY_LIMITS } from '@/lib/backend/jsonBodyLimit';
+
+// Avoid hitting the rate limiter during these tests — they're a pure
+// payload-size concern.
+vi.mock('@/lib/backend/rateLimit', () => ({
+    checkRateLimit: vi.fn(async () => true),
+}));
+
+// Marketplace service is mocked because the marketplace route calls it on
+// the happy path; we never exercise that here but the import graph demands it.
+vi.mock('@/lib/backend/services/marketplace', async () => {
+    const actual =
+        await vi.importActual<typeof import('@/lib/backend/services/marketplace')>(
+            '@/lib/backend/services/marketplace'
+        );
+    return {
+        ...actual,
+        marketplaceService: {
+            createListing: vi.fn(),
+        },
+    };
+});
+
+function oversizedRequest(url: string, limit: number): NextRequest {
+    const padding = 'a'.repeat(limit + 64);
+    return new NextRequest(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ junk: padding }),
+    });
+}
+
+describe('POST /api/auth/verify — payload size limit', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('returns 413 PAYLOAD_TOO_LARGE for oversized bodies', async () => {
+        const { POST } = await import('@/app/api/auth/verify/route');
+        const req = oversizedRequest(
+            'http://localhost/api/auth/verify',
+            JSON_BODY_LIMITS.authVerify
+        );
+
+        const res = await POST(req, { params: {} });
+        const body = await res.json();
+
+        expect(res.status).toBe(413);
+        expect(body.success).toBe(false);
+        expect(body.error.code).toBe('PAYLOAD_TOO_LARGE');
+    });
+});
+
+describe('POST /api/commitments — payload size limit', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('returns 413 PAYLOAD_TOO_LARGE for oversized bodies', async () => {
+        const { POST } = await import('@/app/api/commitments/route');
+        const req = oversizedRequest(
+            'http://localhost/api/commitments',
+            JSON_BODY_LIMITS.commitmentsCreate
+        );
+
+        const res = await POST(req, { params: {} });
+        const body = await res.json();
+
+        expect(res.status).toBe(413);
+        expect(body.success).toBe(false);
+        expect(body.error.code).toBe('PAYLOAD_TOO_LARGE');
+    });
+});
+
+describe('POST /api/attestations — payload size limit', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('returns 413 PAYLOAD_TOO_LARGE for oversized bodies', async () => {
+        const { POST } = await import('@/app/api/attestations/route');
+        const req = oversizedRequest(
+            'http://localhost/api/attestations',
+            JSON_BODY_LIMITS.attestationsCreate
+        );
+
+        const res = await POST(req, { params: {} });
+        const body = await res.json();
+
+        expect(res.status).toBe(413);
+        expect(body.success).toBe(false);
+        expect(body.error.code).toBe('PAYLOAD_TOO_LARGE');
+    });
+});
+
+describe('POST /api/marketplace/listings — payload size limit', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('returns 413 PAYLOAD_TOO_LARGE for oversized bodies', async () => {
+        const { POST } = await import('@/app/api/marketplace/listings/route');
+        const req = oversizedRequest(
+            'http://localhost/api/marketplace/listings',
+            JSON_BODY_LIMITS.marketplaceListingsCreate
+        );
+
+        const res = await POST(req, { params: {} });
+        const body = await res.json();
+
+        expect(res.status).toBe(413);
+        expect(body.success).toBe(false);
+        expect(body.error.code).toBe('PAYLOAD_TOO_LARGE');
+    });
+});


### PR DESCRIPTION
## Summary

Adds JSON request body size limits to protect backend POST routes from abusive payloads, returning HTTP 413 `PAYLOAD_TOO_LARGE`.

Changes:

- `src/lib/backend/errors.ts` — Added `PayloadTooLargeError` class (code `PAYLOAD_TOO_LARGE`, status 413) and registered the status in `HTTP_ERROR_CODES`.
- `src/lib/backend/jsonBodyLimit.ts` (new) — `parseJsonWithLimit(req, { limitBytes })` helper that:
  - Rejects early if the `Content-Length` header advertises an oversized body (cheap DoS guard).
  - Reads the body as text and verifies UTF-8 byte length against the configured limit (handles missing/forged Content-Length).
  - Throws `PayloadTooLargeError` on overflow and `ValidationError` on malformed/empty JSON.
  - Exports `DEFAULT_JSON_BODY_LIMIT_BYTES` and a `JSON_BODY_LIMITS` table with per-route limits (commitments 8 KiB, attestations 16 KiB, marketplace listings 4 KiB, auth/verify 4 KiB).
- `src/lib/backend/index.ts` — Re-exports the new error, helper, and limits.
- Applied `parseJsonWithLimit` to the four JSON POST routes, preserving existing 400 behaviour for malformed JSON while letting `PayloadTooLargeError` propagate via `withApiHandler`:
  - `src/app/api/commitments/route.ts`
  - `src/app/api/attestations/route.ts`
  - `src/app/api/marketplace/listings/route.ts`
  - `src/app/api/auth/verify/route.ts`

Tests added (all passing):

- `src/lib/backend/jsonBodyLimit.test.ts` — 10 unit tests covering default limit, explicit limit, Content-Length short-circuit, actual byte overflow, malformed JSON, empty body, non-numeric Content-Length, invalid limit option, exact-limit acceptance, and limits-table sanity.
- `tests/api/payloadLimits.test.ts` — 4 route-level integration tests asserting each POST route returns 413 with `PAYLOAD_TOO_LARGE` for oversized bodies.

All tests for files I modified (14 new + 6 pre-existing marketplace listings tests) pass; lint and typecheck report zero issues in the files I touched.

Pre-existing failures on `main` that I did NOT introduce and left alone per scope rules:
- `tests/api/commitments.test.ts` — 9 failures: tests assert an outdated API shape (`id`/`title`/`amount` fields, `Missing required fields` message) that does not match the current `/api/commitments` route. Verified identically failing on `main` via `git stash`.
- `tests/api/health.test.ts` — fails to load because `src/app/api/health/route.ts` has a syntax error (stray second `import` mid-statement). Same file also causes a typecheck and lint parse error. Pre-existing on `main`.
- `src/components/modals/CommitmentDetailsModal.tsx` — broken JSX (unclosed `<div>`) causing typecheck and lint parse errors. Pre-existing on `main`.
- Pre-existing unused-variable lint errors in `src/app/api/auth/nonce/route.ts`, `src/app/api/commitments/[id]/settle/route.ts`, `src/components/CommitmentEarlyExitModal/CommitmentEarlyExitModal.tsx`, and `src/lib/backend/auth.ts`. Pre-existing on `main`.

(The only file I touched that previously had a pre-existing lint error was `src/app/api/auth/verify/route.ts`; my rewrite incidentally eliminated that unused-var warning.)

---

closes #252