### PR TITLE
feat: add commitment draft validation endpoint with warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,12 +21,13 @@
         "react-icons": "^5.5.0",
         "recharts": "^3.7.0",
         "tailwind-merge": "^3.4.0",
-        "tailwindcss": "^4.1.18"
+        "tailwindcss": "^4.1.18",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@types/node": "^20.0.0",
+        "@types/node": "^20.19.33",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@vitest/ui": "^4.0.18",
@@ -34,6 +35,7 @@
         "eslint-config-next": "^14.0.0",
         "happy-dom": "^20.7.0",
         "node-fetch": "^3.3.2",
+        "tsx": "^4.21.0",
         "typescript": "^5.0.0",
         "vitest": "^4.0.18"
       }
@@ -62,6 +64,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -77,6 +80,7 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1667,6 +1671,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1687,6 +1692,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -1760,7 +1766,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1848,11 +1855,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.19.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
-      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1868,7 +1875,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1879,7 +1885,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1948,7 +1953,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.54.0.tgz",
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2521,7 +2525,6 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -2557,7 +2560,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3404,6 +3406,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3433,7 +3436,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3722,7 +3726,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3885,7 +3888,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4649,7 +4651,6 @@
       "integrity": "sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -5683,6 +5684,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6279,6 +6281,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6294,6 +6297,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6306,7 +6310,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6371,7 +6376,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6383,7 +6387,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6410,7 +6413,6 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6472,8 +6474,7 @@
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "peer": true
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7449,6 +7450,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -7556,7 +7577,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7672,7 +7692,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7748,7 +7767,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -8099,6 +8117,15 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -8118,6 +8145,7 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -8128,7 +8156,8 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@babel/runtime": {
       "version": "7.28.6",
@@ -8998,6 +9027,7 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -9014,6 +9044,7 @@
           "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
           "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
           "dev": true,
+          "peer": true,
           "requires": {
             "dequal": "^2.0.3"
           }
@@ -9064,7 +9095,8 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@types/chai": {
       "version": "5.2.3",
@@ -9149,11 +9181,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.19.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
-      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "undici-types": "~6.21.0"
       }
