### PR TITLE
feat: harden seed endpoint and remove shell execution

### DIFF
--- a/scripts/seed-backend-mock.ts
+++ b/scripts/seed-backend-mock.ts
@@ -1,89 +1,21 @@
-import fs from 'fs';
-import path from 'path';
+/**
+ * CLI entry-point for seeding mock data.
+ * Delegates to the shared seedMockData module so there is a single source of truth.
+ *
+ * Usage:
+ *   SEED_ROUTE_ENABLED=true NODE_ENV=development npx tsx scripts/seed-backend-mock.ts
+ */
 
-const mockDbPath = path.join(process.cwd(), '.mock-db.json');
+// Ensure guards pass when running from the CLI
+process.env.NODE_ENV = process.env.NODE_ENV ?? "development";
+process.env.SEED_ROUTE_ENABLED = process.env.SEED_ROUTE_ENABLED ?? "true";
 
-const sampleCommitments = [
-    {
-        id: 'CMT-ABC123',
-        type: 'Safe',
-        status: 'Active',
-        asset: 'XLM',
-        amount: '50,000',
-        currentValue: '52,600',
-        changePercent: 5.2,
-        durationProgress: 75,
-        daysRemaining: 15,
-        complianceScore: 95,
-        maxLoss: '2%',
-        currentDrawdown: '0.8%',
-        createdDate: 'Jan 10, 2026',
-        expiryDate: 'Feb 9, 2026',
-    },
-    {
-        id: 'CMT-XYZ789',
-        type: 'Balanced',
-        status: 'Active',
-        asset: 'USDC',
-        amount: '100,000',
-        currentValue: '112,500',
-        changePercent: 12.5,
-        durationProgress: 30,
-        daysRemaining: 42,
-        complianceScore: 88,
-        maxLoss: '8%',
-        currentDrawdown: '3.2%',
-        createdDate: 'Dec 15, 2025',
-        expiryDate: 'Feb 13, 2026',
-    }
-];
+import { seedMockData } from "../src/lib/backend/seed";
 
