### PR TITLE
feat: add marketplace purchase endpoint with ownership transfer

### DIFF
--- a/docs/backend-api-reference.md
+++ b/docs/backend-api-reference.md
@@ -64,6 +64,46 @@ Clients should wait the indicated seconds before retrying. See [error-handling.m
 
 ---
 
+## `POST /api/marketplace/listings/[id]/purchase`
+
+Purchases a marketplace listing. Requires an active session cookie. Runs
+preflight eligibility checks, triggers on-chain ownership transfer, and records
+the event in the audit log.
+
+- **Authentication**: session cookie (`requireAuth`)
+- **Path parameter**: `id` — the marketplace listing ID
+- **Request body**: none
+- **Response**:
+  - `200 OK`: Purchase completed.
+  - `401 Unauthorized`: Missing or invalid session.
+  - `404 Not Found`: Listing does not exist.
+  - `409 Conflict`: Preflight failed (e.g. listing inactive, buyer is seller).
+  - `502 Bad Gateway`: On-chain transfer failed.
+
+### Example
+
+```bash
+curl -X POST http://localhost:3000/api/marketplace/listings/listing_1/purchase \
+     -H 'Cookie: session=<token>'
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "listingId": "listing_1",
+    "commitmentId": "cm_abc",
+    "buyerAddress": "GBUYER...",
+    "price": "52000",
+    "currencyAsset": "USDC",
+    "txHash": null,
+    "reference": "TODO_CHAIN_CALL_TRANSFER_OWNERSHIP"
+  }
+}
+```
+
+---
+
 ## `POST /api/commitments`
 
 Creates a new commitment on the Stellar network.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -227,6 +227,114 @@ paths:
               schema:
                 $ref: '#/components/schemas/SuccessEnvelope'
 
+  /api/marketplace/listings/{id}/preflight:
+    post:
+      summary: Purchase Preflight
+      description: Checks whether the authenticated buyer is eligible to purchase a listing before committing.
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [buyerAddress]
+              properties:
+                buyerAddress:
+                  type: string
+                  example: "GBUYERADDRESS..."
+      responses:
+        '200':
+          description: Preflight result.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          eligible:
+                            type: boolean
+                          reasons:
+                            type: array
+                            items:
+                              type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/marketplace/listings/{id}/purchase:
+    post:
+      summary: Purchase Listing
+      description: |
+        Purchases a marketplace listing. Runs preflight eligibility checks,
+        authenticates the buyer via session cookie, triggers on-chain ownership
+        transfer through the contracts service, and records the event in the
+        audit log.
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The marketplace listing ID.
+      responses:
+        '200':
+          description: Purchase completed successfully.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          listingId:
+                            type: string
+                          commitmentId:
+                            type: string
+                          buyerAddress:
+                            type: string
+                          price:
+                            type: string
+                          currencyAsset:
+                            type: string
+                          txHash:
+                            type: string
+                            nullable: true
+                          reference:
+                            type: string
+                            nullable: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Purchase not eligible (listing inactive, buyer is seller, etc.).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/attestations:
     get:
       summary: List Attestations

--- a/src/app/api/marketplace/listings/[id]/purchase/route.ts
+++ b/src/app/api/marketplace/listings/[id]/purchase/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest } from 'next/server';
+import { withApiHandler } from '@/lib/backend/withApiHandler';
+import { ok } from '@/lib/backend/apiResponse';
+import { requireAuth } from '@/lib/backend/requireAuth';
+import { marketplaceService } from '@/lib/backend/services/marketplace';
+import { transferOwnership } from '@/lib/backend/services/contracts';
+import { appendAuditEvent } from '@/lib/backend/auditLog';
+import { BadRequestError, ConflictError, NotFoundError } from '@/lib/backend/errors';
+import { logInfo } from '@/lib/backend/logger';
+
+export const POST = withApiHandler(async (req: NextRequest, { params }: { params: { id: string } }) => {
+  const authReq = requireAuth(req);
+  const buyerAddress = authReq.user.address;
+  const listingId = params.id;
+
+  if (!listingId) {
+    throw new BadRequestError('Missing listing ID');
+  }
+
+  // 1. Load listing
+  const listing = await marketplaceService.getListing(listingId);
+  if (!listing) {
+    throw new NotFoundError('Listing', { listingId });
+  }
+
+  // 2. Preflight eligibility check
+  const preflight = await marketplaceService.getPurchasePreflight(listingId, buyerAddress);
+  if (!preflight.eligible) {
+    throw new ConflictError(
+      `Purchase not eligible: ${preflight.reasons.join(', ')}`,
+      { listingId, reasons: preflight.reasons },
+    );
+  }
+
+  logInfo(req, 'Marketplace purchase initiated', { listingId, buyerAddress });
+
+  // 3. On-chain ownership transfer
+  const transfer = await transferOwnership({
+    commitmentId: listing.commitmentId,
+    fromAddress: listing.sellerAddress,
+    toAddress: buyerAddress,
+  });
+
+  // 4. Audit log
+  await appendAuditEvent({
+    category: 'marketplace',
+    action: 'marketplace.purchase',
+    severity: 'info',
+    actor: buyerAddress,
+    resourceId: listingId,
+    metadata: {
+      listingId,
+      commitmentId: listing.commitmentId,
+      price: listing.price,
+      currencyAsset: listing.currencyAsset,
+      txHash: transfer.txHash,
+      reference: transfer.reference,
+    },
+  });
+
+  return ok({
+    listingId,
+    commitmentId: listing.commitmentId,
+    buyerAddress,
+    price: listing.price,
+    currencyAsset: listing.currencyAsset,
+    txHash: transfer.txHash,
+    reference: transfer.reference,
+  });
+});

