### PR TITLE
feat: add commitment status endpoint for lightweight polling

### DIFF
--- a/docs/commitment-status-endpoint.md
+++ b/docs/commitment-status-endpoint.md
@@ -1,0 +1,49 @@
+# Commitment Status Endpoint
+
+## Overview
+
+`GET /api/commitments/[id]/status` returns a lightweight status snapshot
+for a commitment. It is designed for **efficient polling** — returning only
+the fields needed to track commitment health without the full payload.
+
+## Request
+No request body or query parameters required.
+
+## Response — 200 OK
+
+```json
+{
+  "data": {
+    "commitmentId": "commitment-123",
+    "status": "ACTIVE",
+    "daysRemaining": 14,
+    "complianceScore": 92,
+    "currentValue": "10500",
+    "violationCount": 0,
+    "expiresAt": "2026-05-01T00:00:00.000Z"
+  }
+}
+```
+
+| Field           | Type            | Description                              |
+|-----------------|-----------------|------------------------------------------|
+| commitmentId    | string          | Unique commitment identifier             |
+| status          | string          | ACTIVE, SETTLED, VIOLATED, EARLY_EXIT    |
+| daysRemaining   | number          | Days until expiry (0 if expired)         |
+| complianceScore | number          | Current compliance score (0-100)         |
+| currentValue    | string          | Current value of the commitment          |
+| violationCount  | number          | Number of violations recorded            |
+| expiresAt       | string or null  | ISO 8601 expiry timestamp                |
+
+## Error Responses
+
+| Status | Code          | Description                    |
+|--------|---------------|--------------------------------|
+| 404    | NOT_FOUND     | Commitment does not exist      |
+| 429    | TOO_MANY_REQUESTS | Rate limit exceeded        |
+
+## Polling Recommendation
+
+Poll at most once every **30 seconds** per commitment to stay within
+rate limits. Use the `status` field to stop polling once a terminal
+state (`SETTLED`, `VIOLATED`, `EARLY_EXIT`) is reached.

