### PR TITLE
docs: add backend breaking change checklist to developer guide

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -40,6 +40,20 @@ Welcome to the CommitLabs Frontend developer guide. This document provides guide
 -   The resolved request id is included in structured backend logs and returned
     to the client via the `x-request-id` response header.
 
+### Backend Breaking Change Checklist
+
+If your change introduces a backend contract break that can impact frontend
+clients, complete this checklist in the same PR:
+
+-   [ ] Update OpenAPI docs/spec so the contract change is explicit and reviewable.
+-   [ ] Add an entry to `docs/backend-changelog.md` using the template in that file.
+-   [ ] Update or add contract tests that validate the new request/response shape.
+-   [ ] Add UI migration notes that describe impacted pages/components and required
+    frontend changes.
+
+Treat this checklist as required for all endpoint, payload, auth, and error
+shape breaking changes.
+
 ### React & Next.js
 
 -   **Functional Components**: Use functional components with hooks.


### PR DESCRIPTION
## Overview
This PR adds a backend breaking change checklist to `DEVELOPER_GUIDE.md` so contract-impacting backend updates are documented consistently and safely consumed by frontend contributors.

## Related Issue
Closes #228

## Changes

### 📘 Developer Guide Updates
- **[MODIFY]** `DEVELOPER_GUIDE.md`
- Added a new `Backend Breaking Change Checklist` section.
- Added required checklist items for:
  - OpenAPI docs/spec updates
  - Changelog entry in `docs/backend-changelog.md`
  - Contract test updates/additions
  - UI migration notes for impacted frontend areas
- Added guidance that this checklist is required for endpoint, payload, auth, and error-shape breaking changes.

### 🔗 Reference Template
- **[REFERENCE]** `docs/backend-changelog.md`
- Linked the checklist to the backend changelog template location.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Checklist section added to `DEVELOPER_GUIDE.md` | ✅ |
| Includes OpenAPI update checklist item | ✅ |
| Includes changelog entry checklist item | ✅ |
| Includes contract tests checklist item | ✅ |
| Includes UI migration notes checklist item | ✅ |
| Links to `docs/backend-changelog.md` template | ✅ |

## How to Test

```bash
# 1. Confirm branch
git branch --show-current

# 2. Inspect docs change
git diff -- DEVELOPER_GUIDE.md

```