@@ -9169,7 +9200,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -9180,7 +9210,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
-      "peer": true,
       "requires": {}
     },
     "@types/use-sync-external-store": {
@@ -9232,7 +9261,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.54.0.tgz",
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -9563,7 +9591,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.18.tgz",
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -9588,8 +9615,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -10160,7 +10186,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "detect-libc": {
       "version": "2.1.2",
@@ -10180,7 +10207,8 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "dunder-proto": {
       "version": "1.0.1",
@@ -10410,7 +10438,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10532,7 +10559,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11059,7 +11085,6 @@
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.7.0.tgz",
       "integrity": "sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -11678,7 +11703,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "magic-string": {
       "version": "0.30.21",
@@ -12050,6 +12076,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -12060,13 +12087,15 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "react-is": {
           "version": "17.0.2",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
           "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -12118,7 +12147,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -12127,7 +12155,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12149,7 +12176,6 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
-      "peer": true,
       "requires": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -12186,8 +12212,7 @@
     "redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "peer": true
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "redux-thunk": {
       "version": "3.1.0",
@@ -12857,6 +12882,17 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "requires": {
+        "esbuild": "~0.27.0",
+        "fsevents": "~2.3.3",
+        "get-tsconfig": "^4.7.5"
+      }
+    },
     "tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -12933,8 +12969,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.1.0",
@@ -13028,7 +13063,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13044,7 +13078,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -13247,6 +13280,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
     }
   }
 }

--- a/src/app/api/commitments/validate/route.ts
+++ b/src/app/api/commitments/validate/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from "next/server";
+import { withApiHandler } from "@/lib/backend/withApiHandler";
+import { ok } from "@/lib/backend/apiResponse";
+import { validateCommitmentDraft } from "@/lib/backend/validation";
+
+export const POST = withApiHandler(async (req: NextRequest) => {
+  const body = await req.json();
+
+  const result = validateCommitmentDraft(body);
+
+  if (!result.valid) {
+    return ok(
+      {
+        valid: false,
+        errors: result.errors,
+        warnings: [],
+      },
+      200
+    );
+  }
+
+  return ok({
+    valid: true,
+    errors: [],
+    warnings: result.warnings,
+    data: result.data,
+  });
+});

--- a/src/lib/backend/validation.ts
+++ b/src/lib/backend/validation.ts
@@ -2,6 +2,37 @@
 import { z } from "zod";
 import { StrKey } from "@stellar/stellar-sdk";
 
+// ─── Warning types ────────────────────────────────────────────────────────────
+
+export type WarningCode =
+  | "HIGH_RISK_LOSS_TOLERANCE"
+  | "UNUSUAL_DURATION"
+  | "UNUSUAL_AMOUNT"
+  | "LOW_COMPLIANCE_SCORE"
+  | "DUPLICATE_COMMITMENT";
+
+export interface ValidationWarning {
+  code: WarningCode;
+  message: string;
+  field?: string;
+}
+
+export interface ValidatedCommitmentDraft {
+  ownerAddress: string;
+  asset: string;
+  amount: number;
+  durationDays: number;
+  maxLossBps: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationWarning[];
+  warnings: ValidationWarning[];
+  data?: ValidatedCommitmentDraft;
+}
+
 export class ValidationError extends Error {
   constructor(
     message: string,
@@ -88,6 +119,164 @@ export const createAttestationSchema = z.object({
   rating: z.number().int().min(1).max(5, "Rating must be between 1 and 5"),
   comment: z.string().optional(),
 });
+
+export type CreateAttestationInput = z.infer<typeof createAttestationSchema>;
+
+// ─── Commitment draft validation schema ──────────────────────────────────────
+
+const commitmentDraftInputSchema = z.object({
+  ownerAddress: z.string().min(1, "Owner address is required"),
+  asset: z.string().min(1, "Asset is required"),
+  amount: z.unknown(),
+  durationDays: z.unknown(),
+  maxLossBps: z.unknown(),
+});
+
+export function validateCommitmentDraft(
+  input: unknown
+): ValidationResult {
+  const errors: ValidationWarning[] = [];
+
+  const parsed = commitmentDraftInputSchema.safeParse(input);
+
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      errors.push({
+        code: "VALIDATION_ERROR" as WarningCode,
+        message: issue.message,
+        field: issue.path.join("."),
+      });
+    }
+    return { valid: false, errors, warnings: [] };
+  }
+
+  const rawData = parsed.data;
+
+  const amount = typeof rawData.amount === "string" ? parseFloat(rawData.amount) : rawData.amount;
+  const durationDays = typeof rawData.durationDays === "string" ? parseInt(rawData.durationDays, 10) : rawData.durationDays;
+  const maxLossBps = typeof rawData.maxLossBps === "string" ? parseFloat(rawData.maxLossBps) : rawData.maxLossBps;
+
+  if (typeof amount !== "number" || isNaN(amount) || amount <= 0) {
+    return {
+      valid: false,
+      errors: [
+        {
+          code: "VALIDATION_ERROR" as WarningCode,
+          message: "Amount must be a positive number",
+          field: "amount",
+        },
+      ],
+      warnings: [],
+    };
+  }
+
+  if (typeof durationDays !== "number" || isNaN(durationDays) || !Number.isInteger(durationDays) || durationDays <= 0) {
+    return {
+      valid: false,
+      errors: [
+        {
+          code: "VALIDATION_ERROR" as WarningCode,
+          message: "Duration must be a positive integer",
+          field: "durationDays",
+        },
+      ],
+      warnings: [],
+    };
+  }
+
+  if (typeof maxLossBps !== "number" || isNaN(maxLossBps) || maxLossBps < 0) {
+    return {
+      valid: false,
+      errors: [
+        {
+          code: "VALIDATION_ERROR" as WarningCode,
+          message: "Max loss must be a non-negative number",
+          field: "maxLossBps",
+        },
+      ],
+      warnings: [],
+    };
+  }
+
+  if (!StrKey.isValidEd25519PublicKey(rawData.ownerAddress)) {
+    return {
+      valid: false,
+      errors: [
+        {
+          code: "VALIDATION_ERROR" as WarningCode,
+          message: "Invalid Stellar address format",
+          field: "ownerAddress",
+        },
+      ],
+      warnings: [],
+    };
+  }
+
+  const data: ValidatedCommitmentDraft = {
+    ownerAddress: rawData.ownerAddress,
+    asset: rawData.asset,
+    amount,
+    durationDays,
+    maxLossBps,
+  };
+
+  const warnings = checkWarnings(data);
+
+  return {
+    valid: true,
+    errors: [],
+    warnings,
+    data,
+  };
+}
+
+export type CommitmentDraftInput = z.infer<typeof commitmentDraftInputSchema>;
+
+// ─── Warning rules ────────────────────────────────────────────────────────────
+
+const HIGH_RISK_THRESHOLD_BPS = 5000;
+const UNUSUAL_DURATION_MIN_DAYS = 1;
+const UNUSUAL_DURATION_MAX_DAYS = 365;
+const UNUSUAL_AMOUNT_MIN = 0.001;
+const UNUSUAL_AMOUNT_MAX = 1000000;
+
+function checkWarnings(data: ValidatedCommitmentDraft): ValidationWarning[] {
+  const warnings: ValidationWarning[] = [];
+
+  if (data.maxLossBps > HIGH_RISK_THRESHOLD_BPS) {
+    warnings.push({
+      code: "HIGH_RISK_LOSS_TOLERANCE",
+      message: `Max loss tolerance of ${data.maxLossBps} bps is high (>${HIGH_RISK_THRESHOLD_BPS} bps). Consider reducing risk exposure.`,
+      field: "maxLossBps",
+    });
+  }
+
+  if (
+    data.durationDays < UNUSUAL_DURATION_MIN_DAYS ||
+    data.durationDays > UNUSUAL_DURATION_MAX_DAYS
+  ) {
+    warnings.push({
+      code: "UNUSUAL_DURATION",
+      message: `Duration of ${data.durationDays} days is unusual. Consider a duration between ${UNUSUAL_DURATION_MIN_DAYS} and ${UNUSUAL_DURATION_MAX_DAYS} days.`,
+      field: "durationDays",
+    });
+  }
+
+  if (
+    data.amount < UNUSUAL_AMOUNT_MIN ||
+    data.amount > UNUSUAL_AMOUNT_MAX
+  ) {
+    warnings.push({
+      code: "UNUSUAL_AMOUNT",
+      message: `Amount of ${data.amount} is outside typical range. Consider an amount between ${UNUSUAL_AMOUNT_MIN} and ${UNUSUAL_AMOUNT_MAX}.`,
+      field: "amount",
+    });
+  }
+
+  return warnings;
+}
+
+// ─── Address validation ───────────────────────────────────────────────────────
 
 export type CreateCommitmentInput = z.infer<typeof createCommitmentSchema>;
 export type CreateMarketplaceListingInput = z.infer<

--- a/tests/api/commitments.validate.test.ts
+++ b/tests/api/commitments.validate.test.ts
@@ -1,0 +1,507 @@
+import { describe, it, expect } from "vitest";
+import { validateCommitmentDraft } from "@/lib/backend/validation";
+import { POST } from "@/app/api/commitments/validate/route";
+import { createMockRequest, parseResponse } from "./helpers";
+
+const VALID_ADDRESS = "GB5BLJAK3JTMPFNFN57J6RGPKOHVDOS26QA5VRL22TCBS65VK4BAOXKK";
+const VALID_DRAFT = {
+  ownerAddress: VALID_ADDRESS,
+  asset: "USDC",
+  amount: 1000,
+  durationDays: 30,
+  maxLossBps: 1000,
+};
+
+describe("validateCommitmentDraft", () => {
+  describe("valid inputs", () => {
+    it("should return valid result with no warnings for normal values", () => {
+      const result = validateCommitmentDraft(VALID_DRAFT);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.warnings).toHaveLength(0);
+      expect(result.data).toEqual({
+        ownerAddress: VALID_ADDRESS,
+        asset: "USDC",
+        amount: 1000,
+        durationDays: 30,
+        maxLossBps: 1000,
+      });
+    });
+
+    it("should accept string values for numeric fields", () => {
+      const result = validateCommitmentDraft({
+        ownerAddress: VALID_ADDRESS,
+        asset: "XLM",
+        amount: "500.5",
+        durationDays: "90",
+        maxLossBps: "2500",
+      });
+      expect(result.valid).toBe(true);
+      expect(result.data?.amount).toBe(500.5);
+      expect(result.data?.durationDays).toBe(90);
+      expect(result.data?.maxLossBps).toBe(2500);
+    });
+
+    it("should accept metadata field (ignored in validation)", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        metadata: { description: "My commitment", tags: ["test"] },
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("validation errors", () => {
+    it("should return error for missing ownerAddress", () => {
+      const result = validateCommitmentDraft({
+        asset: "USDC",
+        amount: 1000,
+        durationDays: 30,
+        maxLossBps: 1000,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ field: "ownerAddress" })
+      );
+    });
+
+    it("should return error for missing asset", () => {
+      const result = validateCommitmentDraft({
+        ownerAddress: VALID_ADDRESS,
+        amount: 1000,
+        durationDays: 30,
+        maxLossBps: 1000,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ field: "asset" })
+      );
+    });
+
+    it("should return error for missing amount", () => {
+      const result = validateCommitmentDraft({
+        ownerAddress: VALID_ADDRESS,
+        asset: "USDC",
+        durationDays: 30,
+        maxLossBps: 1000,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ field: "amount" })
+      );
+    });
+
+    it("should return error for negative amount", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        amount: -100,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ field: "amount" })
+      );
+    });
+
+    it("should return error for zero amount", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        amount: 0,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ field: "amount" })
+      );
+    });
+
+    it("should return error for missing durationDays", () => {
+      const result = validateCommitmentDraft({
+        ownerAddress: VALID_ADDRESS,
+        asset: "USDC",
+        amount: 1000,
+        maxLossBps: 1000,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ field: "durationDays" })
+      );
+    });
+
+    it("should return error for zero durationDays", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        durationDays: 0,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ field: "durationDays" })
+      );
+    });
+
+    it("should return error for negative durationDays", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        durationDays: -30,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ field: "durationDays" })
+      );
+    });
+
+    it("should return error for missing maxLossBps", () => {
+      const result = validateCommitmentDraft({
+        ownerAddress: VALID_ADDRESS,
+        asset: "USDC",
+        amount: 1000,
+        durationDays: 30,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ field: "maxLossBps" })
+      );
+    });
+
+    it("should return error for invalid Stellar address", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        ownerAddress: "INVALID_ADDRESS",
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ field: "ownerAddress", message: "Invalid Stellar address format" })
+      );
+    });
+
+    it("should return error for empty string address", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        ownerAddress: "",
+      });
+      expect(result.valid).toBe(false);
+    });
+
+    it("should return error for non-numeric amount string", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        amount: "abc",
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ field: "amount" })
+      );
+    });
+  });
+
+  describe("warnings - high risk", () => {
+    it("should warn when maxLossBps exceeds 5000 (50%)", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        maxLossBps: 6000,
+      });
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          code: "HIGH_RISK_LOSS_TOLERANCE",
+          field: "maxLossBps",
+        })
+      );
+    });
+
+    it("should warn at exactly 5001 bps threshold", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        maxLossBps: 5001,
+      });
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({ code: "HIGH_RISK_LOSS_TOLERANCE" })
+      );
+    });
+
+    it("should not warn at 5000 bps exactly", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        maxLossBps: 5000,
+      });
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ code: "HIGH_RISK_LOSS_TOLERANCE" })
+      );
+    });
+
+    it("should not warn for low maxLossBps", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        maxLossBps: 100,
+      });
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ code: "HIGH_RISK_LOSS_TOLERANCE" })
+      );
+    });
+  });
+
+  describe("warnings - unusual duration", () => {
+    it("should warn for duration less than 1 day", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        durationDays: 0,
+      });
+      expect(result.valid).toBe(false);
+    });
+
+    it("should warn for duration exceeding 365 days", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        durationDays: 400,
+      });
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          code: "UNUSUAL_DURATION",
+          field: "durationDays",
+        })
+      );
+    });
+
+    it("should not warn for duration at 365 days", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        durationDays: 365,
+      });
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ code: "UNUSUAL_DURATION" })
+      );
+    });
+
+    it("should not warn for normal duration", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        durationDays: 90,
+      });
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ code: "UNUSUAL_DURATION" })
+      );
+    });
+  });
+
+  describe("warnings - unusual amount", () => {
+    it("should warn for amount below 0.001", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        amount: 0.0001,
+      });
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          code: "UNUSUAL_AMOUNT",
+          field: "amount",
+        })
+      );
+    });
+
+    it("should warn for amount above 1000000", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        amount: 2000000,
+      });
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          code: "UNUSUAL_AMOUNT",
+          field: "amount",
+        })
+      );
+    });
+
+    it("should not warn for amount at min boundary (0.001)", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        amount: 0.001,
+      });
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ code: "UNUSUAL_AMOUNT" })
+      );
+    });
+
+    it("should not warn for amount at max boundary (1000000)", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        amount: 1000000,
+      });
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ code: "UNUSUAL_AMOUNT" })
+      );
+    });
+
+    it("should not warn for normal amount", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        amount: 10000,
+      });
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ code: "UNUSUAL_AMOUNT" })
+      );
+    });
+  });
+
+  describe("multiple warnings", () => {
+    it("should return multiple warnings when multiple conditions met", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        maxLossBps: 6000,
+        durationDays: 400,
+        amount: 2000000,
+      });
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(3);
+      expect(result.warnings.map((w) => w.code)).toEqual([
+        "HIGH_RISK_LOSS_TOLERANCE",
+        "UNUSUAL_DURATION",
+        "UNUSUAL_AMOUNT",
+      ]);
+    });
+
+    it("should return no warnings when all values are normal", () => {
+      const result = validateCommitmentDraft({
+        ownerAddress: VALID_ADDRESS,
+        asset: "USDC",
+        amount: 1000,
+        durationDays: 30,
+        maxLossBps: 1000,
+      });
+      expect(result.warnings).toHaveLength(0);
+    });
+  });
+
+  describe("type coercion", () => {
+    it("should coerce string amount to number", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        amount: "999.99",
+      });
+      expect(result.data?.amount).toBe(999.99);
+    });
+
+    it("should coerce string duration to integer", () => {
+      const result = validateCommitmentDraft({
+        ...VALID_DRAFT,
+        durationDays: "45",
+      });
+      expect(result.data?.durationDays).toBe(45);
+    });
+  });
+
+  describe("null/undefined handling", () => {
+    it("should return error for null input", () => {
+      const result = validateCommitmentDraft(null);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should return error for undefined input", () => {
+      const result = validateCommitmentDraft(undefined);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should return error for empty object", () => {
+      const result = validateCommitmentDraft({});
+      expect(result.valid).toBe(false);
+    });
+  });
+});
+
+describe("POST /api/commitments/validate", () => {
+  const validRequest = {
+    ownerAddress: VALID_ADDRESS,
+    asset: "USDC",
+    amount: 1000,
+    durationDays: 30,
+    maxLossBps: 1000,
+  };
+
+  it("should return valid response for valid draft", async () => {
+    const request = createMockRequest(
+      "http://localhost:3000/api/commitments/validate",
+      {
+        method: "POST",
+        body: validRequest,
+      }
+    );
+    const response = await POST(request);
+    const result = await parseResponse(response);
+
+    expect(result.status).toBe(200);
+    expect(result.data.success).toBe(true);
+    expect(result.data.data.valid).toBe(true);
+    expect(result.data.data.errors).toHaveLength(0);
+    expect(result.data.data.data).toBeDefined();
+  });
+
+  it("should return warnings in response for high risk draft", async () => {
+    const request = createMockRequest(
+      "http://localhost:3000/api/commitments/validate",
+      {
+        method: "POST",
+        body: { ...validRequest, maxLossBps: 6000 },
+      }
+    );
+    const response = await POST(request);
+    const result = await parseResponse(response);
+
+    expect(result.data.data.valid).toBe(true);
+    expect(result.data.data.warnings.length).toBeGreaterThan(0);
+    expect(result.data.data.warnings[0]).toHaveProperty("code");
+    expect(result.data.data.warnings[0]).toHaveProperty("message");
+  });
+
+  it("should return errors for invalid draft", async () => {
+    const request = createMockRequest(
+      "http://localhost:3000/api/commitments/validate",
+      {
+        method: "POST",
+        body: { asset: "USDC" },
+      }
+    );
+    const response = await POST(request);
+    const result = await parseResponse(response);
+
+    expect(result.status).toBe(200);
+    expect(result.data.success).toBe(true);
+    expect(result.data.data.valid).toBe(false);
+    expect(result.data.data.errors.length).toBeGreaterThan(0);
+    expect(result.data.data.data).toBeUndefined();
+  });
+
+  it("should handle string numeric values", async () => {
+    const request = createMockRequest(
+      "http://localhost:3000/api/commitments/validate",
+      {
+        method: "POST",
+        body: {
+          ownerAddress: VALID_ADDRESS,
+          asset: "XLM",
+          amount: "500.5",
+          durationDays: "90",
+          maxLossBps: "2500",
+        },
+      }
+    );
+    const response = await POST(request);
+    const result = await parseResponse(response);
+
+    expect(result.data.data.valid).toBe(true);
+    expect(result.data.data.data?.amount).toBe(500.5);
+  });
+
+  it("should handle empty body gracefully", async () => {
+    const request = createMockRequest(
+      "http://localhost:3000/api/commitments/validate",
+      {
+        method: "POST",
+        body: {},
+      }
+    );
+    const response = await POST(request);
+    const result = await parseResponse(response);
+
+    expect(result.data.data.valid).toBe(false);
+    expect(result.data.data.errors.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
- Add POST /api/commitments/validate endpoint for preflight validation
- Implement Zod schema with warning rules (high risk, unusual bounds)
- Return standardized validation response with normalized data
- Add comprehensive tests (40 test cases) for invalid drafts and warning cases
- No state changes - purely validation focused

closes: #267 