--- a/src/lib/backend/services/contracts.ts
+++ b/src/lib/backend/services/contracts.ts
@@ -861,3 +861,68 @@ export async function earlyExitCommitmentOnChain(
     });
   }
 }
+
+export interface TransferOwnershipParams {
+  commitmentId: string;
+  fromAddress: string;
+  toAddress: string;
+}
+
+export interface TransferOwnershipResult {
+  commitmentId: string;
+  newOwner: string;
+  txHash?: string;
+  reference?: string;
+}
+
+export async function transferOwnership(
+  params: TransferOwnershipParams,
+): Promise<TransferOwnershipResult> {
+  try {
+    if (!params.commitmentId) {
+      throw new BackendError({
+        code: "BAD_REQUEST",
+        message: "Missing commitment id for ownership transfer.",
+        status: 400,
+      });
+    }
+    validateOwnerAddress(params.fromAddress);
+    validateOwnerAddress(params.toAddress);
+
+    const invocation = await invokeContractMethod(
+      getContractId("commitmentCore"),
+      "transfer_ownership",
+      [
+        nativeToScVal(params.commitmentId),
+        new Address(params.fromAddress).toScVal(),
+        new Address(params.toAddress).toScVal(),
+      ],
+      "write",
+    );
+
+    const countersAdapter = getCountersAdapter();
+    void countersAdapter.incrementSuccessfulActions();
+
+    void cache.delete(CacheKey.commitment(params.commitmentId));
+    void cache.delete(CacheKey.userCommitments(params.fromAddress));
+    void cache.delete(CacheKey.userCommitments(params.toAddress));
+
+    const result = asRecord(invocation.value);
+    return {
+      commitmentId: params.commitmentId,
+      newOwner: asString(result.newOwner, params.toAddress),
+      txHash: invocation.txHash,
+      reference: invocation.txHash ? undefined : "TODO_CHAIN_CALL_TRANSFER_OWNERSHIP",
+    };
+  } catch (error) {
+    const countersAdapter = getCountersAdapter();
+    void countersAdapter.incrementChainFailures();
+
+    throw normalizeBackendError(error, {
+      code: "BLOCKCHAIN_CALL_FAILED",
+      message: "Unable to transfer commitment ownership on chain.",
+      status: 502,
+      details: { method: "transfer_ownership", commitmentId: params.commitmentId },
+    });
+  }
+}