--- a/src/app/api/commitments/[id]/status/route.test.ts
+++ b/src/app/api/commitments/[id]/status/route.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, getDaysRemaining } from './route';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/backend/rateLimit', () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@/lib/backend/services/contracts', () => ({
+  getCommitmentFromChain: vi.fn(),
+}));
+
+import { getCommitmentFromChain } from '@/lib/backend/services/contracts';
+import { checkRateLimit } from '@/lib/backend/rateLimit';
+
+const mockGetCommitment = vi.mocked(getCommitmentFromChain);
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRequest(id: string): [NextRequest, { params: Record<string, string> }] {
+  const req = new NextRequest(`http://localhost/api/commitments/${id}/status`);
+  return [req, { params: { id } }];
+}
+
+const MOCK_COMMITMENT = {
+  id: 'commitment-123',
+  ownerAddress: 'GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU',
+  asset: 'USDC',
+  amount: '10000',
+  status: 'ACTIVE' as const,
+  complianceScore: 92,
+  currentValue: '10500',
+  feeEarned: '150',
+  violationCount: 0,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+};
+
+// ── getDaysRemaining ──────────────────────────────────────────────────────────
+
+describe('getDaysRemaining', () => {
+  it('returns 0 for undefined', () => {
+    expect(getDaysRemaining(undefined)).toBe(0);
+  });
+
+  it('returns 0 for empty string', () => {
+    expect(getDaysRemaining('')).toBe(0);
+  });
+
+  it('returns 0 for invalid date string', () => {
+    expect(getDaysRemaining('not-a-date')).toBe(0);
+  });
+
+  it('returns 0 for a past date', () => {
+    const past = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    expect(getDaysRemaining(past)).toBe(0);
+  });
+
+  it('returns positive days for a future date', () => {
+    const future = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString();
+    expect(getDaysRemaining(future)).toBeGreaterThan(0);
+  });
+
+  it('returns approximately 30 for 30 days in the future', () => {
+    const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    const days = getDaysRemaining(future);
+    expect(days).toBeGreaterThanOrEqual(29);
+    expect(days).toBeLessThanOrEqual(31);
+  });
+});
+
+// ── GET handler ───────────────────────────────────────────────────────────────
+
+describe('GET /api/commitments/[id]/status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckRateLimit.mockResolvedValue(true);
+  });
+
+  describe('200 - success', () => {
+    it('returns status snapshot for a valid commitment', async () => {
+      mockGetCommitment.mockResolvedValue(MOCK_COMMITMENT);
+      const [req, ctx] = makeRequest('commitment-123');
+      const res = await GET(req, ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.commitmentId).toBe('commitment-123');
+      expect(body.data.status).toBe('ACTIVE');
+      expect(body.data.complianceScore).toBe(92);
+      expect(body.data.currentValue).toBe('10500');
+      expect(body.data.violationCount).toBe(0);
+      expect(body.data.daysRemaining).toBeGreaterThan(0);
+      expect(body.data.expiresAt).toBeDefined();
+    });
+
+    it('returns daysRemaining as 0 when commitment has no expiresAt', async () => {
+      mockGetCommitment.mockResolvedValue({ ...MOCK_COMMITMENT, expiresAt: undefined });
+      const [req, ctx] = makeRequest('commitment-123');
+      const res = await GET(req, ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.daysRemaining).toBe(0);
+      expect(body.data.expiresAt).toBeNull();
+    });
+
+    it('returns daysRemaining as 0 for expired commitment', async () => {
+      const expired = { ...MOCK_COMMITMENT, expiresAt: '2020-01-01T00:00:00.000Z' };
+      mockGetCommitment.mockResolvedValue(expired);
+      const [req, ctx] = makeRequest('commitment-123');
+      const res = await GET(req, ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.daysRemaining).toBe(0);
+    });
+
+    it('returns correct fields for a SETTLED commitment', async () => {
+      mockGetCommitment.mockResolvedValue({ ...MOCK_COMMITMENT, status: 'SETTLED' });
+      const [req, ctx] = makeRequest('commitment-123');
+      const res = await GET(req, ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.status).toBe('SETTLED');
+    });
+  });
+
+  describe('404 - not found', () => {
+    it('returns 404 when commitment does not exist', async () => {
+      mockGetCommitment.mockRejectedValue(new Error('Not found'));
+      const [req, ctx] = makeRequest('nonexistent-id');
+      const res = await GET(req, ctx);
+
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 when commitment id is empty string', async () => {
+      mockGetCommitment.mockRejectedValue(new Error('Not found'));
+      const [req, ctx] = makeRequest('');
+      ctx.params.id = '';
+      const res = await GET(req, ctx);
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('429 - rate limit', () => {
+    it('returns 429 when rate limit is exceeded', async () => {
+      mockCheckRateLimit.mockResolvedValue(false);
+      const [req, ctx] = makeRequest('commitment-123');
+      const res = await GET(req, ctx);
+
+      expect(res.status).toBe(429);
+    });
+  });
+});

--- a/src/app/api/commitments/[id]/status/route.ts
+++ b/src/app/api/commitments/[id]/status/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest } from 'next/server';
+import { ok } from '@/lib/backend/apiResponse';
+import { NotFoundError, TooManyRequestsError } from '@/lib/backend/errors';
+import { withApiHandler } from '@/lib/backend/withApiHandler';
+import { checkRateLimit } from '@/lib/backend/rateLimit';
+import { getCommitmentFromChain } from '@/lib/backend/services/contracts';
+
+/**
+ * Lightweight commitment status response for efficient polling.
+ * Returns only the fields needed to track commitment health
+ * without fetching the full commitment payload.
+ */
+export interface CommitmentStatusResponse {
+  commitmentId: string;
+  status: string;
+  daysRemaining: number;
+  complianceScore: number;
+  currentValue: string;
+  violationCount: number;
+  expiresAt: string | null;
+}
+
+/**
+ * Calculate the number of days remaining until a commitment expires.
+ * Returns 0 if the commitment has already expired.
+ */
+export function getDaysRemaining(expiresAt?: string): number {
+  if (!expiresAt) return 0;
+  const expiresAtMs = new Date(expiresAt).getTime();
+  if (isNaN(expiresAtMs)) return 0;
+  const msPerDay = 24 * 60 * 60 * 1000;
+  return Math.max(0, Math.ceil((expiresAtMs - Date.now()) / msPerDay));
+}
+
+/**
+ * GET /api/commitments/[id]/status
+ *
+ * Returns a lightweight status snapshot for a commitment.
+ * Designed for efficient polling — returns only the fields needed
+ * to track commitment health without the full payload.
+ *
+ * @returns 200 with CommitmentStatusResponse
+ * @returns 404 if commitment not found
+ * @returns 429 if rate limit exceeded
+ */
+export const GET = withApiHandler(async (
+  req: NextRequest,
+  context: { params: Record<string, string> },
+) => {
+  const ip = req.ip ?? req.headers.get('x-forwarded-for') ?? 'anonymous';
+  const isAllowed = await checkRateLimit(ip, 'api/commitments/status');
+  if (!isAllowed) {
+    throw new TooManyRequestsError();
+  }
+
+  const commitmentId = context.params.id;
+
+  if (!commitmentId) {
+    throw new NotFoundError('Commitment');
+  }
+
+  let commitment;
+  try {
+    commitment = await getCommitmentFromChain(commitmentId);
+  } catch {
+    throw new NotFoundError('Commitment', { commitmentId });
+  }
+
+  if (!commitment) {
+    throw new NotFoundError('Commitment', { commitmentId });
+  }
+
+  const response: CommitmentStatusResponse = {
+    commitmentId: commitment.id,
+    status: commitment.status,
+    daysRemaining: getDaysRemaining(commitment.expiresAt),
+    complianceScore: commitment.complianceScore,
+    currentValue: commitment.currentValue,
+    violationCount: commitment.violationCount,
+    expiresAt: commitment.expiresAt ?? null,
+  };
+
+  return ok(response);
+});


### PR DESCRIPTION
Closes #268 

## What this PR does
- Added `GET /api/commitments/[id]/status` returning a lightweight status snapshot
- Response includes: `commitmentId`, `status`, `daysRemaining`, `complianceScore`, `currentValue`, `violationCount`, `expiresAt`
- Added `getDaysRemaining()` helper with edge case handling (undefined, invalid date, past dates)
- Rate limited via existing `checkRateLimit` infrastructure
- Added `docs/commitment-status-endpoint.md` with full API reference and polling recommendations

## Tests
All tests passing covering:
- 200 success with valid commitment
- 200 with no expiresAt (daysRemaining = 0)
- 200 with expired commitment (daysRemaining = 0)
- 200 for SETTLED commitment
- 404 when commitment not found
- 404 when commitment id is empty
- 429 when rate limit exceeded
- getDaysRemaining edge cases (undefined, empty, invalid, past, future dates)