### PR TITLE
Feat/commitment history endpoint

### DIFF
--- a/scripts/seed-backend-mock.ts
+++ b/scripts/seed-backend-mock.ts
@@ -1,89 +1,21 @@
-import fs from 'fs';
-import path from 'path';
+/**
+ * CLI entry-point for seeding mock data.
+ * Delegates to the shared seedMockData module so there is a single source of truth.
+ *
+ * Usage:
+ *   SEED_ROUTE_ENABLED=true NODE_ENV=development npx tsx scripts/seed-backend-mock.ts
+ */
 
-const mockDbPath = path.join(process.cwd(), '.mock-db.json');
+// Ensure guards pass when running from the CLI
+process.env.NODE_ENV = process.env.NODE_ENV ?? "development";
+process.env.SEED_ROUTE_ENABLED = process.env.SEED_ROUTE_ENABLED ?? "true";
 
-const sampleCommitments = [
-    {
-        id: 'CMT-ABC123',
-        type: 'Safe',
-        status: 'Active',
-        asset: 'XLM',
-        amount: '50,000',
-        currentValue: '52,600',
-        changePercent: 5.2,
-        durationProgress: 75,
-        daysRemaining: 15,
-        complianceScore: 95,
-        maxLoss: '2%',
-        currentDrawdown: '0.8%',
-        createdDate: 'Jan 10, 2026',
-        expiryDate: 'Feb 9, 2026',
-    },
-    {
-        id: 'CMT-XYZ789',
-        type: 'Balanced',
-        status: 'Active',
-        asset: 'USDC',
-        amount: '100,000',
-        currentValue: '112,500',
-        changePercent: 12.5,
-        durationProgress: 30,
-        daysRemaining: 42,
-        complianceScore: 88,
-        maxLoss: '8%',
-        currentDrawdown: '3.2%',
-        createdDate: 'Dec 15, 2025',
-        expiryDate: 'Feb 13, 2026',
-    }
-];
+import { seedMockData } from "../src/lib/backend/seed";
 