--- a/tests/api/marketplace-purchase.test.ts
+++ b/tests/api/marketplace-purchase.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockRequest, createMockRouteContext, parseResponse } from './helpers';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/backend/requireAuth', () => ({
+  requireAuth: vi.fn(),
+}));
+
+vi.mock('@/lib/backend/services/marketplace', () => ({
+  marketplaceService: {
+    getListing: vi.fn(),
+    getPurchasePreflight: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/backend/services/contracts', () => ({
+  transferOwnership: vi.fn(),
+}));
+
+vi.mock('@/lib/backend/auditLog', () => ({
+  appendAuditEvent: vi.fn(),
+}));
+
+// ─── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { POST } from '@/app/api/marketplace/listings/[id]/purchase/route';
+import { requireAuth } from '@/lib/backend/requireAuth';
+import { marketplaceService } from '@/lib/backend/services/marketplace';
+import { transferOwnership } from '@/lib/backend/services/contracts';
+import { appendAuditEvent } from '@/lib/backend/auditLog';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const BUYER = 'GBUYERADDRESS000000000000000000000000000000000000000000000';
+const SELLER = 'GSELLERADDRESS00000000000000000000000000000000000000000000';
+
+const mockListing = {
+  id: 'listing_1',
+  commitmentId: 'cm_abc',
+  price: '52000',
+  currencyAsset: 'USDC',
+  sellerAddress: SELLER,
+  status: 'Active',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const mockTransfer = {
+  commitmentId: 'cm_abc',
+  newOwner: BUYER,
+  reference: 'TODO_CHAIN_CALL_TRANSFER_OWNERSHIP',
+};
+
+function makeRequest(listingId = 'listing_1') {
+  return createMockRequest(
+    `http://localhost:3000/api/marketplace/listings/${listingId}/purchase`,
+    { method: 'POST' },
+  );
+}
+
+function makeContext(id = 'listing_1') {
+  return createMockRouteContext({ id });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/marketplace/listings/[id]/purchase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: authenticated buyer
+    vi.mocked(requireAuth).mockReturnValue({
+      user: { address: BUYER, csrfToken: 'tok' },
+    } as any);
+
+    vi.mocked(marketplaceService.getListing).mockResolvedValue(mockListing as any);
+    vi.mocked(marketplaceService.getPurchasePreflight).mockResolvedValue({
+      eligible: true,
+      reasons: [],
+    });
+    vi.mocked(transferOwnership).mockResolvedValue(mockTransfer);
+    vi.mocked(appendAuditEvent).mockResolvedValue(undefined);
+  });
+
+  it('returns 200 with purchase details on success', async () => {
+    const res = await POST(makeRequest(), makeContext());
+    const { status, data } = await parseResponse(res);
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.listingId).toBe('listing_1');
+    expect(data.data.commitmentId).toBe('cm_abc');
+    expect(data.data.buyerAddress).toBe(BUYER);
+    expect(data.data.price).toBe('52000');
+  });
+
+  it('calls transferOwnership with correct params', async () => {
+    await POST(makeRequest(), makeContext());
+
+    expect(transferOwnership).toHaveBeenCalledWith({
+      commitmentId: 'cm_abc',
+      fromAddress: SELLER,
+      toAddress: BUYER,
+    });
+  });
+
+  it('records an audit event on success', async () => {
+    await POST(makeRequest(), makeContext());
+
+    expect(appendAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'marketplace',
+        action: 'marketplace.purchase',
+        severity: 'info',
+        actor: BUYER,
+        resourceId: 'listing_1',
+      }),
+    );
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const { UnauthorizedError } = await import('@/lib/backend/errors');
+    vi.mocked(requireAuth).mockImplementation(() => {
+      throw new UnauthorizedError('No session token provided');
+    });
+
+    const res = await POST(makeRequest(), makeContext());
+    const { status, data } = await parseResponse(res);
+
+    expect(status).toBe(401);
+    expect(data.success).toBe(false);
+  });
+
+  it('returns 404 when listing does not exist', async () => {
+    vi.mocked(marketplaceService.getListing).mockResolvedValue(null);
+
+    const res = await POST(makeRequest(), makeContext());
+    const { status, data } = await parseResponse(res);
+
+    expect(status).toBe(404);
+    expect(data.success).toBe(false);
+  });
+
+  it('returns 409 when preflight fails (listing inactive)', async () => {
+    vi.mocked(marketplaceService.getPurchasePreflight).mockResolvedValue({
+      eligible: false,
+      reasons: ['listing_inactive'],
+    });
+
+    const res = await POST(makeRequest(), makeContext());
+    const { status, data } = await parseResponse(res);
+
+    expect(status).toBe(409);
+    expect(data.success).toBe(false);
+    expect(data.error.message).toContain('listing_inactive');
+  });
+
+  it('returns 409 when buyer is the seller', async () => {
+    vi.mocked(marketplaceService.getPurchasePreflight).mockResolvedValue({
+      eligible: false,
+      reasons: ['buyer_is_seller'],
+    });
+
+    const res = await POST(makeRequest(), makeContext());
+    const { status, data } = await parseResponse(res);
+
+    expect(status).toBe(409);
+    expect(data.success).toBe(false);
+  });
+
+  it('does not call transferOwnership when preflight fails', async () => {
+    vi.mocked(marketplaceService.getPurchasePreflight).mockResolvedValue({
+      eligible: false,
+      reasons: ['listing_inactive'],
+    });
+
+    await POST(makeRequest(), makeContext());
+
+    expect(transferOwnership).not.toHaveBeenCalled();
+  });
+
+  it('does not record audit event when preflight fails', async () => {
+    vi.mocked(marketplaceService.getPurchasePreflight).mockResolvedValue({
+      eligible: false,
+      reasons: ['listing_inactive'],
+    });
+
+    await POST(makeRequest(), makeContext());
+
+    expect(appendAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns 5xx when on-chain transfer fails', async () => {
+    vi.mocked(transferOwnership).mockRejectedValue(
+      new Error('Soroban RPC unreachable'),
+    );
+
+    const res = await POST(makeRequest(), makeContext());
+    const { status, data } = await parseResponse(res);
+
+    expect(status).toBeGreaterThanOrEqual(500);
+    expect(data.success).toBe(false);
+  });
+
+  it('includes txHash in response when transfer returns one', async () => {
+    vi.mocked(transferOwnership).mockResolvedValue({
+      ...mockTransfer,
+      txHash: 'abc123txhash',
+      reference: undefined,
+    });
+
+    const res = await POST(makeRequest(), makeContext());
+    const { data } = await parseResponse(res);
+
+    expect(data.data.txHash).toBe('abc123txhash');
+  });
+});


### PR DESCRIPTION
- POST /api/marketplace/listings/[id]/purchase
- requireAuth gates the route (session cookie)
- getPurchasePreflight checked before any state change
- transferOwnership added to contracts service (Soroban call)
- appendAuditEvent records every purchase under marketplace category
- 11 tests covering success, auth, preflight, and chain failure paths
- openapi.yaml and docs/backend-api-reference.md updated

Closes #454 