### PR TITLE
feat: add admin and fee-recipient rotation functions

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,3 +1,13 @@
+### Admin and Fee Recipient Rotation
+
+The contract supports secure rotation of the admin and fee recipient addresses after initialization:
+
+| Function | Description |
+| --- | --- |
+| `set_admin(new_admin)` | Admin-only. Rotates the contract admin to `new_admin`. Emits an event. |
+| `set_fee_recipient(new_fee_recipient)` | Admin-only. Rotates the protocol fee recipient. Emits an event. |
+
+Both functions require the current admin to authorize the call. Rotation is rejected if the contract is not initialized. Events are emitted for auditability.
 # CommitLabs Soroban Contracts
 
 Soroban (Rust) smart-contract workspace backing the CommitLabs liquidity

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -106,6 +106,33 @@ pub struct EscrowContract;
 
 #[contractimpl]
 impl EscrowContract {
+        /// Set a new admin address. Only callable by current admin after initialization.
+        /// Emits an event on success.
+        pub fn set_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+            Self::require_init(&env)?;
+            let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
+            admin.require_auth();
+            env.storage().instance().set(&DataKey::Admin, &new_admin);
+            env.events().publish(
+                (Symbol::new(&env, "set_admin"), admin.clone()),
+                (new_admin.clone(),),
+            );
+            Ok(())
+        }
+
+        /// Set a new fee recipient address. Only callable by current admin after initialization.
+        /// Emits an event on success.
+        pub fn set_fee_recipient(env: Env, new_fee_recipient: Address) -> Result<(), Error> {
+            Self::require_init(&env)?;
+            let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
+            admin.require_auth();
+            env.storage().instance().set(&DataKey::FeeRecipient, &new_fee_recipient);
+            env.events().publish(
+                (Symbol::new(&env, "set_fee_recipient"), admin.clone()),
+                (new_fee_recipient.clone(),),
+            );
+            Ok(())
+        }
     /// One-time initialization. Sets the admin, the escrow token and the fee
     /// recipient. Must be called before any commitment is created.
     pub fn initialize(

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -1,3 +1,39 @@
+#[test]
+fn admin_can_rotate_admin_and_fee_recipient() {
+    let f = setup();
+    let new_admin = Address::generate(&f.env);
+    let new_fee = Address::generate(&f.env);
+
+    // Only admin can rotate admin
+    f.env.set_auths(&[&f.admin]);
+    f.client.set_admin(&new_admin);
+    // Only new admin can rotate fee recipient
+    f.env.set_auths(&[&new_admin]);
+    f.client.set_fee_recipient(&new_fee);
+
+    // Check storage
+    let stored_admin: Address = f.env.storage().instance().get(&DataKey::Admin).unwrap();
+    let stored_fee: Address = f.env.storage().instance().get(&DataKey::FeeRecipient).unwrap();
+    assert_eq!(stored_admin, new_admin);
+    assert_eq!(stored_fee, new_fee);
+}
+
+#[test]
+fn unauthorized_cannot_rotate_admin_or_fee_recipient() {
+    let f = setup();
+    let new_admin = Address::generate(&f.env);
+    let new_fee = Address::generate(&f.env);
+    let not_admin = Address::generate(&f.env);
+
+    // Not admin tries to rotate admin
+    f.env.set_auths(&[&not_admin]);
+    let res = f.client.try_set_admin(&new_admin);
+    assert_eq!(res, Err(Ok(Error::Unauthorized)));
+
+    // Not admin tries to rotate fee recipient
+    let res2 = f.client.try_set_fee_recipient(&new_fee);
+    assert_eq!(res2, Err(Ok(Error::Unauthorized)));
+}
 #![cfg(test)]
 
 use super::*;


### PR DESCRIPTION
- Add set_admin and set_fee_recipient functions with admin.require_auth
- Emit events on rotation
- Reject rotation before initialize
- Add tests for authorized and unauthorized rotation
- Document rotation in README