-const sampleAttestations = [
-    {
-        id: 'ATTR-001',
-        commitmentId: 'CMT-ABC123',
-        provider: 'Provider A',
-        status: 'Valid',
-        timestamp: '2026-01-11T12:00:00Z',
-    }
-];
-
-const sampleListings = [
-    {
-        id: '001',
-        type: 'Safe',
-        score: 95,
-        amount: '$50,000',
-        duration: '25 days',
-        yield: '5.2%',
-        maxLoss: '2%',
-        owner: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
-        price: '$52,000',
-        forSale: true,
-    },
-    {
-        id: '002',
-        type: 'Balanced',
-        score: 88,
-        amount: '$100,000',
-        duration: '45 days',
-        yield: '12.5%',
-        maxLoss: '8%',
-        owner: '0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199',
-        price: '$105,000',
-        forSale: true,
-    }
-];
-
-function seedMockData() {
-    const data = {
-        commitments: sampleCommitments,
-        attestations: sampleAttestations,
-        listings: sampleListings,
-    };
-
-    fs.writeFileSync(mockDbPath, JSON.stringify(data, null, 2), 'utf8');
-    console.log(`Mock data successfully seeded to ${mockDbPath}`);
+const result = await seedMockData(process.env.SEED_SECRET ?? null);
+if (result.seeded) {
+  console.log(result.message);
+} else {
+  console.error(result.message);
+  process.exit(1);
 }
-
-seedMockData();

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -1,21 +1,24 @@
-import { withApiHandler } from '@/lib/backend/withApiHandler';
-import { ok } from '@/lib/backend/apiResponse';
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { withApiHandler } from "@/lib/backend/withApiHandler";
+import { ok } from "@/lib/backend/apiResponse";
+import { seedMockData, isSeedAllowed } from "@/lib/backend/seed";
+import type { NextRequest } from "next/server";
 
-const execAsync = promisify(exec);
+export const POST = withApiHandler(async (req: NextRequest) => {
+  // Hard guard: reject immediately outside development/test + flag check
+  if (!isSeedAllowed()) {
+    return ok({ message: "Not Found" }, 404);
+  }
 
-export const POST = withApiHandler(async () => {
-    // Only allow this route in development mode
-    if (process.env.NODE_ENV !== 'development') {
-        return ok({ message: 'Not Found' }, 404);
+  const secret = req.headers.get("x-seed-secret");
+  const result = await seedMockData(secret);
+
+  if (!result.seeded) {
+    // Distinguish auth failure from other errors
+    if (result.message === "Invalid seed secret.") {
+      return ok({ message: result.message }, 403);
     }
+    return ok({ message: result.message }, 500);
+  }
 
-    try {
-        await execAsync('npm run seed:mock');
-        return ok({ message: 'Mock data seeded successfully.' }, 200);
-    } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return ok({ message: 'Failed to seed mock data', error: msg }, 500);
-    }
+  return ok({ message: result.message }, 200);
 });

--- a/src/lib/backend/seed.ts
+++ b/src/lib/backend/seed.ts
@@ -1,0 +1,153 @@
+/**
+ * Seed module for mock database.
+ *
+ * Exports a callable `seedMockData` function so the seed route and CLI script
+ * can share the same logic without spawning a child process.
+ *
+ * Guard rules (enforced at call-time):
+ *  1. NODE_ENV must be "development" or "test".
+ *  2. SEED_ROUTE_ENABLED must be "true".
+ *
+ * An optional SEED_SECRET env var can be set; when present, callers must
+ * supply the matching value via the `x-seed-secret` request header.
+ */
+
+import { setMockData } from "./mockDb";
+import type { MockData } from "./mockDb";
+
+// ---------------------------------------------------------------------------
+// Sample data
+// ---------------------------------------------------------------------------
+
+const SAMPLE_DATA: MockData = {
+  commitments: [
+    {
+      id: "CMT-ABC123",
+      type: "Safe",
+      status: "Active",
+      asset: "XLM",
+      amount: "50,000",
+      currentValue: "52,600",
+      changePercent: 5.2,
+      durationProgress: 75,
+      daysRemaining: 15,
+      complianceScore: 95,
+      maxLoss: "2%",
+      currentDrawdown: "0.8%",
+      createdDate: "Jan 10, 2026",
+      expiryDate: "Feb 9, 2026",
+    },
+    {
+      id: "CMT-XYZ789",
+      type: "Balanced",
+      status: "Active",
+      asset: "USDC",
+      amount: "100,000",
+      currentValue: "112,500",
+      changePercent: 12.5,
+      durationProgress: 30,
+      daysRemaining: 42,
+      complianceScore: 88,
+      maxLoss: "8%",
+      currentDrawdown: "3.2%",
+      createdDate: "Dec 15, 2025",
+      expiryDate: "Feb 13, 2026",
+    },
+  ],
+  attestations: [
+    {
+      id: "ATTR-001",
+      commitmentId: "CMT-ABC123",
+      provider: "Provider A",
+      status: "Valid",
+      timestamp: "2026-01-11T12:00:00Z",
+    },
+  ],
+  listings: [
+    {
+      id: "001",
+      type: "Safe",
+      score: 95,
+      amount: "$50,000",
+      duration: "25 days",
+      yield: "5.2%",
+      maxLoss: "2%",
+      owner: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX1",
+      price: "$52,000",
+      forSale: true,
+    },
+    {
+      id: "002",
+      type: "Balanced",
+      score: 88,
+      amount: "$100,000",
+      duration: "45 days",
+      yield: "12.5%",
+      maxLoss: "8%",
+      owner: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX2",
+      price: "$105,000",
+      forSale: true,
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Guard helpers (exported for testing)
+// ---------------------------------------------------------------------------
+
+/** Returns true only when the runtime environment permits seeding. */
+export function isSeedAllowed(): boolean {
+  const env = process.env.NODE_ENV;
+  if (env !== "development" && env !== "test") return false;
+  return process.env.SEED_ROUTE_ENABLED === "true";
+}
+
+/**
+ * Validates an optional shared secret.
+ * Returns true when no secret is configured (open) or when the supplied
+ * value matches SEED_SECRET exactly.
+ */
+export function isSeedSecretValid(suppliedSecret: string | null): boolean {
+  const expected = process.env.SEED_SECRET;
+  if (!expected) return true; // no secret configured → always valid
+  return suppliedSecret === expected;
+}
+
+// ---------------------------------------------------------------------------
+// Core seed function
+// ---------------------------------------------------------------------------
+
+export interface SeedResult {
+  seeded: boolean;
+  message: string;
+}
+
+/**
+ * Seeds the mock database with sample data.
+ *
+ * @param suppliedSecret - Value from the `x-seed-secret` header (or null).
+ * @returns SeedResult describing the outcome.
+ * @throws Never – errors are captured and returned as a failed SeedResult.
+ */
+export async function seedMockData(
+  suppliedSecret: string | null = null
+): Promise<SeedResult> {
+  if (!isSeedAllowed()) {
+    return {
+      seeded: false,
+      message: "Seed is disabled. Set SEED_ROUTE_ENABLED=true in development.",
+    };
+  }
+
+  if (!isSeedSecretValid(suppliedSecret)) {
+    return { seeded: false, message: "Invalid seed secret." };
+  }
+
+  try {
+    await setMockData(SAMPLE_DATA);
+    return { seeded: true, message: "Mock data seeded successfully." };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { seeded: false, message: `Failed to seed mock data: ${msg}` };
+  }
+}

--- a/tests/api/seed.test.ts
+++ b/tests/api/seed.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createMockRequest, parseResponse } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setEnv(overrides: Record<string, string | undefined>) {
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: seed module guards
+// ---------------------------------------------------------------------------
+
+describe("seed module – isSeedAllowed", () => {
+  afterEach(() => {
+    vi.resetModules();
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: undefined, SEED_SECRET: undefined });
+  });
+
+  it("returns false when SEED_ROUTE_ENABLED is not set", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: undefined });
+    const { isSeedAllowed } = await import("@/lib/backend/seed");
+    expect(isSeedAllowed()).toBe(false);
+  });
+
+  it("returns false when SEED_ROUTE_ENABLED=false", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "false" });
+    const { isSeedAllowed } = await import("@/lib/backend/seed");
+    expect(isSeedAllowed()).toBe(false);
+  });
+
+  it("returns false in production even with flag set", async () => {
+    setEnv({ NODE_ENV: "production", SEED_ROUTE_ENABLED: "true" });
+    const { isSeedAllowed } = await import("@/lib/backend/seed");
+    expect(isSeedAllowed()).toBe(false);
+  });
+
+  it("returns true in development with flag set", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "true" });
+    const { isSeedAllowed } = await import("@/lib/backend/seed");
+    expect(isSeedAllowed()).toBe(true);
+  });
+
+  it("returns true in test env with flag set", async () => {
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: "true" });
+    const { isSeedAllowed } = await import("@/lib/backend/seed");
+    expect(isSeedAllowed()).toBe(true);
+  });
+});
+
+describe("seed module – isSeedSecretValid", () => {
+  afterEach(() => {
+    vi.resetModules();
+    setEnv({ SEED_SECRET: undefined });
+  });
+
+  it("returns true when no SEED_SECRET is configured", async () => {
+    setEnv({ SEED_SECRET: undefined });
+    const { isSeedSecretValid } = await import("@/lib/backend/seed");
+    expect(isSeedSecretValid(null)).toBe(true);
+    expect(isSeedSecretValid("anything")).toBe(true);
+  });
+
+  it("returns true when supplied secret matches", async () => {
+    setEnv({ SEED_SECRET: "super-secret" });
+    const { isSeedSecretValid } = await import("@/lib/backend/seed");
+    expect(isSeedSecretValid("super-secret")).toBe(true);
+  });
+
+  it("returns false when supplied secret does not match", async () => {
+    setEnv({ SEED_SECRET: "super-secret" });
+    const { isSeedSecretValid } = await import("@/lib/backend/seed");
+    expect(isSeedSecretValid("wrong")).toBe(false);
+  });
+
+  it("returns false when secret is required but null is supplied", async () => {
+    setEnv({ SEED_SECRET: "super-secret" });
+    const { isSeedSecretValid } = await import("@/lib/backend/seed");
+    expect(isSeedSecretValid(null)).toBe(false);
+  });
+});
+
+describe("seed module – seedMockData", () => {
+  afterEach(() => {
+    vi.resetModules();
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: undefined, SEED_SECRET: undefined });
+  });
+
+  it("returns seeded:false when guard is not enabled", async () => {
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: "false" });
+    const { seedMockData } = await import("@/lib/backend/seed");
+    const result = await seedMockData(null);
+    expect(result.seeded).toBe(false);
+    expect(result.message).toMatch(/disabled/i);
+  });
+
+  it("returns seeded:false with invalid secret", async () => {
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: "true", SEED_SECRET: "abc" });
+    const { seedMockData } = await import("@/lib/backend/seed");
+    const result = await seedMockData("wrong");
+    expect(result.seeded).toBe(false);
+    expect(result.message).toMatch(/invalid seed secret/i);
+  });
+
+  it("returns seeded:true when guard passes and no secret configured", async () => {
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: "true", SEED_SECRET: undefined });
+    // Mock setMockData so we don't touch the filesystem
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockResolvedValue(undefined),
+      getMockData: vi.fn(),
+    }));
+    const { seedMockData } = await import("@/lib/backend/seed");
+    const result = await seedMockData(null);
+    expect(result.seeded).toBe(true);
+    expect(result.message).toMatch(/successfully/i);
+  });
+
+  it("returns seeded:true when correct secret is supplied", async () => {
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: "true", SEED_SECRET: "s3cr3t" });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockResolvedValue(undefined),
+      getMockData: vi.fn(),
+    }));
+    const { seedMockData } = await import("@/lib/backend/seed");
+    const result = await seedMockData("s3cr3t");
+    expect(result.seeded).toBe(true);
+  });
+
+  it("returns seeded:false when setMockData throws", async () => {
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: "true", SEED_SECRET: undefined });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockRejectedValue(new Error("disk full")),
+      getMockData: vi.fn(),
+    }));
+    const { seedMockData } = await import("@/lib/backend/seed");
+    const result = await seedMockData(null);
+    expect(result.seeded).toBe(false);
+    expect(result.message).toMatch(/disk full/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: POST /api/seed route
+// ---------------------------------------------------------------------------
+
+describe("POST /api/seed route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    setEnv({ NODE_ENV: "test", SEED_ROUTE_ENABLED: undefined, SEED_SECRET: undefined });
+  });
+
+  it("returns 404 in production (NODE_ENV=production)", async () => {
+    setEnv({ NODE_ENV: "production", SEED_ROUTE_ENABLED: "true" });
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", { method: "POST" });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(404);
+  });
+
+  it("returns 404 when SEED_ROUTE_ENABLED is not set", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: undefined });
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", { method: "POST" });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(404);
+  });
+
+  it("returns 404 when SEED_ROUTE_ENABLED=false", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "false" });
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", { method: "POST" });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(404);
+  });
+
+  it("returns 403 when secret is required but wrong header supplied", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "true", SEED_SECRET: "correct" });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockResolvedValue(undefined),
+      getMockData: vi.fn(),
+    }));
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", {
+      method: "POST",
+      headers: { "x-seed-secret": "wrong" },
+    });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(403);
+  });
+
+  it("returns 403 when secret is required but no header supplied", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "true", SEED_SECRET: "correct" });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockResolvedValue(undefined),
+      getMockData: vi.fn(),
+    }));
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", { method: "POST" });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(403);
+  });
+
+  it("returns 200 in development with flag set and no secret configured", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "true", SEED_SECRET: undefined });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockResolvedValue(undefined),
+      getMockData: vi.fn(),
+    }));
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", { method: "POST" });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(200);
+    expect(result.data.data.message).toMatch(/successfully/i);
+  });
+
+  it("returns 200 in development with correct secret header", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "true", SEED_SECRET: "s3cr3t" });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockResolvedValue(undefined),
+      getMockData: vi.fn(),
+    }));
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", {
+      method: "POST",
+      headers: { "x-seed-secret": "s3cr3t" },
+    });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(200);
+  });
+
+  it("returns 500 when seeding fails internally", async () => {
+    setEnv({ NODE_ENV: "development", SEED_ROUTE_ENABLED: "true", SEED_SECRET: undefined });
+    vi.doMock("@/lib/backend/mockDb", () => ({
+      setMockData: vi.fn().mockRejectedValue(new Error("write error")),
+      getMockData: vi.fn(),
+    }));
+    const { POST } = await import("@/app/api/seed/route");
+    const req = createMockRequest("http://localhost:3000/api/seed", { method: "POST" });
+    const res = await POST(req);
+    const result = await parseResponse(res);
+    expect(result.status).toBe(500);
+    expect(result.data.data.message).toMatch(/write error/);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the `child_process.exec` call in `POST /api/seed` with a direct import of a new callable seed module, adds an explicit `SEED_ROUTE_ENABLED` guard flag, and supports an optional `x-seed-secret` header for shared-secret protection.

## Changes

- **`src/lib/backend/seed.ts`** — new importable module with sample data, `isSeedAllowed()`, `isSeedSecretValid()`, and `seedMockData()`
- **`src/app/api/seed/route.ts`** — removed `child_process`/`exec`; calls `seedMockData()` directly; maps result to 200/403/404/500
- **`scripts/seed-backend-mock.ts`** — now delegates to the shared module instead of duplicating logic
- **`tests/api/seed.test.ts`** — 22 tests covering all guard combinations, secret validation, and HTTP responses

Close #274

## Security

- Route returns 404 outside `development`/`test` environments
- `SEED_ROUTE_ENABLED=true` must be explicitly set
- Optional `SEED_SECRET` env var enforces header-based shared secret (`x-seed-secret`)