### PR TITLE
Feat : Add contracts service error normalization for retryable and fatal failures

### DIFF
--- a/src/lib/backend/services/contracts.ts
+++ b/src/lib/backend/services/contracts.ts
@@ -8,7 +8,7 @@ import {
   nativeToScVal,
   scValToNative,
 } from "@stellar/stellar-sdk";
-import { BackendError, normalizeBackendError } from "@/lib/backend/errors";
+import { BackendError } from "@/lib/backend/errors";
 import { getBackendConfig } from "@/lib/backend/config";
 
 export type ChainCommitmentStatus =
@@ -80,8 +80,6 @@ export interface SettleCommitmentOnChainResult {
 }
 
 type ContractCallMode = 'read' | 'write';
-type ContractCallMode = "read" | "write";
-
 interface ContractInvocationResult {
   value: unknown;
   txHash?: string;
@@ -177,6 +175,77 @@ function normalizeStatus(value: unknown): ChainCommitmentStatus {
     return raw;
   }
   return "UNKNOWN";
+}
+
+/**
+ * Normalizes blockchain-related errors into stable BackendError types.
+ * Maps RPC failures, simulation errors, and timeouts to appropriate status codes.
+ * Ensures that sensitive raw RPC details are not leaked to the client.
+ */
+function normalizeContractError(
+  error: unknown,
+  defaults: {
+    code: string;
+    message: string;
+    status: number;
+    details?: Record<string, unknown>;
+  }
+): BackendError {
+  // If it's already a well-formed BackendError, we enrich it with defaults
+  if (error instanceof BackendError) {
+    const isRetryable = [429, 503, 504].includes(error.status);
+    return new BackendError({
+      code: error.code,
+      message: error.message,
+      status: error.status,
+      details: {
+        ...asRecord(error.details),
+        ...asRecord(defaults.details),
+        retryable: isRetryable || asRecord(error.details).retryable === true,
+      },
+    });
+  }
+
+  const errMessage = error instanceof Error ? error.message : String(error);
+  const errStr = errMessage.toLowerCase();
+
+  let status = defaults.status;
+  let code = defaults.code;
+  let message = defaults.message;
+  let retryable = false;
+
+  // Pattern match for specific failure types from Soroban RPC or SDK
+  if (errStr.includes("timeout") || errStr.includes("deadline") || errStr.includes("timed out")) {
+    status = 504;
+    code = "GATEWAY_TIMEOUT";
+    message = "The blockchain operation timed out. It may still be processed later.";
+    retryable = true;
+  } else if (errStr.includes("429") || errStr.includes("rate limit") || errStr.includes("too many requests")) {
+    status = 429;
+    code = "TOO_MANY_REQUESTS";
+    message = "Rate limit exceeded for blockchain calls. Please try again later.";
+    retryable = true;
+  } else if (errStr.includes("not found") || errStr.includes("404")) {
+    status = 404;
+    code = "NOT_FOUND";
+    message = "The requested resource was not found on the blockchain.";
+  } else if (errStr.includes("insufficient") || errStr.includes("invalid") || errStr.includes("malformed")) {
+    status = 400;
+    code = "VALIDATION_ERROR";
+    message = "The transaction was rejected due to invalid parameters or state.";
+  } else if (status >= 500) {
+    retryable = true;
+  }
+
+  return new BackendError({
+    code,
+    message,
+    status,
+    details: {
+      ...asRecord(defaults.details),
+      retryable,
+    },
+  });
 }
 
 function parseChainCommitment(value: unknown): ChainCommitment {
@@ -291,11 +360,11 @@ async function waitForTransactionResult(
       return tx.returnValue ? scValToNative(tx.returnValue) : null;
     }
     if (tx.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
-      throw new BackendError({
+      throw normalizeContractError(new Error("Transaction execution failed"), {
         code: "BLOCKCHAIN_CALL_FAILED",
         message: "Soroban transaction failed.",
         status: 502,
-        details: { hash, txStatus: tx.status },
+        details: { hash, txStatus: tx.status }
       });
     }
 
@@ -304,11 +373,11 @@ async function waitForTransactionResult(
     });
   }
 
-  throw new BackendError({
+  throw normalizeContractError(new Error("RPC Timeout"), {
     code: "BLOCKCHAIN_CALL_FAILED",
     message: "Timed out waiting for Soroban transaction result.",
     status: 504,
-    details: { hash },
+    details: { hash }
   });
 }
 
@@ -358,11 +427,11 @@ async function invokeContractMethod(
 
   const simulation = await server.simulateTransaction(tx);
   if (SorobanRpc.Api.isSimulationError(simulation)) {
-    throw new BackendError({
+    throw normalizeContractError(new Error(simulation.error), {
       code: "BLOCKCHAIN_CALL_FAILED",
       message: `Soroban simulation failed for ${methodName}.`,
       status: 502,
-      details: { methodName, error: simulation.error },
+      details: { methodName }
     });
   }
 
@@ -423,7 +492,7 @@ export async function createCommitmentOnChain(
 
     return parseCreateCommitmentResult(invocation.value, invocation.txHash);
   } catch (error) {
-    throw normalizeBackendError(error, {
+    throw normalizeContractError(error, {
       code: "BLOCKCHAIN_CALL_FAILED",
       message: "Unable to create commitment on chain.",
       status: 502,
@@ -453,7 +522,7 @@ export async function getCommitmentFromChain(
 
     return parseChainCommitment(invocation.value);
   } catch (error) {
-    throw normalizeBackendError(error, {
+    throw normalizeContractError(error, {
       code: "BLOCKCHAIN_CALL_FAILED",
       message: "Unable to fetch commitment from chain.",
       status: 502,
@@ -501,7 +570,7 @@ export async function getUserCommitmentsFromChain(
 
     return commitments;
   } catch (error) {
-    throw normalizeBackendError(error, {
+    throw normalizeContractError(error, {
       code: "BLOCKCHAIN_CALL_FAILED",
       message: "Unable to fetch user commitments from chain.",
       status: 502,
@@ -539,7 +608,7 @@ export async function recordAttestationOnChain(
 
     return parseAttestationResult(invocation.value, invocation.txHash);
   } catch (error) {
-    throw normalizeBackendError(error, {
+    throw normalizeContractError(error, {
       code: "BLOCKCHAIN_CALL_FAILED",
       message: "Unable to record attestation on chain.",
       status: 502,
@@ -612,7 +681,7 @@ export async function settleCommitmentOnChain(
       reference: invocation.txHash ? undefined : `TODO_CHAIN_CALL_SETTLE_COMMITMENT`
     };
   } catch (error) {
-    throw normalizeBackendError(error, {
+    throw normalizeContractError(error, {
       code: 'BLOCKCHAIN_CALL_FAILED',
       message: 'Unable to settle commitment on chain.',
       status: 502,


### PR DESCRIPTION
## Closes #217 
## Summary
- Replace generic `normalizeBackendError` with contract-specific `normalizeContractError` function
- Improve error handling for blockchain operations (timeouts, rate limits, simulation failures)
- Remove duplicate `ContractCallMode` type definition
- Ensure sensitive RPC details are not leaked to clients

## Changes
- Modified: `src/lib/backend/services/contracts.ts` (+83, -14)
  - Added `normalizeContractError` function for contract-specific error normalization
  - Removed import of `normalizeBackendError` (no longer needed)
  - Removed duplicate `ContractCallMode` type definition
  - Updated all error throws to use new `normalizeContractError`
  - Added pattern matching for timeouts, rate limits, and not found errors
  - Added retryable flag detection for appropriate status codes

## Testing
- Error handling now properly categorizes blockchain RPC errors
- Timeout errors return 504 with retryable=true
- Rate limit errors return 429 with retryable=true
- Transaction failures return 502 with appropriate context