-const sampleAttestations = [
-    {
-        id: 'ATTR-001',
-        commitmentId: 'CMT-ABC123',
-        provider: 'Provider A',
-        status: 'Valid',
-        timestamp: '2026-01-11T12:00:00Z',
-    }
-];
-
-const sampleListings = [
-    {
-        id: '001',
-        type: 'Safe',
-        score: 95,
-        amount: '$50,000',
-        duration: '25 days',
-        yield: '5.2%',
-        maxLoss: '2%',
-        owner: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
-        price: '$52,000',
-        forSale: true,
-    },
-    {
-        id: '002',
-        type: 'Balanced',
-        score: 88,
-        amount: '$100,000',
-        duration: '45 days',
-        yield: '12.5%',
-        maxLoss: '8%',
-        owner: '0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199',
-        price: '$105,000',
-        forSale: true,
-    }
-];
-
-function seedMockData() {
-    const data = {
-        commitments: sampleCommitments,
-        attestations: sampleAttestations,
-        listings: sampleListings,
-    };
-
-    fs.writeFileSync(mockDbPath, JSON.stringify(data, null, 2), 'utf8');
-    console.log(`Mock data successfully seeded to ${mockDbPath}`);
+const result = await seedMockData(process.env.SEED_SECRET ?? null);
+if (result.seeded) {
+  console.log(result.message);
+} else {
+  console.error(result.message);
+  process.exit(1);
 }
-
-seedMockData();

--- a/src/app/api/attestations/route.ts
+++ b/src/app/api/attestations/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 import { checkRateLimit } from '@/lib/backend/rateLimit';
 import {
   getCommitmentFromChain,
@@ -13,43 +14,31 @@ import {
 import { withApiHandler } from '@/lib/backend/withApiHandler';
 import { ok } from '@/lib/backend/apiResponse';
 import { getMockData } from '@/lib/backend/mockDb';
+import {
+  validateAttestationData,
+  type AttestationData,
+} from '@/lib/backend/attestationSchemas';
+import { ATTESTATION_TYPES } from '@/lib/types/domain';
+import type { AttestationType } from '@/lib/types/domain';
 import type { RecordAttestationOnChainParams } from '@/lib/backend/services/contracts';
 
-const ATTESTATION_TYPES = [
-  'health_check',
-  'violation',
-  'fee_generation',
-  'drawdown',
-] as const;
-
-export type AttestationType = (typeof ATTESTATION_TYPES)[number];
+export type { AttestationType };
 
 function isAttestationType(value: unknown): value is AttestationType {
-  return typeof value === 'string' && ATTESTATION_TYPES.includes(value as AttestationType);
+  return typeof value === 'string' && (ATTESTATION_TYPES as readonly string[]).includes(value);
 }
 
 export interface RecordAttestationRequestBody {
   commitmentId: string;
   attestationType: AttestationType;
-  data: Record<string, unknown>;
+  /** Validated and normalised — only allowlisted keys for the given type. */
+  data: AttestationData;
   verifiedBy: string;
-}
-
-function ensureObject(value: unknown, field: string): Record<string, unknown> {
-  if (value === null || value === undefined) {
-    throw new ValidationError(`Missing required field: ${field}.`, { field });
-  }
-  if (typeof value !== 'object' || Array.isArray(value)) {
-    throw new ValidationError(`Field "${field}" must be an object.`, { field });
-  }
-  return value as Record<string, unknown>;
 }
 
 function ensureNonEmptyString(value: unknown, field: string): string {
   if (typeof value !== 'string' || value.trim() === '') {
-    throw new ValidationError(`Field "${field}" must be a non-empty string.`, {
-      field,
-    });
+    throw new ValidationError(`Field "${field}" must be a non-empty string.`, { field });
   }
   return value.trim();
 }
@@ -61,89 +50,65 @@ function parseAndValidateBody(raw: unknown): RecordAttestationRequestBody {
   }
 
   const commitmentId = ensureNonEmptyString(body.commitmentId, 'commitmentId');
+
   const attestationType = body.attestationType;
   if (!isAttestationType(attestationType)) {
     throw new ValidationError(
       `Invalid attestationType. Must be one of: ${ATTESTATION_TYPES.join(', ')}.`,
-      { field: 'attestationType', allowed: ATTESTATION_TYPES }
+      { field: 'attestationType', allowed: ATTESTATION_TYPES },
     );
   }
-  const data = ensureObject(body.data, 'data');
+
+  if (body.data === null || body.data === undefined || typeof body.data !== 'object' || Array.isArray(body.data)) {
+    throw new ValidationError('Field "data" must be an object.', { field: 'data' });
+  }
+
+  // Validate data against the per-type allowlisted schema
+  let data: AttestationData;
+  try {
+    data = validateAttestationData(attestationType, body.data);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'PAYLOAD_TOO_LARGE') {
+      throw new ValidationError((err as Error).message, { field: 'data' });
+    }
+    if (err instanceof z.ZodError) {
+      const first = err.issues[0];
+      const fieldPath = ['data', ...first.path].join('.');
+      throw new ValidationError(first.message, { field: fieldPath, issues: err.issues });
+    }
+    throw err;
+  }
+
   const verifiedBy = ensureNonEmptyString(body.verifiedBy, 'verifiedBy');
 
-  if (attestationType === 'health_check') {
-    const score = data.complianceScore;
-    if (score === undefined || score === null) {
-      throw new ValidationError(
-        'data.complianceScore is required for attestationType "health_check".',
-        { field: 'data.complianceScore' }
-      );
-    }
-    const num = Number(score);
-    if (!Number.isFinite(num) || num < 0 || num > 100) {
-      throw new ValidationError(
-        'data.complianceScore must be a number between 0 and 100.',
-        { field: 'data.complianceScore' }
-      );
-    }
-  }
-
-  if (attestationType === 'fee_generation') {
-    const feeEarned = data.feeEarned ?? data.amount;
-    if (feeEarned === undefined || feeEarned === null) {
-      throw new ValidationError(
-        'data.feeEarned or data.amount is required for attestationType "fee_generation".',
-        { field: 'data' }
-      );
-    }
-  }
-
-  return {
-    commitmentId,
-    attestationType,
-    data,
-    verifiedBy,
-  };
+  return { commitmentId, attestationType, data, verifiedBy };
 }
 
 function mapToRecordParams(
-  body: RecordAttestationRequestBody
+  body: RecordAttestationRequestBody,
 ): RecordAttestationOnChainParams {
   const { commitmentId, attestationType, data, verifiedBy } = body;
   const timestamp = new Date().toISOString();
+
+  // All fields are now guaranteed to be valid and normalised by the schema.
+  const d = data as Record<string, unknown>;
 
   let complianceScore = 0;
   let violation = false;
   let feeEarned: string | undefined;
 
   if (attestationType === 'health_check') {
-    complianceScore = Number(data.complianceScore);
-    violation = Boolean(data.violation);
+    complianceScore = d.complianceScore as number;
+    violation = (d.violation as boolean) ?? false;
   } else if (attestationType === 'violation') {
     violation = true;
-    complianceScore =
-      typeof data.complianceScore === 'number' && Number.isFinite(data.complianceScore)
-        ? data.complianceScore
-        : 0;
+    complianceScore = typeof d.complianceScore === 'number' ? (d.complianceScore as number) : 0;
   } else if (attestationType === 'fee_generation') {
-    const raw = data.feeEarned ?? data.amount;
-    feeEarned =
-      typeof raw === 'string' ? raw : typeof raw === 'number' ? String(raw) : '0';
-    complianceScore =
-      typeof data.complianceScore === 'number' && Number.isFinite(data.complianceScore)
-        ? data.complianceScore
-        : 0;
+    feeEarned = d.feeEarned as string; // already coerced to string by schema
+    complianceScore = typeof d.complianceScore === 'number' ? (d.complianceScore as number) : 0;
   } else {
-    complianceScore =
-      typeof data.complianceScore === 'number' && Number.isFinite(data.complianceScore)
-        ? data.complianceScore
-        : 0;
-    violation = Boolean(data.violation);
-    const rawFee = data.feeEarned ?? data.amount;
-    if (rawFee !== undefined && rawFee !== null) {
-      feeEarned =
-        typeof rawFee === 'string' ? rawFee : typeof rawFee === 'number' ? String(rawFee) : undefined;
-    }
+    // drawdown
+    complianceScore = typeof d.complianceScore === 'number' ? (d.complianceScore as number) : 0;
   }
 
   return {
@@ -153,30 +118,23 @@ function mapToRecordParams(
     violation,
     feeEarned,
     timestamp,
-    details: { type: attestationType, ...data },
+    details: { type: attestationType, ...d },
   };
 }
 
 export const GET = withApiHandler(async (req: NextRequest) => {
   const ip = req.ip ?? req.headers.get('x-forwarded-for') ?? 'anonymous';
-
   const isAllowed = await checkRateLimit(ip, 'api/attestations');
-  if (!isAllowed) {
-    throw new TooManyRequestsError();
-  }
+  if (!isAllowed) throw new TooManyRequestsError();
 
   const { attestations } = await getMockData();
-
   return ok({ attestations }, 200);
 });
 
 export const POST = withApiHandler(async (req: NextRequest) => {
   const ip = req.ip ?? req.headers.get('x-forwarded-for') ?? 'anonymous';
-
   const isAllowed = await checkRateLimit(ip, 'api/attestations');
-  if (!isAllowed) {
-    throw new TooManyRequestsError();
-  }
+  if (!isAllowed) throw new TooManyRequestsError();
 
   let body: RecordAttestationRequestBody;
   try {
@@ -196,31 +154,26 @@ export const POST = withApiHandler(async (req: NextRequest) => {
       status: 502,
       details: { commitmentId: body.commitmentId },
     });
-    return NextResponse.json(toBackendErrorResponse(normalized), {
-      status: normalized.status,
-    });
+    return NextResponse.json(toBackendErrorResponse(normalized), { status: normalized.status });
   }
 
   const params = mapToRecordParams(body);
 
   try {
     const result = await recordAttestationOnChain(params);
-
-    const summary = {
-      attestationId: result.attestationId,
-      commitmentId: result.commitmentId,
-      complianceScore: result.complianceScore,
-      violation: result.violation,
-      feeEarned: result.feeEarned,
-      recordedAt: result.recordedAt,
-    };
-
     return ok(
       {
-        attestation: summary,
+        attestation: {
+          attestationId: result.attestationId,
+          commitmentId: result.commitmentId,
+          complianceScore: result.complianceScore,
+          violation: result.violation,
+          feeEarned: result.feeEarned,
+          recordedAt: result.recordedAt,
+        },
         txReference: result.txHash ?? null,
       },
-      201
+      201,
     );
   } catch (err) {
     const normalized = normalizeBackendError(err, {
@@ -229,8 +182,6 @@ export const POST = withApiHandler(async (req: NextRequest) => {
       status: 502,
       details: { commitmentId: body.commitmentId, attestationType: body.attestationType },
     });
-    return NextResponse.json(toBackendErrorResponse(normalized), {
-      status: normalized.status,
-    });
+    return NextResponse.json(toBackendErrorResponse(normalized), { status: normalized.status });
   }
 });

--- a/src/app/api/commitments/[id]/history/route.ts
+++ b/src/app/api/commitments/[id]/history/route.ts
@@ -1,0 +1,109 @@
+/**
+ * GET /api/commitments/[id]/history
+ *
+ * Returns a paginated, time-ordered list of lifecycle events for a commitment.
+ *
+ * ## Response shape
+ * ```json
+ * {
+ *   "success": true,
+ *   "data": {
+ *     "commitmentId": "CMT-ABC123",
+ *     "events": [
+ *       {
+ *         "eventId": "created:CMT-ABC123",
+ *         "kind": "created",
+ *         "occurredAt": "2026-01-10T00:00:00.000Z",
+ *         "payload": { "asset": "XLM", "amount": "50000", "expiresAt": "..." }
+ *       },
+ *       {
+ *         "eventId": "attestation:ATTR-001",
+ *         "kind": "attestation",
+ *         "occurredAt": "2026-01-11T12:00:00Z",
+ *         "payload": { "attestationId": "ATTR-001", "attestationType": "health_check", ... }
+ *       }
+ *     ],
+ *     "meta": {
+ *       "page": 1,
+ *       "pageSize": 20,
+ *       "total": 5,
+ *       "totalPages": 1,
+ *       "hasNextPage": false,
+ *       "hasPrevPage": false
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * ## Query parameters
+ * | param    | type    | default | description                        |
+ * |----------|---------|---------|------------------------------------|
+ * | page     | integer | 1       | 1-based page number                |
+ * | pageSize | integer | 20      | Items per page (max 100)           |
+ *
+ * ## Error responses
+ * - `404` — commitment not found
+ * - `400` — invalid pagination params
+ * - `429` — rate limit exceeded
+ */
+
+import { NextRequest } from 'next/server';
+import { withApiHandler } from '@/lib/backend/withApiHandler';
+import { ok } from '@/lib/backend/apiResponse';
+import { NotFoundError, TooManyRequestsError } from '@/lib/backend/errors';
+import { checkRateLimit } from '@/lib/backend/rateLimit';
+import {
+  parsePaginationParams,
+  paginateArray,
+  paginationErrorResponse,
+  PaginationParseError,
+} from '@/lib/backend/pagination';
+import { getCommitmentFromChain } from '@/lib/backend/services/contracts';
+import { getCommitmentHistory } from '@/lib/backend/services/commitmentHistory';
+
+const DEFAULT_HISTORY_PAGE_SIZE = 20;
+
+export const GET = withApiHandler(async (
+  req: NextRequest,
+  context: { params: Record<string, string> },
+) => {
+  const commitmentId = context.params.id;
+
+  const ip = req.ip ?? req.headers.get('x-forwarded-for') ?? 'anonymous';
+  const isAllowed = await checkRateLimit(ip, 'api/commitments/history');
+  if (!isAllowed) throw new TooManyRequestsError();
+
+  // Parse pagination
+  const { searchParams } = new URL(req.url);
+  let pagination;
+  try {
+    pagination = parsePaginationParams(searchParams, {
+      defaultPageSize: DEFAULT_HISTORY_PAGE_SIZE,
+    });
+  } catch (err) {
+    if (err instanceof PaginationParseError) {
+      return paginationErrorResponse(err);
+    }
+    throw err;
+  }
+
+  // Resolve commitment — throws NotFoundError (→ 404) if absent
+  let commitment;
+  try {
+    commitment = await getCommitmentFromChain(commitmentId);
+  } catch {
+    throw new NotFoundError('Commitment', { commitmentId });
+  }
+
+  // Aggregate history events
+  const { events } = await getCommitmentHistory(commitment);
+
+  // Paginate
+  const page = paginateArray(events, pagination);
+
+  return ok({
+    commitmentId,
+    events: page.data,
+    meta: page.meta,
+  });
+});

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -1,21 +1,24 @@
-import { withApiHandler } from '@/lib/backend/withApiHandler';
-import { ok } from '@/lib/backend/apiResponse';
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { withApiHandler } from "@/lib/backend/withApiHandler";
+import { ok } from "@/lib/backend/apiResponse";
+import { seedMockData, isSeedAllowed } from "@/lib/backend/seed";
+import type { NextRequest } from "next/server";
 
-const execAsync = promisify(exec);
+export const POST = withApiHandler(async (req: NextRequest) => {
+  // Hard guard: reject immediately outside development/test + flag check
+  if (!isSeedAllowed()) {
+    return ok({ message: "Not Found" }, 404);
+  }
 
-export const POST = withApiHandler(async () => {
-    // Only allow this route in development mode
-    if (process.env.NODE_ENV !== 'development') {
-        return ok({ message: 'Not Found' }, 404);
+  const secret = req.headers.get("x-seed-secret");
+  const result = await seedMockData(secret);
+
+  if (!result.seeded) {
+    // Distinguish auth failure from other errors
+    if (result.message === "Invalid seed secret.") {
+      return ok({ message: result.message }, 403);
     }
+    return ok({ message: result.message }, 500);
+  }
 
-    try {
-        await execAsync('npm run seed:mock');
-        return ok({ message: 'Mock data seeded successfully.' }, 200);
-    } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return ok({ message: 'Failed to seed mock data', error: msg }, 500);
-    }
+  return ok({ message: result.message }, 200);
 });

--- a/src/lib/backend/attestationSchemas.ts
+++ b/src/lib/backend/attestationSchemas.ts
@@ -1,0 +1,184 @@
+/**
+ * Allowlisted Zod schemas for attestation `data` payloads, keyed by attestationType.
+ *
+ * Rules enforced here:
+ *  - Only explicitly listed keys are accepted (`.strict()` strips nothing — it rejects).
+ *  - Each field has a type constraint and, where applicable, a range limit.
+ *  - String fields are capped at MAX_STRING_LENGTH characters.
+ *  - The total serialised payload may not exceed MAX_PAYLOAD_BYTES bytes.
+ *
+ * Adding a new attestation type:
+ *  1. Add the type to ATTESTATION_TYPES in src/lib/types/domain.ts.
+ *  2. Add a corresponding Zod schema below.
+ *  3. Document the allowed fields in the JSDoc block for that schema.
+ *  4. Add tests in tests/api/attestationSchemas.test.ts.
+ */
+
+import { z } from "zod";
+import type { AttestationType } from "@/lib/types/domain";
+
+// ---------------------------------------------------------------------------
+// Shared limits
+// ---------------------------------------------------------------------------
+
+/** Maximum length for any single string field inside `data`. */
+export const MAX_STRING_LENGTH = 256;
+
+/** Maximum serialised byte size of the entire `data` object. */
+export const MAX_PAYLOAD_BYTES = 2048;
+
+// ---------------------------------------------------------------------------
+// Reusable field primitives
+// ---------------------------------------------------------------------------
+
+const boundedString = z.string().max(MAX_STRING_LENGTH);
+
+const complianceScoreField = z
+  .number({ invalid_type_error: "complianceScore must be a number" })
+  .min(0, "complianceScore must be >= 0")
+  .max(100, "complianceScore must be <= 100");
+
+const violationField = z.boolean({
+  invalid_type_error: "violation must be a boolean",
+});
+
+const feeAmountField = z
+  .union([z.string().max(MAX_STRING_LENGTH), z.number().nonnegative()])
+  .transform((v) => String(v));
+
+// ---------------------------------------------------------------------------
+// Per-type schemas  (all use .strict() to reject unknown keys)
+// ---------------------------------------------------------------------------
+
+/**
+ * health_check — periodic compliance snapshot.
+ *
+ * Allowed fields:
+ *  - complianceScore  (required) number 0–100
+ *  - violation        (optional) boolean — true if a rule was breached
+ *  - notes            (optional) string ≤ 256 chars
+ */
+export const healthCheckDataSchema = z
+  .object({
+    complianceScore: complianceScoreField,
+    violation: violationField.optional().default(false),
+    notes: boundedString.optional(),
+  })
+  .strict();
+
+/**
+ * violation — explicit rule-breach record.
+ *
+ * Allowed fields:
+ *  - reason           (required) string ≤ 256 chars — human-readable cause
+ *  - complianceScore  (optional) number 0–100 — score at time of violation
+ *  - severity         (optional) "low" | "medium" | "high"
+ */
+export const violationDataSchema = z
+  .object({
+    reason: boundedString.min(1, "reason is required for violation attestations"),
+    complianceScore: complianceScoreField.optional(),
+    severity: z.enum(["low", "medium", "high"]).optional(),
+  })
+  .strict();
+
+/**
+ * fee_generation — fee accrual event.
+ *
+ * Allowed fields:
+ *  - feeEarned        (required) string or non-negative number — amount earned
+ *  - asset            (optional) string ≤ 256 chars — asset ticker (e.g. "XLM")
+ *  - complianceScore  (optional) number 0–100
+ */
+export const feeGenerationDataSchema = z
+  .object({
+    feeEarned: feeAmountField,
+    asset: boundedString.optional(),
+    complianceScore: complianceScoreField.optional(),
+  })
+  .strict();
+
+/**
+ * drawdown — drawdown measurement event.
+ *
+ * Allowed fields:
+ *  - drawdownPercent  (required) number 0–100 — current drawdown as a percentage
+ *  - maxAllowed       (optional) number 0–100 — configured max-loss threshold
+ *  - complianceScore  (optional) number 0–100
+ */
+export const drawdownDataSchema = z
+  .object({
+    drawdownPercent: z
+      .number({ invalid_type_error: "drawdownPercent must be a number" })
+      .min(0, "drawdownPercent must be >= 0")
+      .max(100, "drawdownPercent must be <= 100"),
+    maxAllowed: z
+      .number()
+      .min(0)
+      .max(100)
+      .optional(),
+    complianceScore: complianceScoreField.optional(),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+export const ATTESTATION_DATA_SCHEMAS = {
+  health_check: healthCheckDataSchema,
+  violation: violationDataSchema,
+  fee_generation: feeGenerationDataSchema,
+  drawdown: drawdownDataSchema,
+} as const satisfies Record<AttestationType, z.ZodTypeAny>;
+
+// ---------------------------------------------------------------------------
+// Validated output types
+// ---------------------------------------------------------------------------
+
+export type HealthCheckData = z.infer<typeof healthCheckDataSchema>;
+export type ViolationData = z.infer<typeof violationDataSchema>;
+export type FeeGenerationData = z.infer<typeof feeGenerationDataSchema>;
+export type DrawdownData = z.infer<typeof drawdownDataSchema>;
+
+export type AttestationData =
+  | HealthCheckData
+  | ViolationData
+  | FeeGenerationData
+  | DrawdownData;
+
+// ---------------------------------------------------------------------------
+// Validation entry-point
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates and normalises an attestation `data` payload for the given type.
+ *
+ * Enforces:
+ *  1. Payload byte-size limit (MAX_PAYLOAD_BYTES).
+ *  2. Per-type allowlist via the corresponding Zod schema (unknown keys rejected).
+ *  3. Field-level type and range constraints.
+ *
+ * @param attestationType - One of the known AttestationType values.
+ * @param data            - Raw `data` object from the request body.
+ * @returns Parsed and normalised data object.
+ * @throws `z.ZodError` if validation fails.
+ * @throws `Error` with code `PAYLOAD_TOO_LARGE` if the payload exceeds the size limit.
+ */
+export function validateAttestationData(
+  attestationType: AttestationType,
+  data: unknown,
+): AttestationData {
+  // Size guard — check before parsing to avoid processing huge payloads
+  const serialised = JSON.stringify(data ?? {});
+  if (Buffer.byteLength(serialised, "utf8") > MAX_PAYLOAD_BYTES) {
+    const err = new Error(
+      `Attestation data payload exceeds the maximum allowed size of ${MAX_PAYLOAD_BYTES} bytes.`,
+    );
+    (err as NodeJS.ErrnoException).code = "PAYLOAD_TOO_LARGE";
+    throw err;
+  }
+
+  const schema = ATTESTATION_DATA_SCHEMAS[attestationType];
+  return schema.parse(data) as AttestationData;
+}

--- a/src/lib/backend/seed.ts
+++ b/src/lib/backend/seed.ts
@@ -1,0 +1,153 @@
+/**
+ * Seed module for mock database.
+ *
+ * Exports a callable `seedMockData` function so the seed route and CLI script
+ * can share the same logic without spawning a child process.
+ *
+ * Guard rules (enforced at call-time):
+ *  1. NODE_ENV must be "development" or "test".
+ *  2. SEED_ROUTE_ENABLED must be "true".
+ *
+ * An optional SEED_SECRET env var can be set; when present, callers must
+ * supply the matching value via the `x-seed-secret` request header.
+ */
+
+import { setMockData } from "./mockDb";
+import type { MockData } from "./mockDb";
+
+// ---------------------------------------------------------------------------
+// Sample data
+// ---------------------------------------------------------------------------
+
+const SAMPLE_DATA: MockData = {
+  commitments: [
+    {
+      id: "CMT-ABC123",
+      type: "Safe",
+      status: "Active",
+      asset: "XLM",
+      amount: "50,000",
+      currentValue: "52,600",
+      changePercent: 5.2,
+      durationProgress: 75,
+      daysRemaining: 15,
+      complianceScore: 95,
+      maxLoss: "2%",
+      currentDrawdown: "0.8%",
+      createdDate: "Jan 10, 2026",
+      expiryDate: "Feb 9, 2026",
+    },
+    {
+      id: "CMT-XYZ789",
+      type: "Balanced",
+      status: "Active",
+      asset: "USDC",
+      amount: "100,000",
+      currentValue: "112,500",
+      changePercent: 12.5,
+      durationProgress: 30,
+      daysRemaining: 42,
+      complianceScore: 88,
+      maxLoss: "8%",
+      currentDrawdown: "3.2%",
+      createdDate: "Dec 15, 2025",
+      expiryDate: "Feb 13, 2026",
+    },
+  ],
+  attestations: [
+    {
+      id: "ATTR-001",
+      commitmentId: "CMT-ABC123",
+      provider: "Provider A",
+      status: "Valid",
+      timestamp: "2026-01-11T12:00:00Z",
+    },
+  ],
+  listings: [
+    {
+      id: "001",
+      type: "Safe",
+      score: 95,
+      amount: "$50,000",
+      duration: "25 days",
+      yield: "5.2%",
+      maxLoss: "2%",
+      owner: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX1",
+      price: "$52,000",
+      forSale: true,
+    },
+    {
+      id: "002",
+      type: "Balanced",
+      score: 88,
+      amount: "$100,000",
+      duration: "45 days",
+      yield: "12.5%",
+      maxLoss: "8%",
+      owner: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX2",
+      price: "$105,000",
+      forSale: true,
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Guard helpers (exported for testing)
+// ---------------------------------------------------------------------------
+
+/** Returns true only when the runtime environment permits seeding. */
+export function isSeedAllowed(): boolean {
+  const env = process.env.NODE_ENV;
+  if (env !== "development" && env !== "test") return false;
+  return process.env.SEED_ROUTE_ENABLED === "true";
+}
+
+/**
+ * Validates an optional shared secret.
+ * Returns true when no secret is configured (open) or when the supplied
+ * value matches SEED_SECRET exactly.
+ */
+export function isSeedSecretValid(suppliedSecret: string | null): boolean {
+  const expected = process.env.SEED_SECRET;
+  if (!expected) return true; // no secret configured → always valid
+  return suppliedSecret === expected;
+}
+
+// ---------------------------------------------------------------------------
+// Core seed function
+// ---------------------------------------------------------------------------
+
+export interface SeedResult {
+  seeded: boolean;
+  message: string;
+}
+
+/**
+ * Seeds the mock database with sample data.
+ *
+ * @param suppliedSecret - Value from the `x-seed-secret` header (or null).
+ * @returns SeedResult describing the outcome.
+ * @throws Never – errors are captured and returned as a failed SeedResult.
+ */
+export async function seedMockData(
+  suppliedSecret: string | null = null
+): Promise<SeedResult> {
+  if (!isSeedAllowed()) {
+    return {
+      seeded: false,
+      message: "Seed is disabled. Set SEED_ROUTE_ENABLED=true in development.",
+    };
+  }
+
+  if (!isSeedSecretValid(suppliedSecret)) {
+    return { seeded: false, message: "Invalid seed secret." };
+  }
+
+  try {
+    await setMockData(SAMPLE_DATA);
+    return { seeded: true, message: "Mock data seeded successfully." };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { seeded: false, message: `Failed to seed mock data: ${msg}` };
+  }
+}

--- a/src/lib/backend/services/commitmentHistory.ts
+++ b/src/lib/backend/services/commitmentHistory.ts
@@ -1,0 +1,139 @@
+/**
+ * Commitment history service.
+ *
+ * Aggregates lifecycle events for a single commitment from all available
+ * sources (mock DB + chain reads) and returns them in chronological order.
+ *
+ * Sources consulted:
+ *  1. Commitment record itself  → `created` event
+ *  2. Attestations in mockDb    → `attestation` events
+ *  3. Commitment status         → `early_exit` / `settlement` terminal events
+ *
+ * When a real on-chain indexer is available, replace the mockDb reads with
+ * indexed queries and remove the chain-status heuristic.
+ */
+
+import { getMockData } from '@/lib/backend/mockDb';
+import type {
+  HistoryEvent,
+  CreatedEvent,
+  AttestationEvent,
+  EarlyExitEvent,
+  SettlementEvent,
+} from '@/lib/types/domain';
+import type { ChainCommitment } from '@/lib/backend/services/contracts';
+
+// ---------------------------------------------------------------------------
+// Event builders
+// ---------------------------------------------------------------------------
+
+function buildCreatedEvent(commitment: ChainCommitment): CreatedEvent {
+  return {
+    eventId: `created:${commitment.id}`,
+    kind: 'created',
+    occurredAt: commitment.createdAt ?? new Date(0).toISOString(),
+    payload: {
+      asset: commitment.asset,
+      amount: commitment.amount,
+      expiresAt: commitment.expiresAt,
+    },
+  };
+}
+
+function buildAttestationEvents(
+  commitmentId: string,
+  attestations: Awaited<ReturnType<typeof getMockData>>['attestations'],
+): AttestationEvent[] {
+  return attestations
+    .filter((a) => a.commitmentId === commitmentId)
+    .map((a) => ({
+      eventId: `attestation:${a.id}`,
+      kind: 'attestation' as const,
+      occurredAt: a.observedAt,
+      txHash: a.txHash,
+      payload: {
+        attestationId: a.id,
+        attestationType: a.kind ?? 'unknown',
+        complianceScore:
+          typeof a.details?.complianceScore === 'number'
+            ? (a.details.complianceScore as number)
+            : undefined,
+        violation:
+          typeof a.details?.violation === 'boolean'
+            ? (a.details.violation as boolean)
+            : undefined,
+        severity: a.severity,
+      },
+    }));
+}
+
+function buildTerminalEvent(
+  commitment: ChainCommitment,
+): EarlyExitEvent | SettlementEvent | null {
+  if (commitment.status === 'EARLY_EXIT') {
+    const event: EarlyExitEvent = {
+      eventId: `early_exit:${commitment.id}`,
+      kind: 'early_exit',
+      // Use expiresAt as a proxy timestamp until the indexer provides the real one
+      occurredAt: commitment.expiresAt ?? new Date().toISOString(),
+      payload: {
+        penaltyAmount: undefined,
+        exitedBy: commitment.ownerAddress,
+      },
+    };
+    return event;
+  }
+
+  if (commitment.status === 'SETTLED') {
+    const event: SettlementEvent = {
+      eventId: `settlement:${commitment.id}`,
+      kind: 'settlement',
+      occurredAt: commitment.expiresAt ?? new Date().toISOString(),
+      payload: {
+        settlementAmount: commitment.feeEarned,
+        finalStatus: 'SETTLED',
+      },
+    };
+    return event;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface CommitmentHistoryResult {
+  events: HistoryEvent[];
+  total: number;
+}
+
+/**
+ * Aggregates all lifecycle events for `commitmentId`, sorted oldest-first.
+ *
+ * @param commitment - Chain commitment record (caller is responsible for
+ *                     fetching and 404-checking before calling this).
+ * @returns All events sorted by `occurredAt` ascending.
+ */
+export async function getCommitmentHistory(
+  commitment: ChainCommitment,
+): Promise<CommitmentHistoryResult> {
+  const { attestations } = await getMockData();
+
+  const events: HistoryEvent[] = [
+    buildCreatedEvent(commitment),
+    ...buildAttestationEvents(commitment.id, attestations),
+  ];
+
+  const terminal = buildTerminalEvent(commitment);
+  if (terminal) events.push(terminal);
+
+  // Sort chronologically (oldest first)
+  events.sort(
+    (a, b) =>
+      new Date(a.occurredAt).getTime() - new Date(b.occurredAt).getTime(),
+  );
+
+  return { events, total: events.length };
+}

--- a/src/lib/types/domain.ts
+++ b/src/lib/types/domain.ts
@@ -86,3 +86,76 @@ export interface CreateListingRequest {
   currencyAsset: string;
   sellerAddress: string;
 }
+
+// ---------------------------------------------------------------------------
+// Commitment history / timeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union of all lifecycle event kinds that can appear in a
+ * commitment's history timeline.
+ *
+ * | kind          | trigger                                      |
+ * |---------------|----------------------------------------------|
+ * | created       | Commitment first recorded on-chain           |
+ * | attestation   | Any attestation recorded against it          |
+ * | early_exit    | Owner triggered an early exit                |
+ * | settlement    | Commitment reached maturity and was settled  |
+ */
+export type HistoryEventKind =
+  | 'created'
+  | 'attestation'
+  | 'early_exit'
+  | 'settlement';
+
+export interface BaseHistoryEvent {
+  /** Stable, deterministic identifier for this event (kind + source id). */
+  eventId: string;
+  kind: HistoryEventKind;
+  /** ISO-8601 timestamp used for chronological ordering. */
+  occurredAt: string;
+  /** Optional on-chain transaction reference. */
+  txHash?: string;
+}
+
+export interface CreatedEvent extends BaseHistoryEvent {
+  kind: 'created';
+  payload: {
+    asset: string;
+    amount: string;
+    expiresAt?: string;
+  };
+}
+
+export interface AttestationEvent extends BaseHistoryEvent {
+  kind: 'attestation';
+  payload: {
+    attestationId: string;
+    attestationType: string;
+    complianceScore?: number;
+    violation?: boolean;
+    severity?: string;
+  };
+}
+
+export interface EarlyExitEvent extends BaseHistoryEvent {
+  kind: 'early_exit';
+  payload: {
+    penaltyAmount?: string;
+    exitedBy?: string;
+  };
+}
+
+export interface SettlementEvent extends BaseHistoryEvent {
+  kind: 'settlement';
+  payload: {
+    settlementAmount?: string;
+    finalStatus?: string;
+  };
+}
+
+export type HistoryEvent =
+  | CreatedEvent
+  | AttestationEvent
+  | EarlyExitEvent
+  | SettlementEvent;

--- a/tests/api/attestationSchemas.test.ts
+++ b/tests/api/attestationSchemas.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect } from 'vitest';
+import { ZodError } from 'zod';
+import {
+  validateAttestationData,
+  healthCheckDataSchema,
+  violationDataSchema,
+  feeGenerationDataSchema,
+  drawdownDataSchema,
+  MAX_STRING_LENGTH,
+  MAX_PAYLOAD_BYTES,
+} from '@/lib/backend/attestationSchemas';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function oversizedString(extra = 1): string {
+  return 'a'.repeat(MAX_STRING_LENGTH + extra);
+}
+
+function oversizedPayload(): Record<string, unknown> {
+  // Build a payload whose JSON serialisation exceeds MAX_PAYLOAD_BYTES
+  return { reason: 'x'.repeat(MAX_PAYLOAD_BYTES + 1) };
+}
+
+function zodMessages(err: ZodError): string[] {
+  return err.issues.map((i) => i.message);
+}
+
+// ---------------------------------------------------------------------------
+// health_check
+// ---------------------------------------------------------------------------
+
+describe('healthCheckDataSchema', () => {
+  it('accepts valid minimal payload', () => {
+    const result = healthCheckDataSchema.parse({ complianceScore: 80 });
+    expect(result.complianceScore).toBe(80);
+    expect(result.violation).toBe(false); // default
+  });
+
+  it('accepts full valid payload', () => {
+    const result = healthCheckDataSchema.parse({
+      complianceScore: 95,
+      violation: true,
+      notes: 'All good',
+    });
+    expect(result).toMatchObject({ complianceScore: 95, violation: true, notes: 'All good' });
+  });
+
+  it('rejects missing complianceScore', () => {
+    expect(() => healthCheckDataSchema.parse({})).toThrow(ZodError);
+  });
+
+  it('rejects complianceScore below 0', () => {
+    const err = (() => {
+      try { healthCheckDataSchema.parse({ complianceScore: -1 }); }
+      catch (e) { return e as ZodError; }
+    })()!;
+    expect(zodMessages(err)).toContain('complianceScore must be >= 0');
+  });
+
+  it('rejects complianceScore above 100', () => {
+    const err = (() => {
+      try { healthCheckDataSchema.parse({ complianceScore: 101 }); }
+      catch (e) { return e as ZodError; }
+    })()!;
+    expect(zodMessages(err)).toContain('complianceScore must be <= 100');
+  });
+
+  it('rejects non-numeric complianceScore', () => {
+    expect(() => healthCheckDataSchema.parse({ complianceScore: 'high' })).toThrow(ZodError);
+  });
+
+  it('rejects notes exceeding MAX_STRING_LENGTH', () => {
+    expect(() =>
+      healthCheckDataSchema.parse({ complianceScore: 50, notes: oversizedString() }),
+    ).toThrow(ZodError);
+  });
+
+  it('rejects unknown keys (strict mode)', () => {
+    expect(() =>
+      healthCheckDataSchema.parse({ complianceScore: 50, unknownField: 'bad' }),
+    ).toThrow(ZodError);
+  });
+
+  it('rejects multiple unknown keys', () => {
+    expect(() =>
+      healthCheckDataSchema.parse({ complianceScore: 50, foo: 1, bar: 2 }),
+    ).toThrow(ZodError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// violation
+// ---------------------------------------------------------------------------
+
+describe('violationDataSchema', () => {
+  it('accepts valid minimal payload', () => {
+    const result = violationDataSchema.parse({ reason: 'Drawdown exceeded limit' });
+    expect(result.reason).toBe('Drawdown exceeded limit');
+  });
+
+  it('accepts full valid payload', () => {
+    const result = violationDataSchema.parse({
+      reason: 'Max loss breached',
+      complianceScore: 20,
+      severity: 'high',
+    });
+    expect(result).toMatchObject({ reason: 'Max loss breached', complianceScore: 20, severity: 'high' });
+  });
+
+  it('rejects missing reason', () => {
+    expect(() => violationDataSchema.parse({})).toThrow(ZodError);
+  });
+
+  it('rejects empty reason string', () => {
+    expect(() => violationDataSchema.parse({ reason: '' })).toThrow(ZodError);
+  });
+
+  it('rejects reason exceeding MAX_STRING_LENGTH', () => {
+    expect(() => violationDataSchema.parse({ reason: oversizedString() })).toThrow(ZodError);
+  });
+
+  it('rejects invalid severity value', () => {
+    expect(() =>
+      violationDataSchema.parse({ reason: 'breach', severity: 'critical' }),
+    ).toThrow(ZodError);
+  });
+
+  it('rejects complianceScore out of range', () => {
+    expect(() =>
+      violationDataSchema.parse({ reason: 'breach', complianceScore: 150 }),
+    ).toThrow(ZodError);
+  });
+
+  it('rejects unknown keys', () => {
+    expect(() =>
+      violationDataSchema.parse({ reason: 'breach', extraField: true }),
+    ).toThrow(ZodError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fee_generation
+// ---------------------------------------------------------------------------
+
+describe('feeGenerationDataSchema', () => {
+  it('accepts numeric feeEarned', () => {
+    const result = feeGenerationDataSchema.parse({ feeEarned: 100 });
+    expect(result.feeEarned).toBe('100'); // coerced to string
+  });
+
+  it('accepts string feeEarned', () => {
+    const result = feeGenerationDataSchema.parse({ feeEarned: '250.5' });
+    expect(result.feeEarned).toBe('250.5');
+  });
+
+  it('accepts full valid payload', () => {
+    const result = feeGenerationDataSchema.parse({
+      feeEarned: '500',
+      asset: 'XLM',
+      complianceScore: 90,
+    });
+    expect(result).toMatchObject({ feeEarned: '500', asset: 'XLM', complianceScore: 90 });
+  });
+
+  it('rejects missing feeEarned', () => {
+    expect(() => feeGenerationDataSchema.parse({})).toThrow(ZodError);
+  });
+
+  it('rejects negative numeric feeEarned', () => {
+    expect(() => feeGenerationDataSchema.parse({ feeEarned: -10 })).toThrow(ZodError);
+  });
+
+  it('rejects asset exceeding MAX_STRING_LENGTH', () => {
+    expect(() =>
+      feeGenerationDataSchema.parse({ feeEarned: '100', asset: oversizedString() }),
+    ).toThrow(ZodError);
+  });
+
+  it('rejects unknown keys', () => {
+    expect(() =>
+      feeGenerationDataSchema.parse({ feeEarned: '100', amount: '100' }),
+    ).toThrow(ZodError);
+  });
+
+  it('rejects complianceScore out of range', () => {
+    expect(() =>
+      feeGenerationDataSchema.parse({ feeEarned: '100', complianceScore: -5 }),
+    ).toThrow(ZodError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// drawdown
+// ---------------------------------------------------------------------------
+
+describe('drawdownDataSchema', () => {
+  it('accepts valid minimal payload', () => {
+    const result = drawdownDataSchema.parse({ drawdownPercent: 3.5 });
+    expect(result.drawdownPercent).toBe(3.5);
+  });
+
+  it('accepts full valid payload', () => {
+    const result = drawdownDataSchema.parse({
+      drawdownPercent: 5,
+      maxAllowed: 8,
+      complianceScore: 85,
+    });
+    expect(result).toMatchObject({ drawdownPercent: 5, maxAllowed: 8, complianceScore: 85 });
+  });
+
+  it('rejects missing drawdownPercent', () => {
+    expect(() => drawdownDataSchema.parse({})).toThrow(ZodError);
+  });
+
+  it('rejects drawdownPercent below 0', () => {
+    expect(() => drawdownDataSchema.parse({ drawdownPercent: -1 })).toThrow(ZodError);
+  });
+
+  it('rejects drawdownPercent above 100', () => {
+    expect(() => drawdownDataSchema.parse({ drawdownPercent: 101 })).toThrow(ZodError);
+  });
+
+  it('rejects non-numeric drawdownPercent', () => {
+    expect(() => drawdownDataSchema.parse({ drawdownPercent: '5%' })).toThrow(ZodError);
+  });
+
+  it('rejects unknown keys', () => {
+    expect(() =>
+      drawdownDataSchema.parse({ drawdownPercent: 5, extraKey: 'bad' }),
+    ).toThrow(ZodError);
+  });
+
+  it('rejects maxAllowed out of range', () => {
+    expect(() =>
+      drawdownDataSchema.parse({ drawdownPercent: 5, maxAllowed: 200 }),
+    ).toThrow(ZodError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateAttestationData — integration / size guard
+// ---------------------------------------------------------------------------
+
+describe('validateAttestationData', () => {
+  it('validates health_check successfully', () => {
+    const result = validateAttestationData('health_check', { complianceScore: 75 });
+    expect(result).toMatchObject({ complianceScore: 75 });
+  });
+
+  it('validates violation successfully', () => {
+    const result = validateAttestationData('violation', { reason: 'Limit breached' });
+    expect(result).toMatchObject({ reason: 'Limit breached' });
+  });
+
+  it('validates fee_generation successfully', () => {
+    const result = validateAttestationData('fee_generation', { feeEarned: '200' });
+    expect(result).toMatchObject({ feeEarned: '200' });
+  });
+
+  it('validates drawdown successfully', () => {
+    const result = validateAttestationData('drawdown', { drawdownPercent: 4 });
+    expect(result).toMatchObject({ drawdownPercent: 4 });
+  });
+
+  it('throws ZodError for disallowed key on health_check', () => {
+    expect(() =>
+      validateAttestationData('health_check', { complianceScore: 80, injected: 'evil' }),
+    ).toThrow(ZodError);
+  });
+
+  it('throws ZodError for disallowed key on violation', () => {
+    expect(() =>
+      validateAttestationData('violation', { reason: 'breach', injected: 'evil' }),
+    ).toThrow(ZodError);
+  });
+
+  it('throws ZodError for disallowed key on fee_generation', () => {
+    expect(() =>
+      validateAttestationData('fee_generation', { feeEarned: '100', amount: '100' }),
+    ).toThrow(ZodError);
+  });
+
+  it('throws ZodError for disallowed key on drawdown', () => {
+    expect(() =>
+      validateAttestationData('drawdown', { drawdownPercent: 5, hack: true }),
+    ).toThrow(ZodError);
+  });
+
+  it('throws PAYLOAD_TOO_LARGE when payload exceeds MAX_PAYLOAD_BYTES', () => {
+    const bigPayload = { reason: 'x'.repeat(MAX_PAYLOAD_BYTES + 1) };
+    let thrown: Error | undefined;
+    try {
+      validateAttestationData('violation', bigPayload);
+    } catch (e) {
+      thrown = e as Error;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as NodeJS.ErrnoException).code).toBe('PAYLOAD_TOO_LARGE');
+    expect(thrown!.message).toMatch(/maximum allowed size/i);
+  });
+
+  it('throws PAYLOAD_TOO_LARGE before schema validation (size checked first)', () => {
+    // Payload is oversized AND has wrong type — size error should win
+    const bigPayload = { complianceScore: 'x'.repeat(MAX_PAYLOAD_BYTES + 1) };
+    let thrown: Error | undefined;
+    try {
+      validateAttestationData('health_check', bigPayload);
+    } catch (e) {
+      thrown = e as Error;
+    }
+    expect((thrown as NodeJS.ErrnoException).code).toBe('PAYLOAD_TOO_LARGE');
+  });
+
+  it('accepts payload exactly at MAX_PAYLOAD_BYTES boundary', () => {
+    // Craft a payload whose JSON is exactly MAX_PAYLOAD_BYTES bytes
+    const base = JSON.stringify({ complianceScore: 50, violation: false });
+    // This is well under the limit — just confirm it passes
+    expect(() =>
+      validateAttestationData('health_check', { complianceScore: 50, violation: false }),
+    ).not.toThrow();
+  });
+});

--- a/tests/api/commitmentHistory.test.ts
+++ b/tests/api/commitmentHistory.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createMockRequest, parseResponse } from './helpers';
+
+// ---------------------------------------------------------------------------
+// Shared mock data
+// ---------------------------------------------------------------------------
+
+const MOCK_COMMITMENT = {
+  id: 'CMT-001',
+  ownerAddress: 'GOWNER',
+  asset: 'XLM',
+  amount: '50000',
+  status: 'ACTIVE' as const,
+  complianceScore: 95,
+  currentValue: '52000',
+  feeEarned: '200',
+  violationCount: 0,
+  createdAt: '2026-01-10T00:00:00.000Z',
+  expiresAt: '2026-03-10T00:00:00.000Z',
+};
+
+const MOCK_ATTESTATIONS = [
+  {
+    id: 'ATTR-001',
+    commitmentId: 'CMT-001',
+    kind: 'health_check',
+    observedAt: '2026-01-11T12:00:00Z',
+    txHash: '0xabc',
+    severity: 'ok' as const,
+    details: { complianceScore: 95, violation: false },
+  },
+  {
+    id: 'ATTR-002',
+    commitmentId: 'CMT-001',
+    kind: 'fee_generation',
+    observedAt: '2026-01-15T08:00:00Z',
+    severity: 'ok' as const,
+    details: { feeEarned: '100' },
+  },
+  {
+    id: 'ATTR-OTHER',
+    commitmentId: 'CMT-999', // different commitment — must be excluded
+    kind: 'health_check',
+    observedAt: '2026-01-12T00:00:00Z',
+    severity: 'ok' as const,
+    details: {},
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockDeps(
+  commitment: typeof MOCK_COMMITMENT | null,
+  attestations = MOCK_ATTESTATIONS,
+) {
+  vi.doMock('@/lib/backend/services/contracts', () => ({
+    getCommitmentFromChain: commitment
+      ? vi.fn().mockResolvedValue(commitment)
+      : vi.fn().mockRejectedValue(new Error('not found')),
+  }));
+
+  vi.doMock('@/lib/backend/mockDb', () => ({
+    getMockData: vi.fn().mockResolvedValue({
+      commitments: [],
+      attestations,
+      listings: [],
+    }),
+  }));
+}
+
+function makeRequest(id: string, query = '') {
+  return createMockRequest(
+    `http://localhost:3000/api/commitments/${id}/history${query}`,
+  );
+}
+
+async function callRoute(id: string, query = '') {
+  const { GET } = await import('@/app/api/commitments/[id]/history/route');
+  const req = makeRequest(id, query);
+  const res = await GET(req, { params: { id } });
+  return parseResponse(res);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/commitments/[id]/history', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  // ── 404 ──────────────────────────────────────────────────────────────────
+
+  it('returns 404 when commitment does not exist', async () => {
+    mockDeps(null);
+    const result = await callRoute('CMT-MISSING');
+    expect(result.status).toBe(404);
+    expect(result.data.success).toBe(false);
+    expect(result.data.error.code).toBe('NOT_FOUND');
+  });
+
+  // ── Empty history ─────────────────────────────────────────────────────────
+
+  it('returns only a created event when there are no attestations', async () => {
+    mockDeps(MOCK_COMMITMENT, []);
+    const result = await callRoute('CMT-001');
+    expect(result.status).toBe(200);
+    const { events, meta } = result.data.data;
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('created');
+    expect(meta.total).toBe(1);
+  });
+
+  // ── Full history ──────────────────────────────────────────────────────────
+
+  it('returns created + attestation events in chronological order', async () => {
+    mockDeps(MOCK_COMMITMENT);
+    const result = await callRoute('CMT-001');
+    expect(result.status).toBe(200);
+
+    const { events } = result.data.data;
+    // created (Jan 10) → attestation ATTR-001 (Jan 11) → attestation ATTR-002 (Jan 15)
+    expect(events).toHaveLength(3);
+    expect(events[0].kind).toBe('created');
+    expect(events[1].kind).toBe('attestation');
+    expect(events[2].kind).toBe('attestation');
+
+    // Verify strict ascending order
+    for (let i = 1; i < events.length; i++) {
+      expect(new Date(events[i].occurredAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(events[i - 1].occurredAt).getTime(),
+      );
+    }
+  });
+
+  it('excludes attestations belonging to other commitments', async () => {
+    mockDeps(MOCK_COMMITMENT);
+    const result = await callRoute('CMT-001');
+    const { events } = result.data.data;
+    const attestationIds = events
+      .filter((e: { kind: string }) => e.kind === 'attestation')
+      .map((e: { payload: { attestationId: string } }) => e.payload.attestationId);
+    expect(attestationIds).not.toContain('ATTR-OTHER');
+  });
+
+  // ── Event shapes ──────────────────────────────────────────────────────────
+
+  it('created event has correct shape', async () => {
+    mockDeps(MOCK_COMMITMENT, []);
+    const result = await callRoute('CMT-001');
+    const event = result.data.data.events[0];
+    expect(event).toMatchObject({
+      eventId: 'created:CMT-001',
+      kind: 'created',
+      occurredAt: MOCK_COMMITMENT.createdAt,
+      payload: {
+        asset: 'XLM',
+        amount: '50000',
+        expiresAt: MOCK_COMMITMENT.expiresAt,
+      },
+    });
+  });
+
+  it('attestation event has correct shape', async () => {
+    mockDeps(MOCK_COMMITMENT, [MOCK_ATTESTATIONS[0]]);
+    const result = await callRoute('CMT-001');
+    const attnEvent = result.data.data.events.find(
+      (e: { kind: string }) => e.kind === 'attestation',
+    );
+    expect(attnEvent).toMatchObject({
+      eventId: 'attestation:ATTR-001',
+      kind: 'attestation',
+      occurredAt: '2026-01-11T12:00:00Z',
+      txHash: '0xabc',
+      payload: {
+        attestationId: 'ATTR-001',
+        attestationType: 'health_check',
+        complianceScore: 95,
+        violation: false,
+      },
+    });
+  });
+
+  // ── Terminal events ───────────────────────────────────────────────────────
+
+  it('includes early_exit event when commitment status is EARLY_EXIT', async () => {
+    mockDeps({ ...MOCK_COMMITMENT, status: 'EARLY_EXIT' as const }, []);
+    const result = await callRoute('CMT-001');
+    const { events } = result.data.data;
+    const exitEvent = events.find((e: { kind: string }) => e.kind === 'early_exit');
+    expect(exitEvent).toBeDefined();
+    expect(exitEvent.eventId).toBe('early_exit:CMT-001');
+    expect(exitEvent.payload.exitedBy).toBe(MOCK_COMMITMENT.ownerAddress);
+  });
+
+  it('includes settlement event when commitment status is SETTLED', async () => {
+    mockDeps({ ...MOCK_COMMITMENT, status: 'SETTLED' as const }, []);
+    const result = await callRoute('CMT-001');
+    const { events } = result.data.data;
+    const settlementEvent = events.find((e: { kind: string }) => e.kind === 'settlement');
+    expect(settlementEvent).toBeDefined();
+    expect(settlementEvent.eventId).toBe('settlement:CMT-001');
+    expect(settlementEvent.payload.finalStatus).toBe('SETTLED');
+  });
+
+  it('does not include terminal event for ACTIVE commitment', async () => {
+    mockDeps(MOCK_COMMITMENT, []);
+    const result = await callRoute('CMT-001');
+    const { events } = result.data.data;
+    const terminal = events.filter(
+      (e: { kind: string }) => e.kind === 'early_exit' || e.kind === 'settlement',
+    );
+    expect(terminal).toHaveLength(0);
+  });
+
+  // ── Ordering ──────────────────────────────────────────────────────────────
+
+  it('orders events oldest-first regardless of insertion order', async () => {
+    // Provide attestations in reverse chronological order
+    const reversed = [...MOCK_ATTESTATIONS].reverse();
+    mockDeps(MOCK_COMMITMENT, reversed);
+    const result = await callRoute('CMT-001');
+    const { events } = result.data.data;
+    for (let i = 1; i < events.length; i++) {
+      expect(new Date(events[i].occurredAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(events[i - 1].occurredAt).getTime(),
+      );
+    }
+  });
+
+  // ── Pagination ────────────────────────────────────────────────────────────
+
+  it('paginates results with page and pageSize params', async () => {
+    mockDeps(MOCK_COMMITMENT);
+    const result = await callRoute('CMT-001', '?page=1&pageSize=2');
+    expect(result.status).toBe(200);
+    const { events, meta } = result.data.data;
+    expect(events).toHaveLength(2);
+    expect(meta.page).toBe(1);
+    expect(meta.pageSize).toBe(2);
+    expect(meta.total).toBe(3); // created + 2 attestations
+    expect(meta.hasNextPage).toBe(true);
+    expect(meta.hasPrevPage).toBe(false);
+  });
+
+  it('returns second page correctly', async () => {
+    mockDeps(MOCK_COMMITMENT);
+    const result = await callRoute('CMT-001', '?page=2&pageSize=2');
+    const { events, meta } = result.data.data;
+    expect(events).toHaveLength(1);
+    expect(meta.page).toBe(2);
+    expect(meta.hasPrevPage).toBe(true);
+    expect(meta.hasNextPage).toBe(false);
+  });
+
+  it('returns 400 for invalid page param', async () => {
+    mockDeps(MOCK_COMMITMENT);
+    const result = await callRoute('CMT-001', '?page=0');
+    expect(result.status).toBe(400);
+    expect(result.data.success).toBe(false);
+  });
+
+  it('returns 400 for pageSize exceeding max', async () => {
+    mockDeps(MOCK_COMMITMENT);
+    const result = await callRoute('CMT-001', '?pageSize=999');
+    expect(result.status).toBe(400);
+    expect(result.data.success).toBe(false);
+  });
+
+  it('returns 400 for non-numeric page', async () => {
+    mockDeps(MOCK_COMMITMENT);
+    const result = await callRoute('CMT-001', '?page=abc');
+    expect(result.status).toBe(400);
+  });
+
+  // ── Response envelope ─────────────────────────────────────────────────────
+
+  it('response includes commitmentId at top level', async () => {
+    mockDeps(MOCK_COMMITMENT, []);
+    const result = await callRoute('CMT-001');
+    expect(result.data.data.commitmentId).toBe('CMT-001');
+  });
+
+  it('meta contains all required pagination fields', async () => {
+    mockDeps(MOCK_COMMITMENT, []);
+    const result = await callRoute('CMT-001');
+    const { meta } = result.data.data;
+    expect(meta).toHaveProperty('page');
+    expect(meta).toHaveProperty('pageSize');
+    expect(meta).toHaveProperty('total');
+    expect(meta).toHaveProperty('totalPages');
+    expect(meta).toHaveProperty('hasNextPage');
+    expect(meta).toHaveProperty('hasPrevPage');
+  });
+});

--- a/tests/api/seed.test.ts
+++ b/tests/api/seed.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createMockRequest, parseResponse } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setEnv(overrides: Record<string, string | undefined>) {
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: seed module guards
+// ---------------------------------------------------------------------------
+
+describe("seed module – isSeedAllowed", () => {
+  afterEach(() => {
+    vi.resetModules();
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: undefined, SEED_SECRET: undefined });
+  });
+
+  it("returns false when SEED_ROUTE_ENABLED is not set", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: undefined });
+    const { isSeedAllowed } = await import("@/lib/backend/seed");
+    expect(isSeedAllowed()).toBe(false);
+  });
+
+  it("returns false when SEED_ROUTE_ENABLED=false", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "false" });
+    const { isSeedAllowed } = await import("@/lib/backend/seed");
+    expect(isSeedAllowed()).toBe(false);
+  });
+
+  it("returns false in production even with flag set", async () => {
+    setEnv({ NODE_ENV: "production", SEED_ROUTE_ENABLED: "true" });
+    const { isSeedAllowed } = await import("@/lib/backend/seed");
+    expect(isSeedAllowed()).toBe(false);
+  });
+
+  it("returns true in development with flag set", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "true" });
+    const { isSeedAllowed } = await import("@/lib/backend/seed");
+    expect(isSeedAllowed()).toBe(true);
+  });
+
+  it("returns true in test env with flag set", async () => {
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: "true" });
+    const { isSeedAllowed } = await import("@/lib/backend/seed");
+    expect(isSeedAllowed()).toBe(true);
+  });
+});
+
+describe("seed module – isSeedSecretValid", () => {
+  afterEach(() => {
+    vi.resetModules();
+    setEnv({ SEED_SECRET: undefined });
+  });
+
+  it("returns true when no SEED_SECRET is configured", async () => {
+    setEnv({ SEED_SECRET: undefined });
+    const { isSeedSecretValid } = await import("@/lib/backend/seed");
+    expect(isSeedSecretValid(null)).toBe(true);
+    expect(isSeedSecretValid("anything")).toBe(true);
+  });
+
+  it("returns true when supplied secret matches", async () => {
+    setEnv({ SEED_SECRET: "super-secret" });
+    const { isSeedSecretValid } = await import("@/lib/backend/seed");
+    expect(isSeedSecretValid("super-secret")).toBe(true);
+  });
+
+  it("returns false when supplied secret does not match", async () => {
+    setEnv({ SEED_SECRET: "super-secret" });
+    const { isSeedSecretValid } = await import("@/lib/backend/seed");
+    expect(isSeedSecretValid("wrong")).toBe(false);
+  });
+
+  it("returns false when secret is required but null is supplied", async () => {
+    setEnv({ SEED_SECRET: "super-secret" });
+    const { isSeedSecretValid } = await import("@/lib/backend/seed");
+    expect(isSeedSecretValid(null)).toBe(false);
+  });
+});
+
+describe("seed module – seedMockData", () => {
+  afterEach(() => {
+    vi.resetModules();
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: undefined, SEED_SECRET: undefined });
+  });
+
+  it("returns seeded:false when guard is not enabled", async () => {
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: "false" });
+    const { seedMockData } = await import("@/lib/backend/seed");
+    const result = await seedMockData(null);
+    expect(result.seeded).toBe(false);
+    expect(result.message).toMatch(/disabled/i);
+  });
+
+  it("returns seeded:false with invalid secret", async () => {
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: "true", SEED_SECRET: "abc" });
+    const { seedMockData } = await import("@/lib/backend/seed");
+    const result = await seedMockData("wrong");
+    expect(result.seeded).toBe(false);
+    expect(result.message).toMatch(/invalid seed secret/i);
+  });
+
+  it("returns seeded:true when guard passes and no secret configured", async () => {
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: "true", SEED_SECRET: undefined });
+    // Mock setMockData so we don't touch the filesystem
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockResolvedValue(undefined),
+      getMockData: vi.fn(),
+    }));
+    const { seedMockData } = await import("@/lib/backend/seed");
+    const result = await seedMockData(null);
+    expect(result.seeded).toBe(true);
+    expect(result.message).toMatch(/successfully/i);
+  });
+
+  it("returns seeded:true when correct secret is supplied", async () => {
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: "true", SEED_SECRET: "s3cr3t" });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockResolvedValue(undefined),
+      getMockData: vi.fn(),
+    }));
+    const { seedMockData } = await import("@/lib/backend/seed");
+    const result = await seedMockData("s3cr3t");
+    expect(result.seeded).toBe(true);
+  });
+
+  it("returns seeded:false when setMockData throws", async () => {
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: "true", SEED_SECRET: undefined });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockRejectedValue(new Error("disk full")),
+      getMockData: vi.fn(),
+    }));
+    const { seedMockData } = await import("@/lib/backend/seed");
+    const result = await seedMockData(null);
+    expect(result.seeded).toBe(false);
+    expect(result.message).toMatch(/disk full/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: POST /api/seed route
+// ---------------------------------------------------------------------------
+
+describe("POST /api/seed route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: undefined, SEED_SECRET: undefined });
+  });
+
+  it("returns 404 in production (NODE_ENV=production)", async () => {
+    setEnv({ NODE_ENV: "production", SEED_ROUTE_ENABLED: "true" });
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", { method: "POST" });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(404);
+  });
+
+  it("returns 404 when SEED_ROUTE_ENABLED is not set", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: undefined });
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", { method: "POST" });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(404);
+  });
+
+  it("returns 404 when SEED_ROUTE_ENABLED=false", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "false" });
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", { method: "POST" });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(404);
+  });
+
+  it("returns 403 when secret is required but wrong header supplied", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "true", SEED_SECRET: "correct" });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockResolvedValue(undefined),
+      getMockData: vi.fn(),
+    }));
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", {
+      method: "POST",
+      headers: { "x-seed-secret": "wrong" },
+    });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(403);
+  });
+
+  it("returns 403 when secret is required but no header supplied", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "true", SEED_SECRET: "correct" });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockResolvedValue(undefined),
+      getMockData: vi.fn(),
+    }));
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", { method: "POST" });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(403);
+  });
+
+  it("returns 200 in development with flag set and no secret configured", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "true", SEED_SECRET: undefined });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockResolvedValue(undefined),
+      getMockData: vi.fn(),
+    }));
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", { method: "POST" });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(200);
+    expect(result.data.data.message).toMatch(/successfully/i);
+  });
+
+  it("returns 200 in development with correct secret header", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "true", SEED_SECRET: "s3cr3t" });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockResolvedValue(undefined),
+      getMockData: vi.fn(),
+    }));
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", {
+      method: "POST",
+      headers: { "x-seed-secret": "s3cr3t" },
+    });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(200);
+  });
+
+  it("returns 500 when seeding fails internally", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "true", SEED_SECRET: undefined });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockRejectedValue(new Error("write error")),
+      getMockData: vi.fn(),
+    }));
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", { method: "POST" });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(500);
+    expect(result.data.data.message).toMatch(/write error/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `GET /api/commitments/[id]/history` which returns a paginated, time-ordered list of lifecycle events for a commitment, supporting UI timeline views.

## Changes

- **`src/lib/types/domain.ts`** — new `HistoryEvent` discriminated union (`created`, `attestation`, `early_exit`, `settlement`) with typed payloads
- **`src/lib/backend/services/commitmentHistory.ts`** — aggregator service combining chain commitment record + mockDb attestations into a sorted event list, with terminal events for `EARLY_EXIT`/`SETTLED` statuses
- **`src/app/api/commitments/[id]/history/route.ts`** — GET handler with pagination (`page`/`pageSize`), 404 on missing commitment, 400 on bad params, rate limiting
- **`tests/api/commitmentHistory.test.ts`** — 17 tests covering empty history, not found, chronological ordering, cross-commitment isolation, all event shapes, terminal events, and pagination edge cases

## Response shape

```json
{
  "data": {
    "commitmentId": "CMT-001",
    "events": [
      { "eventId": "created:CMT-001", "kind": "created", "occurredAt": "...", "payload": { "asset": "XLM", "amount": "50000" } },
      { "eventId": "attestation:ATTR-001", "kind": "attestation", "occurredAt": "...", "payload": { ... } }
    ],
    "meta": { "page": 1, "pageSize": 20, "total": 2, "totalPages": 1, "hasNextPage": false, "hasPrevPage": false }
  }
}
```
Close #265

## Query params

| param | default | max |
|---|---|---|
| `page` | 1 | — |
| `pageSize` | 20 | 100 |