### PR TITLE
docs: define KPI card component spec and dashboard metric hierarchy rules

### DIFF
--- a/src/components/KPICard/KPICard.module.css
+++ b/src/components/KPICard/KPICard.module.css
@@ -1,0 +1,398 @@
+/* ============================================================================
+   KPI Card Component Styles
+   ============================================================================ */
+
+/* ---------------------------------------------------------------------------
+   Base Card Structure
+   --------------------------------------------------------------------------- */
+.card {
+  background: #0a0a0a;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.card:hover {
+  border-color: var(--accent-color, rgba(255, 255, 255, 0.2));
+  box-shadow: 0 0 20px var(--glow-color, rgba(255, 255, 255, 0.05));
+  transform: translateY(-2px);
+}
+
+.card.clickable {
+  cursor: pointer;
+}
+
+.card.clickable:focus {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------------
+   Size Variants
+   --------------------------------------------------------------------------- */
+.small {
+  padding: 1rem;
+  gap: 0.5rem;
+}
+
+.medium {
+  padding: 1.5rem;
+  gap: 0.75rem;
+}
+
+.large {
+  padding: 2rem;
+  gap: 1rem;
+}
+
+/* ---------------------------------------------------------------------------
+   Accent Color Variants
+   --------------------------------------------------------------------------- */
+.teal {
+  --accent-color: #0ff0fc;
+  --glow-color: rgba(15, 240, 252, 0.2);
+}
+
+.green {
+  --accent-color: #00ff7a;
+  --glow-color: rgba(0, 255, 122, 0.2);
+}
+
+.blue {
+  --accent-color: #3b82f6;
+  --glow-color: rgba(59, 130, 246, 0.2);
+}
+
+.purple {
+  --accent-color: #a855f7;
+  --glow-color: rgba(168, 85, 247, 0.2);
+}
+
+.orange {
+  --accent-color: #f97316;
+  --glow-color: rgba(249, 115, 22, 0.2);
+}
+
+.neutral {
+  --accent-color: #94a3b8;
+  --glow-color: rgba(148, 163, 184, 0.2);
+}
+
+/* ---------------------------------------------------------------------------
+   Header Section (Icon + Label)
+   --------------------------------------------------------------------------- */
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.iconWrapper {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.1) 0%, rgba(0, 0, 0, 0) 100%);
+  border: 0.56px solid rgba(255, 255, 255, 0.1);
+  color: var(--accent-color);
+  flex-shrink: 0;
+}
+
+.small .iconWrapper {
+  width: 28px;
+  height: 28px;
+}
+
+.large .iconWrapper {
+  width: 44px;
+  height: 44px;
+}
+
+.label {
+  font-size: 0.875rem;
+  color: #99a1af;
+  font-weight: 500;
+  flex: 1;
+}
+
+.small .label {
+  font-size: 0.75rem;
+}
+
+.large .label {
+  font-size: 1rem;
+}
+
+.tooltip {
+  color: #64748b;
+  font-size: 0.75rem;
+  cursor: help;
+  margin-left: auto;
+}
+
+/* ---------------------------------------------------------------------------
+   Value Display Section
+   --------------------------------------------------------------------------- */
+.valueContainer {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--accent-color);
+  line-height: 1.2;
+}
+
+.small .value {
+  font-size: 1.5rem;
+}
+
+.large .value {
+  font-size: 2.5rem;
+}
+
+/* ---------------------------------------------------------------------------
+   Delta/Change Indicator
+   --------------------------------------------------------------------------- */
+.delta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.deltaSmall {
+  font-size: 0.625rem;
+  padding: 0.125rem 0.375rem;
+  gap: 0.125rem;
+}
+
+.deltaMedium {
+  font-size: 0.75rem;
+}
+
+.deltaLarge {
+  font-size: 0.875rem;
+  padding: 0.375rem 0.75rem;
+}
+
+.deltaPositive {
+  background: rgba(0, 255, 122, 0.15);
+  color: #00ff7a;
+}
+
+.deltaNegative {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+}
+
+.deltaNeutral {
+  background: rgba(148, 163, 184, 0.15);
+  color: #94a3b8;
+}
+
+.deltaPeriod {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: 400;
+  margin-left: 0.25rem;
+}
+
+/* ---------------------------------------------------------------------------
+   Description
+   --------------------------------------------------------------------------- */
+.description {
+  font-size: 0.75rem;
+  color: #64748b;
+  margin: 0;
+  line-height: 1.4;
+}
+
+/* ---------------------------------------------------------------------------
+   Loading State
+   --------------------------------------------------------------------------- */
+.loadingState {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.loadingSmall {
+  gap: 0.5rem;
+}
+
+.loadingMedium {
+  gap: 0.75rem;
+}
+
+.loadingLarge {
+  gap: 1rem;
+}
+
+.spinner {
+  color: var(--accent-color);
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loadingMessage {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  width: 100%;
+}
+
+.skeletonBar {
+  height: 0.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 0.2;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   Error State
+   --------------------------------------------------------------------------- */
+.errorState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-align: center;
+  padding: 0.5rem 0;
+}
+
+.errorSmall {
+  gap: 0.375rem;
+}
+
+.errorMedium {
+  gap: 0.5rem;
+}
+
+.errorLarge {
+  gap: 0.75rem;
+}
+
+.errorIcon {
+  color: #ef4444;
+}
+
+.errorMessage {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.retryButton {
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #ef4444;
+  padding: 0.375rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.retryButton:hover {
+  background: rgba(239, 68, 68, 0.25);
+  border-color: rgba(239, 68, 68, 0.5);
+}
+
+/* ---------------------------------------------------------------------------
+   Empty State
+   --------------------------------------------------------------------------- */
+.emptyState {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem 0;
+}
+
+.emptySmall {
+  padding: 0.5rem 0;
+}
+
+.emptyMedium {
+  padding: 1rem 0;
+}
+
+.emptyLarge {
+  padding: 1.5rem 0;
+}
+
+.emptyMessage {
+  font-size: 0.875rem;
+  color: #64748b;
+  font-style: italic;
+}
+
+/* ---------------------------------------------------------------------------
+   Responsive Breakpoints
+   --------------------------------------------------------------------------- */
+@media (max-width: 1024px) {
+  .card {
+    padding: 1.25rem;
+  }
+  
+  .value {
+    font-size: 1.75rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .card {
+    padding: 1rem;
+  }
+  
+  .value {
+    font-size: 1.5rem;
+  }
+  
+  .label {
+    font-size: 0.75rem;
+  }
+  
+  .valueContainer {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}

--- a/src/components/KPICard/KPICard.spec.md
+++ b/src/components/KPICard/KPICard.spec.md
@@ -1,0 +1,462 @@
+# KPI Card Component Specification
+
+## Overview
+
+The KPI Card is a reusable component for displaying dashboard metrics with built-in support for loading states, error handling, delta/change indicators, and multiple formatting options.
+
+---
+
+## Table of Contents
+
+1. [Component Variants](#component-variants)
+2. [Size Options](#size-options)
+3. [State Management](#state-management)
+4. [Formatting & Units](#formatting--units)
+5. [Delta/Change Indicators](#deltachange-indicators)
+6. [Hierarchy Rules](#hierarchy-rules)
+7. [Layout Guidelines](#layout-guidelines)
+8. [Accessibility](#accessibility)
+9. [Usage Examples](#usage-examples)
+
+---
+
+## Component Variants
+
+The KPI Card supports 6 color variants for different metric categories:
+
+| Variant | Color | Use Case |
+|---------|-------|----------|
+| `teal` | `#0ff0fc` | Growth, performance, primary metrics |
+| `green` | `#00ff7a` | Positive metrics, revenue, success |
+| `blue` | `#3b82f6` | Informational, neutral-positive |
+| `purple` | `#a855f7` | Analytics, scores, compliance |
+| `orange` | `#f97316` | Warnings, attention needed |
+| `neutral` | `#94a3b8` | Secondary metrics, counts |
+
+### Visual Style
+
+- **Background**: `#0a0a0a` (dark)
+- **Border**: `1px solid rgba(255, 255, 255, 0.1)`
+- **Border Radius**: `16px`
+- **Hover Effect**: Border brightens + subtle glow + translateY(-2px)
+
+---
+
+## Size Options
+
+| Size | Padding | Value Font | Icon Size | Use Case |
+|------|---------|------------|-----------|----------|
+| `small` | 1rem | 1.5rem | 14px | Dense grids, mobile |
+| `medium` | 1.5rem | 2rem | 18px | Standard dashboard |
+| `large` | 2rem | 2.5rem | 22px | Hero metrics, focus areas |
+
+---
+
+## State Management
+
+### 1. Default State
+
+Standard metric display with value, label, and optional delta.
+
+```tsx
+<KPICard
+  label="Total Revenue"
+  value={125000}
+  format="currency"
+  variant="green"
+/>
+```
+
+### 2. Loading State
+
+Displays a spinner with skeleton placeholder animation.
+
+```tsx
+<KPICard
+  label="Total Revenue"
+  state="loading"
+  loadingMessage="Calculating revenue..."
+  variant="green"
+/>
+```
+
+**Loading UI Elements:**
+- Rotating loader icon (matches accent color)
+- Optional loading message
+- Animated skeleton bars (pulse animation)
+
+### 3. Error State
+
+Displays error icon with optional retry button.
+
+```tsx
+<KPICard
+  label="Total Revenue"
+  state="error"
+  errorMessage="Unable to load revenue data"
+  onRetry={() => refetch()}
+  variant="green"
+/>
+```
+
+**Error UI Elements:**
+- AlertCircle icon (red)
+- Error message text
+- Retry button (optional)
+
+### 4. Empty State
+
+Displays when no data is available but no error occurred.
+
+```tsx
+<KPICard
+  label="Total Revenue"
+  state="empty"
+  variant="green"
+/>
+```
+
+**Empty UI Elements:**
+- Italicized "No data available" message
+
+---
+
+## Formatting & Units
+
+### Supported Format Types
+
+| Format | Description | Example |
+|--------|-------------|---------|
+| `value` | Default number | `1,234` |
+| `currency` | USD currency | `$1,234.56` |
+| `percentage` | Percentage | `85.2%` |
+| `count` | Compact (K/M/B) | `1.2M` |
+| `score` | Decimal score | `95.0` |
+
+### Formatting Utilities
+
+```tsx
+import { formatNumber, formatCurrency, formatPercentage, formatCompact } from '@/components/KPICard';
+
+// Numbers
+formatNumber(1234.56, 2) → "1,234.56"
+
+// Currency
+formatCurrency(1234.56, 'USD', 2) → "$1,234.56"
+
+// Percentage
+formatPercentage(85.2, 1, true) → "+85.2%"
+
+// Compact
+formatCompact(1234567) → "1.2M"
+```
+
+### Custom Units
+
+Override the default currency or add custom units:
+
+```tsx
+<KPICard
+  label="Gas Used"
+  value={45000}
+  format="count"
+  unit="Gwei"
+  variant="blue"
+/>
+```
+
+### Decimal Precision
+
+Control decimal places per format type:
+
+```tsx
+// Currency with 0 decimals
+<KPICard value={1250} format="currency" decimals={0} />
+
+// Percentage with 2 decimal places
+<KPICard value={85.234} format="percentage" decimals={2} />
+```
+
+---
+
+## Delta/Change Indicators
+
+### Delta Structure
+
+```tsx
+interface KPIDelta {
+  value: number;        // The delta value (e.g., 12.5)
+  direction: 'up' | 'down' | 'neutral';
+  period?: string;      // e.g., "vs last 30 days"
+  isPercentage?: boolean;
+}
+```
+
+### Delta Display
+
+| Direction | Icon | Color | Background |
+|-----------|------|-------|------------|
+| `up` | TrendingUp | `#00ff7a` | `rgba(0, 255, 122, 0.15)` |
+| `down` | TrendingDown | `#ef4444` | `rgba(239, 68, 68, 0.15)` |
+| `neutral` | Minus | `#94a3b8` | `rgba(148, 163, 184, 0.15)` |
+
+### Auto-Calculate Delta
+
+Provide `previousValue` and the component auto-calculates the delta:
+
+```tsx
+<KPICard
+  label="Monthly Revenue"
+  value={125000}
+  previousValue={110000}
+  variant="green"
+/>
+// Displays: $125,000 with +13.6% delta badge
+```
+
+### Manual Delta
+
+Explicitly pass a delta object:
+
+```tsx
+<KPICard
+  label="Active Users"
+  value={5420}
+  delta={{
+    value: 8.2,
+    direction: 'up',
+    period: 'vs last week'
+  }}
+  variant="teal"
+/>
+```
+
+---
+
+## Hierarchy Rules
+
+### Dashboard Metric Hierarchy
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    DASHBOARD LAYOUT                      │
+├─────────────────────────────────────────────────────────┤
+│                                                          │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐    │
+│  │   HERO      │  │   HERO      │  │   HERO      │    │
+│  │   (large)   │  │   (large)   │  │   (large)   │    │
+│  │             │  │             │  │             │    │
+│  │  $1.2M      │  │  85%       │  │  1,234      │    │
+│  │  Total Rev  │  │  Compliance │  │  Active     │    │
+│  └─────────────┘  └─────────────┘  └─────────────┘    │
+│                                                          │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐    │
+│  │  PRIMARY    │  │  PRIMARY    │  │  PRIMARY    │    │
+│  │  (medium)  │  │  (medium)  │  │  (medium)  │    │
+│  │             │  │             │  │             │    │
+│  └─────────────┘  └─────────────┘  └─────────────┘    │
+│                                                          │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐    │
+│  │  SECONDARY │  │  SECONDARY │  │  SECONDARY │    │
+│  │  (small)   │  │  (small)   │  │  (small)   │    │
+│  └─────────────┘  └─────────────┘  └─────────────┘    │
+│                                                          │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Hierarchy Guidelines
+
+1. **Hero Metrics** (large)
+   - Primary KPIs that are the main focus
+   - Maximum 3 per dashboard row
+   - Use for: Total Revenue, Active Users, Compliance Score
+
+2. **Primary Metrics** (medium)
+   - Secondary important metrics
+   - 3-4 per row
+   - Use for: New Signups, Fees Generated, Drawdown
+
+3. **Secondary Metrics** (small)
+   - Supporting data points
+   - 4-6 per row
+   - Use for: Counts, minor indicators
+
+### Color Assignment by Metric Type
+
+| Metric Category | Recommended Variant |
+|-----------------|---------------------|
+| Revenue/Value | `green` |
+| Growth/Change | `teal` |
+| Compliance/Score | `purple` |
+| Users/Count | `blue` |
+| Warnings | `orange` |
+| Neutral/Other | `neutral` |
+
+---
+
+## Layout Guidelines
+
+### Grid Configuration
+
+```css
+/* 4-column grid for primary/hero metrics */
+.kpiGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.5rem;
+}
+
+/* 2-column for medium screens */
+@media (max-width: 1024px) {
+  .kpiGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* Single column for mobile */
+@media (max-width: 640px) {
+  .kpiGrid {
+    grid-template-columns: 1fr;
+  }
+}
+```
+
+### Spacing Rules
+
+- **Gap between cards**: `1.5rem` (desktop), `1rem` (mobile)
+- **Card padding**: Varies by size (see Size Options)
+- **Section margin**: `2rem` between metric groups
+
+### Alignment
+
+- Values: Left-aligned within card
+- Deltas: Right-aligned next to value
+- Labels: Top of card, above value
+
+---
+
+## Accessibility
+
+### ARIA Attributes
+
+- `aria-label`: Auto-generated as `${label}: ${formattedValue}`
+- Can be overridden via `ariaLabel` prop
+
+### Keyboard Navigation
+
+- Cards with `onClick` are focusable
+- Enter key triggers click handler
+- Tab order follows document flow
+
+### Screen Reader Considerations
+
+- Delta values announced with direction
+- Loading state includes message
+- Error state includes retry action
+
+---
+
+## Usage Examples
+
+### Example 1: Revenue Dashboard
+
+```tsx
+import { KPICard } from '@/components/KPICard';
+
+function RevenueDashboard() {
+  return (
+    <div className="kpiGrid">
+      <KPICard
+        label="Total Revenue"
+        value={1250000}
+        format="currency"
+        variant="green"
+        size="large"
+        delta={{ value: 12.5, direction: 'up', period: 'vs last month' }}
+      />
+      <KPICard
+        label="Active Commitments"
+        value={342}
+        format="count"
+        variant="teal"
+        size="large"
+      />
+      <KPICard
+        label="Compliance Score"
+        value={94.2}
+        format="percentage"
+        variant="purple"
+        size="large"
+        delta={{ value: 2.1, direction: 'up' }}
+      />
+    </div>
+  );
+}
+```
+
+### Example 2: Loading State
+
+```tsx
+<KPICard
+  label="Pending Transactions"
+  state="loading"
+  loadingMessage="Fetching transactions..."
+  variant="orange"
+/>
+```
+
+### Example 3: Error with Retry
+
+```tsx
+<KPICard
+  label="Network Volume"
+  state="error"
+  errorMessage="Failed to load network data"
+  onRetry={refetchNetworkVolume}
+  variant="blue"
+/>
+```
+
+### Example 4: Auto Delta Calculation
+
+```tsx
+<KPICard
+  label="Monthly Active Users"
+  value={5420}
+  previousValue={4890}
+  format="count"
+  variant="teal"
+/>
+// Automatically shows +10.8% delta
+```
+
+---
+
+## Props Reference
+
+| Prop | Type | Default | Required |
+|------|------|---------|----------|
+| `label` | `string` | - | Yes |
+| `value` | `string \| number` | - | No |
+| `previousValue` | `string \| number` | - | No |
+| `variant` | `'teal' \| 'green' \| 'blue' \| 'purple' \| 'orange' \| 'neutral'` | `'teal'` | No |
+| `size` | `'small' \| 'medium' \| 'large'` | `'medium'` | No |
+| `icon` | `LucideIcon` | - | No |
+| `delta` | `KPIDelta` | - | No |
+| `state` | `'default' \| 'loading' \| 'error' \| 'empty'` | `'default'` | No |
+| `loadingMessage` | `string` | `'Loading metrics...'` | No |
+| `errorMessage` | `string` | `'Failed to load'` | No |
+| `format` | `'value' \| 'percentage' \| 'currency' \| 'count' \| 'score'` | `'value'` | No |
+| `unit` | `string` | - | No |
+| `decimals` | `number` | `0` | No |
+| `description` | `string` | - | No |
+| `tooltip` | `string` | - | No |
+| `onRetry` | `() => void` | - | No |
+| `onClick` | `() => void` | - | No |
+| `ariaLabel` | `string` | - | No |
+
+---
+
+## Changelog
+
+- **v1.0.0** (Initial release): KPI Card component with loading/error states, delta indicators, and formatting utilities

--- a/src/components/KPICard/KPICard.test.tsx
+++ b/src/components/KPICard/KPICard.test.tsx
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { KPICard, formatNumber, formatCurrency, formatPercentage, formatCompact, calculateDelta } from './KPICard';
+import React from 'react';
+
+// Mock lucide-react icons
+vi.mock('lucide-react', async () => {
+  const actual = await vi.importActual('lucide-react');
+  return {
+    ...actual,
+  };
+});
+
+describe('KPICard Component', () => {
+  describe('Default State', () => {
+    it('renders label and value correctly', () => {
+      render(
+        <KPICard label="Total Revenue" value={125000} variant="green" />
+      );
+      
+      expect(screen.getByText('Total Revenue')).toBeInTheDocument();
+      expect(screen.getByText('125,000')).toBeInTheDocument();
+    });
+
+    it('applies correct variant styles', () => {
+      const { container } = render(
+        <KPICard label="Test" value={100} variant="teal" />
+      );
+      
+      const card = container.firstChild;
+      expect(card).toHaveClass('teal');
+    });
+
+    it('renders with different sizes', () => {
+      const { container: small } = render(
+        <KPICard label="Small" value={10} size="small" />
+      );
+      expect(small.firstChild).toHaveClass('small');
+
+      const { container: medium } = render(
+        <KPICard label="Medium" value={10} size="medium" />
+      );
+      expect(medium.firstChild).toHaveClass('medium');
+
+      const { container: large } = render(
+        <KPICard label="Large" value={10} size="large" />
+      );
+      expect(large.firstChild).toHaveClass('large');
+    });
+
+    it('displays icon when provided', () => {
+      const { container } = render(
+        <KPICard 
+          label="With Icon" 
+          value={100} 
+          icon={React.createElement('span', { 'data-testid': 'icon' }, '★')}
+        />
+      );
+      
+      expect(container.querySelector('.iconWrapper')).toBeInTheDocument();
+    });
+  });
+
+  describe('Loading State', () => {
+    it('renders loading state with default message', () => {
+      render(<KPICard label="Loading" state="loading" />);
+      
+      expect(screen.getByText('Loading metrics...')).toBeInTheDocument();
+    });
+
+    it('renders loading state with custom message', () => {
+      render(
+        <KPICard 
+          label="Loading" 
+          state="loading" 
+          loadingMessage="Fetching data..."
+        />
+      );
+      
+      expect(screen.getByText('Fetching data...')).toBeInTheDocument();
+    });
+
+    it('shows spinner in loading state', () => {
+      const { container } = render(
+        <KPICard label="Loading" state="loading" />
+      );
+      
+      expect(container.querySelector('.spinner')).toBeInTheDocument();
+    });
+  });
+
+  describe('Error State', () => {
+    it('renders error state with default message', () => {
+      render(<KPICard label="Error" state="error" />);
+      
+      expect(screen.getByText('Failed to load')).toBeInTheDocument();
+    });
+
+    it('renders error state with custom message', () => {
+      render(
+        <KPICard 
+          label="Error" 
+          state="error" 
+          errorMessage="Something went wrong"
+        />
+      );
+      
+      expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    });
+
+    it('shows retry button when onRetry is provided', () => {
+      const handleRetry = vi.fn();
+      render(
+        <KPICard 
+          label="Error" 
+          state="error" 
+          onRetry={handleRetry}
+        />
+      );
+      
+      const retryButton = screen.getByText('Retry');
+      expect(retryButton).toBeInTheDocument();
+      
+      fireEvent.click(retryButton);
+      expect(handleRetry).toHaveBeenCalled();
+    });
+  });
+
+  describe('Empty State', () => {
+    it('renders empty state message', () => {
+      render(<KPICard label="Empty" state="empty" />);
+      
+      expect(screen.getByText('No data available')).toBeInTheDocument();
+    });
+  });
+
+  describe('Delta/Change Indicators', () => {
+    it('renders positive delta correctly', () => {
+      render(
+        <KPICard 
+          label="Growth" 
+          value={100} 
+          delta={{ value: 12.5, direction: 'up', period: 'vs last month' }}
+        />
+      );
+      
+      expect(screen.getByText('12.5%')).toBeInTheDocument();
+    });
+
+    it('renders negative delta correctly', () => {
+      render(
+        <KPICard 
+          label="Decline" 
+          value={80} 
+          delta={{ value: 5.2, direction: 'down' }}
+        />
+      );
+      
+      expect(screen.getByText('5.2%')).toBeInTheDocument();
+    });
+
+    it('renders neutral delta correctly', () => {
+      render(
+        <KPICard 
+          label="Stable" 
+          value={100} 
+          delta={{ value: 0, direction: 'neutral' }}
+        />
+      );
+      
+      expect(screen.getByText('0.0%')).toBeInTheDocument();
+    });
+
+    it('auto-calculates delta from previousValue', () => {
+      render(
+        <KPICard 
+          label="Auto Delta" 
+          value={110} 
+          previousValue={100}
+        />
+      );
+      
+      // 10% increase
+      expect(screen.getByText('10.0%')).toBeInTheDocument();
+    });
+  });
+
+  describe('Formatting Utilities', () => {
+    describe('formatNumber', () => {
+      it('formats whole numbers with separators', () => {
+        expect(formatNumber(1234567)).toBe('1,234,567');
+      });
+
+      it('formats with specified decimals', () => {
+        expect(formatNumber(1234.567, 2)).toBe('1,234.57');
+      });
+
+      it('handles string input', () => {
+        expect(formatNumber('1234')).toBe('1,234');
+      });
+
+      it('returns -- for invalid input', () => {
+        expect(formatNumber('invalid')).toBe('--');
+        expect(formatNumber(NaN)).toBe('--');
+      });
+    });
+
+    describe('formatCurrency', () => {
+      it('formats USD currency', () => {
+        expect(formatCurrency(1234.56)).toBe('$1,234.56');
+      });
+
+      it('formats with zero decimals', () => {
+        expect(formatCurrency(1234, 'USD', 0)).toBe('$1,234');
+      });
+
+      it('handles invalid input', () => {
+        expect(formatCurrency('invalid')).toBe('--');
+      });
+    });
+
+    describe('formatPercentage', () => {
+      it('formats percentage with default decimals', () => {
+        expect(formatPercentage(85.234)).toBe('85.2%');
+      });
+
+      it('shows positive sign when requested', () => {
+        expect(formatPercentage(85.2, 1, true)).toBe('+85.2%');
+      });
+
+      it('handles negative values', () => {
+        expect(formatPercentage(-15.5, 1, true)).toBe('-15.5%');
+      });
+    });
+
+    describe('formatCompact', () => {
+      it('formats billions', () => {
+        expect(formatCompact(1500000000)).toBe('1.5B');
+      });
+
+      it('formats millions', () => {
+        expect(formatCompact(2500000)).toBe('2.5M');
+      });
+
+      it('formats thousands', () => {
+        expect(formatCompact(5500)).toBe('5.5K');
+      });
+
+      it('returns small numbers as-is', () => {
+        expect(formatCompact(500)).toBe('500');
+      });
+    });
+
+    describe('calculateDelta', () => {
+      it('calculates positive percentage change', () => {
+        const delta = calculateDelta(120, 100);
+        expect(delta.value).toBe(20);
+        expect(delta.direction).toBe('up');
+      });
+
+      it('calculates negative percentage change', () => {
+        const delta = calculateDelta(80, 100);
+        expect(delta.value).toBe(20);
+        expect(delta.direction).toBe('down');
+      });
+
+      it('returns neutral for equal values', () => {
+        const delta = calculateDelta(100, 100);
+        expect(delta.direction).toBe('neutral');
+      });
+
+      it('handles zero previous value', () => {
+        const delta = calculateDelta(100, 0);
+        expect(delta.direction).toBe('neutral');
+      });
+    });
+  });
+
+  describe('Click Handling', () => {
+    it('calls onClick when card is clicked', () => {
+      const handleClick = vi.fn();
+      render(
+        <KPICard label="Clickable" value={100} onClick={handleClick} />
+      );
+      
+      fireEvent.click(screen.getByText('Clickable'));
+      expect(handleClick).toHaveBeenCalled();
+    });
+
+    it('is keyboard accessible', () => {
+      const handleClick = vi.fn();
+      render(
+        <KPICard label="Keyboard" value={100} onClick={handleClick} />
+      );
+      
+      const card = screen.getByText('Keyboard').closest('div');
+      fireEvent.keyDown(card!, { key: 'Enter' });
+      expect(handleClick).toHaveBeenCalled();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('generates aria-label from label and value', () => {
+      render(<KPICard label="Test Metric" value={100} />);
+      
+      const card = screen.getByText('Test Metric').closest('div');
+      expect(card).toHaveAttribute('aria-label', 'Test Metric: 100');
+    });
+
+    it('allows custom aria-label', () => {
+      render(
+        <KPICard 
+          label="Test" 
+          value={100} 
+          ariaLabel="Custom aria label"
+        />
+      );
+      
+      const card = screen.getByText('Test').closest('div');
+      expect(card).toHaveAttribute('aria-label', 'Custom aria label');
+    });
+  });
+});

--- a/src/components/KPICard/KPICard.tsx
+++ b/src/components/KPICard/KPICard.tsx
@@ -1,0 +1,411 @@
+'use client';
+
+import React from 'react';
+import { clsx } from 'clsx';
+import { 
+    TrendingUp, 
+    TrendingDown, 
+    Minus, 
+    AlertCircle, 
+    Loader2,
+    LucideIcon 
+} from 'lucide-react';
+import styles from './KPICard.module.css';
+
+// ============================================================================
+// TYPES & INTERFACES
+// ============================================================================
+
+export type KPICardVariant = 'teal' | 'green' | 'blue' | 'purple' | 'orange' | 'neutral';
+export type KPICardSize = 'small' | 'medium' | 'large';
+export type DeltaDirection = 'up' | 'down' | 'neutral';
+export type MetricCategory = 'value' | 'percentage' | 'currency' | 'count' | 'score';
+export type CardState = 'default' | 'loading' | 'error' | 'empty';
+
+export interface KPIDelta {
+    value: number;
+    direction: DeltaDirection;
+    period?: string; // e.g., "vs last 30 days"
+    isPercentage?: boolean;
+}
+
+export interface KPICardProps {
+    // Core data
+    label: string;
+    value?: string | number;
+    previousValue?: string | number;
+    
+    // Visual configuration
+    variant?: KPICardVariant;
+    size?: KPICardSize;
+    icon?: LucideIcon;
+    
+    // Delta/change tracking
+    delta?: KPIDelta;
+    
+    // State management
+    state?: CardState;
+    loadingMessage?: string;
+    errorMessage?: string;
+    
+    // Formatting
+    format?: MetricCategory;
+    unit?: string;
+    decimals?: number;
+    
+    // Optional metadata
+    description?: string;
+    tooltip?: string;
+    
+    // Callbacks
+    onRetry?: () => void;
+    onClick?: () => void;
+    
+    // Accessibility
+    ariaLabel?: string;
+}
+
+// ============================================================================
+// FORMAT UTILITIES
+// ============================================================================
+
+/**
+ * Format a number with specified decimals and separators
+ */
+export function formatNumber(value: string | number, decimals: number = 0): string {
+    const num = typeof value === 'string' ? parseFloat(value) : value;
+    if (isNaN(num)) return '--';
+    
+    return num.toLocaleString('en-US', {
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+    });
+}
+
+/**
+ * Format as currency (USD by default)
+ */
+export function formatCurrency(
+    value: string | number, 
+    currency: string = 'USD',
+    decimals: number = 2
+): string {
+    const num = typeof value === 'string' ? parseFloat(value) : value;
+    if (isNaN(num)) return '--';
+    
+    return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+    }).format(num);
+}
+
+/**
+ * Format as percentage
+ */
+export function formatPercentage(
+    value: string | number, 
+    decimals: number = 1,
+    showSign: boolean = false
+): string {
+    const num = typeof value === 'string' ? parseFloat(value) : value;
+    if (isNaN(num)) return '--';
+    
+    const formatted = Math.abs(num).toFixed(decimals);
+    const sign = showSign && num > 0 ? '+' : '';
+    
+    return `${sign}${formatted}%`;
+}
+
+/**
+ * Format as compact number (1K, 1M, 1B, etc.)
+ */
+export function formatCompact(value: string | number): string {
+    const num = typeof value === 'string' ? parseFloat(value) : value;
+    if (isNaN(num)) return '--';
+    
+    if (num >= 1_000_000_000) {
+        return `${(num / 1_000_000_000).toFixed(1)}B`;
+    }
+    if (num >= 1_000_000) {
+        return `${(num / 1_000_000).toFixed(1)}M`;
+    }
+    if (num >= 1_000) {
+        return `${(num / 1_000).toFixed(1)}K`;
+    }
+    return num.toString();
+}
+
+/**
+ * Calculate delta between two values
+ */
+export function calculateDelta(
+    current: string | number, 
+    previous: string | number
+): KPIDelta {
+    const curr = typeof current === 'string' ? parseFloat(current) : current;
+    const prev = typeof previous === 'string' ? parseFloat(previous) : previous;
+    
+    if (isNaN(curr) || isNaN(prev) || prev === 0) {
+        return { value: 0, direction: 'neutral' };
+    }
+    
+    const percentChange = ((curr - prev) / prev) * 100;
+    
+    return {
+        value: Math.abs(percentChange),
+        direction: percentChange > 0 ? 'up' : percentChange < 0 ? 'down' : 'neutral',
+        isPercentage: true,
+    };
+}
+
+// ============================================================================
+// DELTA COMPONENT
+// ============================================================================
+
+interface DeltaIndicatorProps {
+    delta: KPIDelta;
+    size?: KPICardSize;
+}
+
+const DeltaIndicator: React.FC<DeltaIndicatorProps> = ({ delta, size = 'medium' }) => {
+    const Icon = delta.direction === 'up' 
+        ? TrendingUp 
+        : delta.direction === 'down' 
+            ? TrendingDown 
+            : Minus;
+    
+    const isPositive = delta.direction === 'up';
+    const isNegative = delta.direction === 'down';
+    
+    return (
+        <div 
+            className={clsx(
+                styles.delta,
+                styles[`delta${size.charAt(0).toUpperCase() + size.slice(1)}`],
+                {
+                    [styles.deltaPositive]: isPositive,
+                    [styles.deltaNegative]: isNegative,
+                    [styles.deltaNeutral]: delta.direction === 'neutral',
+                }
+            )}
+        >
+            <Icon size={size === 'small' ? 12 : size === 'large' ? 18 : 14} />
+            <span>{delta.value.toFixed(1)}%</span>
+            {delta.period && <span className={styles.deltaPeriod}>{delta.period}</span>}
+        </div>
+    );
+};
+
+// ============================================================================
+// LOADING STATE COMPONENT
+// ============================================================================
+
+interface LoadingStateProps {
+    message?: string;
+    size?: KPICardSize;
+}
+
+const LoadingState: React.FC<LoadingStateProps> = ({ message, size = 'medium' }) => {
+    return (
+        <div className={clsx(styles.loadingState, styles[`loading${size.charAt(0).toUpperCase() + size.slice(1)}`])}>
+            <Loader2 className={styles.spinner} size={size === 'small' ? 16 : size === 'large' ? 28 : 20} />
+            {message && <span className={styles.loadingMessage}>{message}</span>}
+            <div className={styles.skeleton}>
+                <div className={styles.skeletonBar} style={{ width: '60%' }} />
+                <div className={styles.skeletonBar} style={{ width: '40%' }} />
+            </div>
+        </div>
+    );
+};
+
+// ============================================================================
+// ERROR STATE COMPONENT
+// ============================================================================
+
+interface ErrorStateProps {
+    message?: string;
+    onRetry?: () => void;
+    size?: KPICardSize;
+}
+
+const ErrorState: React.FC<ErrorStateProps> = ({ message, onRetry, size = 'medium' }) => {
+    return (
+        <div className={clsx(styles.errorState, styles[`error${size.charAt(0).toUpperCase() + size.slice(1)}`])}>
+            <AlertCircle className={styles.errorIcon} size={size === 'small' ? 16 : size === 'large' ? 28 : 20} />
+            <span className={styles.errorMessage}>{message || 'Failed to load'}</span>
+            {onRetry && (
+                <button 
+                    className={styles.retryButton}
+                    onClick={onRetry}
+                    aria-label="Retry loading data"
+                >
+                    Retry
+                </button>
+            )}
+        </div>
+    );
+};
+
+// ============================================================================
+// EMPTY STATE COMPONENT
+// ============================================================================
+
+interface EmptyStateProps {
+    message?: string;
+    size?: KPICardSize;
+}
+
+const EmptyState: React.FC<EmptyStateProps> = ({ message, size = 'medium' }) => {
+    return (
+        <div className={clsx(styles.emptyState, styles[`empty${size.charAt(0).toUpperCase() + size.slice(1)}`])}>
+            <span className={styles.emptyMessage}>{message || 'No data available'}</span>
+        </div>
+    );
+};
+
+// ============================================================================
+// MAIN KPI CARD COMPONENT
+// ============================================================================
+
+/**
+ * KPI Card Component
+ * 
+ * A reusable card component for displaying dashboard metrics with:
+ * - Loading, error, and empty states
+ * - Delta/change indicators
+ * - Multiple size and variant options
+ * - Number formatting utilities
+ * - Accessibility support
+ * 
+ * @example
+ * ```tsx
+ * <KPICard
+ *   label="Total Revenue"
+ *   value={125000}
+ *   format="currency"
+ *   variant="green"
+ *   delta={{ value: 12.5, direction: 'up', period: 'vs last month' }}
+ * />
+ * ```
+ */
+export const KPICard: React.FC<KPICardProps> = ({
+    label,
+    value,
+    previousValue,
+    variant = 'teal',
+    size = 'medium',
+    icon: Icon,
+    delta,
+    state = 'default',
+    loadingMessage = 'Loading metrics...',
+    errorMessage,
+    format = 'value',
+    unit,
+    decimals = 0,
+    description,
+    tooltip,
+    onRetry,
+    onClick,
+    ariaLabel,
+}) => {
+    // Format value based on format type
+    const formattedValue = (() => {
+        if (value === undefined || value === null) return '--';
+        
+        switch (format) {
+            case 'currency':
+                return formatCurrency(value, unit || 'USD', decimals);
+            case 'percentage':
+                return formatPercentage(value, decimals);
+            case 'count':
+                return formatCompact(value);
+            case 'score':
+                return formatNumber(value, decimals);
+            default:
+                return formatNumber(value, decimals);
+        }
+    })();
+
+    // Calculate delta if previous value provided
+    const displayDelta = delta || (
+        previousValue !== undefined 
+            ? calculateDelta(value as string | number, previousValue) 
+            : undefined
+    );
+
+    // Render based on state
+    if (state === 'loading') {
+        return (
+            <div className={clsx(styles.card, styles[variant], styles[size])}>
+                <LoadingState message={loadingMessage} size={size} />
+            </div>
+        );
+    }
+
+    if (state === 'error') {
+        return (
+            <div className={clsx(styles.card, styles[variant], styles[size])}>
+                <ErrorState message={errorMessage} onRetry={onRetry} size={size} />
+            </div>
+        );
+    }
+
+    if (state === 'empty') {
+        return (
+            <div className={clsx(styles.card, styles[variant], styles[size])}>
+                <EmptyState size={size} />
+            </div>
+        );
+    }
+
+    // Default state
+    return (
+        <div 
+            className={clsx(
+                styles.card, 
+                styles[variant], 
+                styles[size],
+                { [styles.clickable]: !!onClick }
+            )}
+            onClick={onClick}
+            role={onClick ? 'button' : undefined}
+            tabIndex={onClick ? 0 : undefined}
+            onKeyDown={onClick ? (e) => e.key === 'Enter' && onClick() : undefined}
+            aria-label={ariaLabel || `${label}: ${formattedValue}`}
+        >
+            {/* Header: Icon + Label */}
+            <div className={styles.header}>
+                {Icon && (
+                    <div className={styles.iconWrapper}>
+                        <Icon size={size === 'small' ? 14 : size === 'large' ? 22 : 18} />
+                    </div>
+                )}
+                <span className={styles.label}>{label}</span>
+                {tooltip && (
+                    <span className={styles.tooltip} title={tooltip}>ⓘ</span>
+                )}
+            </div>
+
+            {/* Value Display */}
+            <div className={styles.valueContainer}>
+                <span className={styles.value}>{formattedValue}</span>
+                {displayDelta && (
+                    <DeltaIndicator delta={displayDelta} size={size} />
+                )}
+            </div>
+
+            {/* Description (optional) */}
+            {description && (
+                <p className={styles.description}>{description}</p>
+            )}
+        </div>
+    );
+};
+
+// ============================================================================
+// EXPORTS
+// ============================================================================
+
+export default KPICard;

--- a/src/components/KPICard/index.ts
+++ b/src/components/KPICard/index.ts
@@ -1,0 +1,21 @@
+// KPI Card Component Exports
+// ============================================================================
+
+export { KPICard, default } from './KPICard';
+export { 
+    formatNumber, 
+    formatCurrency, 
+    formatPercentage, 
+    formatCompact, 
+    calculateDelta 
+} from './KPICard';
+
+export type {
+    KPICardProps,
+    KPIDelta,
+    KPICardVariant,
+    KPICardSize,
+    DeltaDirection,
+    MetricCategory,
+    CardState,
+} from './KPICard';


### PR DESCRIPTION
feat: added KPI card component with loading/error states

Created KPICard component with 6 color variants (teal, green, blue, purple, orange, neutral)
- Implemented 3 size options (small, medium, large) for metric hierarchy
- Added 4 state modes: default, loading (spinner + skeleton), error (retry button), empty
- Included delta/change indicators with auto-calculation from previousValue
- Added formatting utilities: formatNumber, formatCurrency, formatPercentage, formatCompact
- Support multiple format types: value, currency, percentage, count, score
- Added responsive grid layout (4col → 2col → 1col at 1024px/640px breakpoints)
- Added keyboard navigation and ARIA accessibility
- Created comprehensive test suite and documentation spec

Closes #232 