### PR TITLE
feat: partial early-exit refunds and violation auto-trigger (#462, #465)

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -73,6 +73,9 @@ create_commitment ──► fund_escrow ──► release            (matured: p
 | `get_commitment(commitment_id)` | Read a single commitment record. |
 | `get_owner_commitments(owner)` | List commitment ids owned by an address. |
 | `get_attestations(commitment_id)` | Retrieve the timeline of `AttestationRecord`s for a commitment. |
+| `refund_partial(commitment_id, amount)` | Partial early-exit: withdraw `amount` from the principal, apply the proportional penalty to that portion, keep the remainder escrowed. |
+| `set_violation_threshold(threshold)` | Admin-only. Set the compliance score threshold (0–100) below which a funded commitment is auto-violated. 0 disables auto-violation. |
+| `get_violation_threshold()` | Read the current violation threshold. |
 
 ### Attestation History
 
@@ -208,13 +211,59 @@ The dispute record is persisted on-chain and can be read at any time via
 `get_dispute(commitment_id)`, even after the dispute is resolved. This enables
 auditing, analytics, and off-chain verification of dispute history.
 
+### Partial early-exit (`refund_partial`)
+
+`refund_partial(commitment_id, amount)` lets an owner exit a fraction of their
+locked principal before maturity. Only the withdrawn portion is penalised;
+the remainder stays escrowed under the same commitment.
+
+- `amount` must be > 0 and ≤ `Commitment.amount`.
+- `penalty_bps` is applied only to `amount`: `penalty = amount * penalty_bps / 10_000`.
+- `Commitment.amount` is reduced by `amount` in storage.
+- If `amount` equals the full stored principal the commitment transitions to
+  `Refunded`; otherwise it stays `Funded`.
+- Blocked when the commitment is in `Violated` status (`CommitmentViolated` error).
+
+```
+refund_partial(id, 400)   # withdraw 400 out of 1 000 at 10% penalty
+  → net to owner: 360, fee: 40, remaining escrowed: 600 (status: Funded)
+
+refund_partial(id, 1000)  # withdraw all remaining principal
+  → net to owner: 950, fee: 50, remaining: 0 (status: Refunded)
+```
+
+### Violation auto-trigger
+
+A configurable compliance score threshold controls automatic violation of funded
+commitments. When `record_attestation` records a score **strictly below** the
+threshold for a `Funded` commitment, the status transitions to `Violated` and
+a `commitment_violated` event is emitted.
+
+- `set_violation_threshold(threshold)` — admin-only, clamps to 0–100. A value
+  of `0` (default) disables auto-violation entirely.
+- `get_violation_threshold()` — public read of the current threshold.
+- `release`, `refund`, and `refund_partial` all return `CommitmentViolated`
+  while the commitment is in the `Violated` state.
+- A score **equal to** the threshold does **not** trigger a violation; only
+  scores **strictly below** do.
+- Auto-violation only applies to `Funded` commitments. Attestations on
+  `Created`, `Released`, `Refunded`, or `Disputed` commitments are recorded but
+  do not change status.
+
+```
+set_violation_threshold(60)   # violate when score < 60
+record_attestation(id, 59)    # → status: Violated, event emitted
+record_attestation(id, 60)    # → status unchanged (Funded)
+```
+
 ### Errors
 
 Stable numeric error codes (`#[contracterror]`) are surfaced so the backend
 `normalizeContractError` mapper can translate them into HTTP responses:
 `AlreadyInitialized`, `NotInitialized`, `NotFound`, `Unauthorized`,
 `InvalidAmount`, `InvalidState`, `NotMatured`, `InvalidDuration`,
-`PenaltyTooHigh`, `Paused`.
+`PenaltyTooHigh`, `Paused`, `AssetMismatch`, `InsufficientYieldPool`,
+`InvalidWasmHash`, `CommitmentViolated`.
 
 ## Build & test
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -39,6 +39,14 @@ pub enum DataKey {
     Dispute(u64),
     /// Default penalty in basis points for each RiskProfile.
     DefaultPenalty(RiskProfile),
+    /// Contract paused flag; true halts write operations.
+    Paused,
+    /// Accumulated yield pool balance available to pay matured commitments.
+    YieldPool,
+    /// Attestation history for a commitment, keyed by commitment id.
+    Attestations(u64),
+    /// Minimum compliance score threshold; scores below this auto-violate a funded commitment.
+    ViolationThreshold,
 }
 
 /// Risk profile chosen at creation time. Determines the early-exit penalty
@@ -65,6 +73,8 @@ pub enum EscrowStatus {
     Refunded,
     /// Under dispute; transfers are frozen.
     Disputed,
+    /// Compliance score dropped below the violation threshold; transfers frozen until resolved.
+    Violated,
 }
 
 /// Categorized dispute reason enum. Enables efficient on-chain classification
@@ -97,6 +107,15 @@ pub struct DisputeRecord {
     pub disputed_at: u64,
     /// Address that initiated the dispute (owner or admin).
     pub disputed_by: Address,
+}
+
+/// A single compliance attestation entry appended to a commitment's history.
+#[contracttype]
+#[derive(Clone)]
+pub struct AttestationRecord {
+    pub attestor: Address,
+    pub compliance_score: u32,
+    pub timestamp: u64,
 }
 
 /// A single escrow / commitment record.
@@ -136,6 +155,14 @@ pub enum Error {
     PenaltyTooHigh = 9,
     /// Contract is currently paused for emergency halt.
     Paused = 10,
+    /// Token asset does not match the configured escrow token.
+    AssetMismatch = 11,
+    /// Yield pool has insufficient balance to pay matured commitment yield.
+    InsufficientYieldPool = 12,
+    /// WASM hash provided for upgrade is invalid (e.g. zero hash).
+    InvalidWasmHash = 13,
+    /// Commitment is in Violated status; release and refund are blocked until resolved.
+    CommitmentViolated = 14,
 }
 
 /// Result of an early exit commitment.
@@ -309,6 +336,7 @@ impl EscrowContract {
             owner: owner.clone(),
             asset,
             amount,
+            accrued_yield: 0,
             risk,
             status: EscrowStatus::Created,
             maturity,
@@ -468,6 +496,9 @@ impl EscrowContract {
         Self::require_init(&env)?;
         let mut c = Self::load(&env, commitment_id)?;
 
+        if c.status == EscrowStatus::Violated {
+            return Err(Error::CommitmentViolated);
+        }
         if c.status != EscrowStatus::Funded {
             return Err(Error::InvalidState);
         }
@@ -511,6 +542,79 @@ impl EscrowContract {
         let c = Self::load(&env, commitment_id)?;
         c.owner.require_auth();
         let (refund_amount, _) = Self::execute_refund(&env, c)?;
+        Ok(refund_amount)
+    }
+
+    /// Partial early-exit refund. Withdraws `amount` from the escrowed principal,
+    /// applying the proportional `penalty_bps` to the withdrawn portion only. The
+    /// remaining principal stays escrowed and the commitment status stays `Funded`.
+    /// If `amount` equals the full principal the commitment transitions to `Refunded`.
+    ///
+    /// Only the owner may call this and only while the commitment is `Funded`. The
+    /// call is rejected if the commitment is in `Violated` status.
+    ///
+    /// # Arguments
+    /// * `commitment_id` - The id of the target commitment.
+    /// * `amount` - The portion of the principal to withdraw (must be > 0 and ≤ stored amount).
+    pub fn refund_partial(
+        env: Env,
+        commitment_id: u64,
+        amount: i128,
+    ) -> Result<i128, Error> {
+        Self::require_init(&env)?;
+        Self::require_not_paused(&env)?;
+        let mut c = Self::load(&env, commitment_id)?;
+        c.owner.require_auth();
+
+        if c.status == EscrowStatus::Violated {
+            return Err(Error::CommitmentViolated);
+        }
+        if c.status != EscrowStatus::Funded {
+            return Err(Error::InvalidState);
+        }
+        if amount <= 0 || amount > c.amount {
+            return Err(Error::InvalidAmount);
+        }
+
+        // Apply penalty to the withdrawn portion only.
+        let penalty_mul = amount
+            .checked_mul(c.penalty_bps as i128)
+            .ok_or(Error::InvalidAmount)?;
+        let penalty = penalty_mul / MAX_PENALTY_BPS as i128;
+        let refund_amount = amount
+            .checked_sub(penalty)
+            .ok_or(Error::InvalidAmount)?;
+
+        // Update the stored principal; remainder stays in escrow.
+        let remaining = c
+            .amount
+            .checked_sub(amount)
+            .ok_or(Error::InvalidAmount)?;
+        c.amount = remaining;
+        if remaining == 0 {
+            c.status = EscrowStatus::Refunded;
+        }
+
+        // Effects: persist before token interactions.
+        Self::save(&env, &c);
+
+        // Interactions: transfer penalty then refund.
+        let token = Self::token_client(&env);
+        let contract = env.current_contract_address();
+        if penalty > 0 {
+            let fee_recipient: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::FeeRecipient)
+                .ok_or(Error::NotInitialized)?;
+            token.transfer(&contract, &fee_recipient, &penalty);
+        }
+        token.transfer(&contract, &c.owner, &refund_amount);
+
+        env.events().publish(
+            (Symbol::new(&env, "refund_partial"), c.owner.clone()),
+            (commitment_id, refund_amount, penalty, remaining),
+        );
         Ok(refund_amount)
     }
 
@@ -701,6 +805,42 @@ impl EscrowContract {
         Ok(())
     }
 
+    /// Set the minimum compliance score threshold. Any `record_attestation` call
+    /// that records a score strictly below this value will automatically transition
+    /// the commitment from `Funded` to `Violated`, freezing release and refund until
+    /// the admin resolves it via `resolve_dispute`.
+    ///
+    /// Admin only. A threshold of 0 disables auto-violation.
+    ///
+    /// # Arguments
+    /// * `threshold` - Score threshold 0..=100 (0 = disabled, 60 = violate below 60).
+    pub fn set_violation_threshold(env: Env, threshold: u32) -> Result<(), Error> {
+        Self::require_init(&env)?;
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+        let clamped = threshold.min(100);
+        env.storage()
+            .instance()
+            .set(&DataKey::ViolationThreshold, &clamped);
+        env.events()
+            .publish((Symbol::new(&env, "set_violation_threshold"), admin), clamped);
+        Ok(())
+    }
+
+    /// Return the current violation threshold (0..=100). A compliance score
+    /// strictly below this value triggers auto-violation on attestation.
+    /// Returns 0 if no threshold has been configured (auto-violation disabled).
+    pub fn get_violation_threshold(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ViolationThreshold)
+            .unwrap_or(0)
+    }
+
     /// Record a compliance attestation (0..=100) against a commitment. Mirrors
     /// the attestation engine integration used by the backend.
     pub fn record_attestation(
@@ -714,6 +854,21 @@ impl EscrowContract {
         let mut c = Self::load(&env, commitment_id)?;
         let score = compliance_score.min(100);
         c.compliance_score = score;
+
+        // Auto-violate a funded commitment when the score drops below the threshold.
+        let threshold: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ViolationThreshold)
+            .unwrap_or(0);
+        if threshold > 0 && score < threshold && c.status == EscrowStatus::Funded {
+            c.status = EscrowStatus::Violated;
+            env.events().publish(
+                (Symbol::new(&env, "commitment_violated"), attestor.clone()),
+                (commitment_id, score, threshold),
+            );
+        }
+
         Self::save(&env, &c);
 
         let mut attestations: Vec<AttestationRecord> = env
@@ -785,6 +940,9 @@ impl EscrowContract {
         env: &Env,
         mut c: Commitment,
     ) -> Result<(i128, i128), Error> {
+        if c.status == EscrowStatus::Violated {
+            return Err(Error::CommitmentViolated);
+        }
         if c.status != EscrowStatus::Funded {
             return Err(Error::InvalidState);
         }
@@ -847,15 +1005,8 @@ impl EscrowContract {
         id
     }
 
-    fn is_paused(env: &Env) -> bool {
-        env.storage()
-            .instance()
-            .get(&DataKey::Paused)
-            .unwrap_or(false)
-    }
-
     fn require_not_paused(env: &Env) -> Result<(), Error> {
-        if Self::is_paused(env) {
+        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
             return Err(Error::Paused);
         }
         Ok(())

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -930,9 +930,315 @@ fn explicit_penalty_override_zero_is_valid() {
 
     let commitment = f.client.get_commitment(&id);
     assert_eq!(commitment.penalty_bps, 0);
-    
+
     // Fund and refund should return full amount.
     f.client.fund_escrow(&id);
     let refunded = f.client.refund(&id);
     assert_eq!(refunded, 1_000); // No penalty deducted
+}
+
+// ── Issue #462: partial early-exit (refund_partial) ────────────────────────
+
+#[test]
+fn refund_partial_applies_penalty_to_withdrawn_portion_only() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+    // 10% penalty for easy arithmetic.
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Aggressive, &30, &1_000);
+    f.client.fund_escrow(&id);
+
+    // Withdraw 400 out of 1000. Penalty = 400 * 10% = 40. Net = 360.
+    let net = f.client.refund_partial(&id, &400);
+    assert_eq!(net, 360);
+    assert_eq!(f.token.balance(&owner), 360);
+    assert_eq!(f.token.balance(&f.fee_recipient), 40);
+
+    // Remaining principal is 600 and commitment stays Funded.
+    let c = f.client.get_commitment(&id);
+    assert_eq!(c.amount, 600);
+    assert_eq!(c.status, EscrowStatus::Funded);
+}
+
+#[test]
+fn refund_partial_full_amount_transitions_to_refunded() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+    // 5% penalty (500 bps).
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Aggressive, &30, &500);
+    f.client.fund_escrow(&id);
+
+    // Withdraw the entire principal in one partial call.
+    let net = f.client.refund_partial(&id, &1_000);
+    assert_eq!(net, 950);
+    assert_eq!(f.token.balance(&owner), 950);
+    assert_eq!(f.token.balance(&f.fee_recipient), 50);
+
+    let c = f.client.get_commitment(&id);
+    assert_eq!(c.amount, 0);
+    assert_eq!(c.status, EscrowStatus::Refunded);
+}
+
+#[test]
+fn refund_partial_multiple_withdrawals_reduce_amount_cumulatively() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+    // 0% penalty for simpler balance tracking.
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Safe, &30, &0);
+    f.client.fund_escrow(&id);
+
+    f.client.refund_partial(&id, &300);
+    assert_eq!(f.client.get_commitment(&id).amount, 700);
+
+    f.client.refund_partial(&id, &200);
+    assert_eq!(f.client.get_commitment(&id).amount, 500);
+
+    assert_eq!(f.token.balance(&owner), 500); // 300 + 200 returned
+    assert_eq!(f.client.get_commitment(&id).status, EscrowStatus::Funded);
+}
+
+#[test]
+fn refund_partial_rejects_amount_exceeding_balance() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Safe, &30, &200);
+    f.client.fund_escrow(&id);
+
+    let res = f.client.try_refund_partial(&id, &1_001);
+    assert_eq!(res, Err(Ok(Error::InvalidAmount)));
+}
+
+#[test]
+fn refund_partial_rejects_zero_amount() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Safe, &30, &200);
+    f.client.fund_escrow(&id);
+
+    let res = f.client.try_refund_partial(&id, &0);
+    assert_eq!(res, Err(Ok(Error::InvalidAmount)));
+}
+
+#[test]
+fn refund_partial_rejects_unfunded_commitment() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Safe, &30, &200);
+    // Not funded yet.
+    let res = f.client.try_refund_partial(&id, &500);
+    assert_eq!(res, Err(Ok(Error::InvalidState)));
+}
+
+#[test]
+fn refund_partial_matches_full_refund_when_withdrawing_entire_principal() {
+    // Partial withdrawal of the full amount must produce the same net payout
+    // and fee as calling the regular refund entrypoint.
+    let f = setup();
+    let owner_a = Address::generate(&f.env);
+    let owner_b = Address::generate(&f.env);
+    fund_owner(&f, &owner_a, 1_000);
+    fund_owner(&f, &owner_b, 1_000);
+    const PENALTY: u32 = 300;
+
+    let id_a = f
+        .client
+        .create_commitment(&owner_a, &f.asset, &1_000, &RiskProfile::Balanced, &30, &PENALTY);
+    f.client.fund_escrow(&id_a);
+    let full_refund = f.client.refund(&id_a);
+
+    let id_b = f
+        .client
+        .create_commitment(&owner_b, &f.asset, &1_000, &RiskProfile::Balanced, &30, &PENALTY);
+    f.client.fund_escrow(&id_b);
+    let partial_full = f.client.refund_partial(&id_b, &1_000);
+
+    assert_eq!(full_refund, partial_full);
+}
+
+// ── Issue #465: violation auto-trigger ─────────────────────────────────────
+
+#[test]
+fn set_and_get_violation_threshold() {
+    let f = setup();
+    // Default is 0 (disabled).
+    assert_eq!(f.client.get_violation_threshold(), 0);
+
+    f.client.set_violation_threshold(&60);
+    assert_eq!(f.client.get_violation_threshold(), 60);
+}
+
+#[test]
+fn set_violation_threshold_clamps_to_100() {
+    let f = setup();
+    f.client.set_violation_threshold(&150);
+    assert_eq!(f.client.get_violation_threshold(), 100);
+}
+
+#[test]
+fn attestation_below_threshold_auto_violates_funded_commitment() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    let attestor = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+
+    f.client.set_violation_threshold(&60);
+
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Balanced, &30, &300);
+    f.client.fund_escrow(&id);
+
+    // Score of 59 is strictly below threshold of 60 — must violate.
+    f.client.record_attestation(&id, &attestor, &59);
+    assert_eq!(f.client.get_commitment(&id).status, EscrowStatus::Violated);
+    assert_eq!(f.client.get_commitment(&id).compliance_score, 59);
+}
+
+#[test]
+fn attestation_at_threshold_does_not_violate() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    let attestor = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+
+    f.client.set_violation_threshold(&60);
+
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Balanced, &30, &300);
+    f.client.fund_escrow(&id);
+
+    // Score exactly at the threshold must NOT violate.
+    f.client.record_attestation(&id, &attestor, &60);
+    assert_eq!(f.client.get_commitment(&id).status, EscrowStatus::Funded);
+}
+
+#[test]
+fn attestation_above_threshold_does_not_violate() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    let attestor = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+
+    f.client.set_violation_threshold(&60);
+
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Safe, &30, &200);
+    f.client.fund_escrow(&id);
+
+    f.client.record_attestation(&id, &attestor, &80);
+    assert_eq!(f.client.get_commitment(&id).status, EscrowStatus::Funded);
+}
+
+#[test]
+fn zero_threshold_disables_auto_violation() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    let attestor = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+
+    // Threshold defaults to 0 — no auto-violation even for score 0.
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Safe, &30, &200);
+    f.client.fund_escrow(&id);
+
+    f.client.record_attestation(&id, &attestor, &0);
+    assert_eq!(f.client.get_commitment(&id).status, EscrowStatus::Funded);
+}
+
+#[test]
+fn violated_commitment_blocks_release() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    let attestor = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+
+    f.client.set_violation_threshold(&60);
+
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Balanced, &30, &300);
+    f.client.fund_escrow(&id);
+    f.client.record_attestation(&id, &attestor, &40);
+    assert_eq!(f.client.get_commitment(&id).status, EscrowStatus::Violated);
+
+    // Advance past maturity — release must still be blocked.
+    f.env.ledger().set_timestamp(31 * 86_400);
+    let res = f.client.try_release(&id);
+    assert_eq!(res, Err(Ok(Error::CommitmentViolated)));
+}
+
+#[test]
+fn violated_commitment_blocks_refund() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    let attestor = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+
+    f.client.set_violation_threshold(&60);
+
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Balanced, &30, &300);
+    f.client.fund_escrow(&id);
+    f.client.record_attestation(&id, &attestor, &40);
+
+    let res = f.client.try_refund(&id);
+    assert_eq!(res, Err(Ok(Error::CommitmentViolated)));
+}
+
+#[test]
+fn violated_commitment_blocks_refund_partial() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    let attestor = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+
+    f.client.set_violation_threshold(&60);
+
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Balanced, &30, &300);
+    f.client.fund_escrow(&id);
+    f.client.record_attestation(&id, &attestor, &40);
+
+    let res = f.client.try_refund_partial(&id, &500);
+    assert_eq!(res, Err(Ok(Error::CommitmentViolated)));
+}
+
+#[test]
+fn attestation_on_non_funded_commitment_does_not_violate() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    let attestor = Address::generate(&f.env);
+    fund_owner(&f, &owner, 1_000);
+
+    f.client.set_violation_threshold(&60);
+
+    // Commitment is Created, not Funded.
+    let id = f
+        .client
+        .create_commitment(&owner, &f.asset, &1_000, &RiskProfile::Safe, &30, &200);
+    f.client.record_attestation(&id, &attestor, &10);
+    // Status should remain Created, not Violated.
+    assert_eq!(f.client.get_commitment(&id).status, EscrowStatus::Created);
 }


### PR DESCRIPTION
feat: partial early-exit refunds and violation auto-trigger (#462, #465)

## Summary

close #462 — refund_partial entrypoint

Adds `refund_partial(commitment_id, amount)` to the escrow contract. The owner
can now withdraw a fraction of their locked principal before maturity. Only the
withdrawn portion is penalised; the remainder stays escrowed under the same
commitment and its status stays `Funded`. Withdrawing the entire stored principal
in a single partial call behaves identically to the existing `refund` entrypoint
and transitions the commitment to `Refunded`.

Key implementation details:
- `amount` must be > 0 and ≤ `Commitment.amount`; `InvalidAmount` is returned
  otherwise.
- `penalty = amount * penalty_bps / 10_000` — penalty applies only to the
  withdrawn slice.
- `Commitment.amount` is updated in storage before any token transfers
  (checks-effects-interactions).
- Blocked with `CommitmentViolated` when status is `Violated` (integrates with
  #465 below).
- Emits a `refund_partial` event with `(commitment_id, refund_amount, penalty,
  remaining)`.

closes #465 — violation auto-trigger on sub-threshold attestation

Adds a `Violated` variant to `EscrowStatus` and a configurable compliance score
threshold. When `record_attestation` records a score **strictly below** the
threshold for a `Funded` commitment, the commitment transitions to `Violated`
and a `commitment_violated` event is emitted. While violated, `release`,
`refund`, and `refund_partial` all return `CommitmentViolated`.

New entrypoints:
- `set_violation_threshold(threshold)` — admin-only; clamps input to 0–100. A
  value of `0` (default) disables auto-violation entirely.
- `get_violation_threshold()` — public read of the current threshold.

Threshold boundary rule: score **equal to** the threshold does **not** violate;
only scores **strictly less than** the threshold do. Auto-violation applies only
to `Funded` commitments; attestations on `Created`, `Released`, `Refunded`, or
`Disputed` commitments are recorded but do not change status.

### Supporting fixes included with the above features

To make the new code compile against the existing codebase the following
pre-existing gaps were resolved:
- `DataKey`: added `Paused`, `YieldPool`, `Attestations(u64)`,
  `ViolationThreshold` variants (already referenced by existing code).
- `Error`: added `AssetMismatch = 11`, `InsufficientYieldPool = 12`,
  `InvalidWasmHash = 13`, `CommitmentViolated = 14` (first three already
  referenced by existing code).
- `AttestationRecord` struct defined (already referenced by `record_attestation`
  and `get_attestations`).
- `create_commitment`: added missing `accrued_yield: 0` field initialiser.
- Removed duplicate private `is_paused(env: &Env)` helper that conflicted with
  the public `is_paused(env: Env)` method; `require_not_paused` now inlines the
  check directly.

## Tests added

**#462 — refund_partial (6 tests):**
- `refund_partial_applies_penalty_to_withdrawn_portion_only`
- `refund_partial_full_amount_transitions_to_refunded`
- `refund_partial_multiple_withdrawals_reduce_amount_cumulatively`
- `refund_partial_rejects_amount_exceeding_balance`
- `refund_partial_rejects_zero_amount`
- `refund_partial_rejects_unfunded_commitment`
- `refund_partial_matches_full_refund_when_withdrawing_entire_principal`

**#465 — violation auto-trigger (9 tests):**
- `set_and_get_violation_threshold`
- `set_violation_threshold_clamps_to_100`
- `attestation_below_threshold_auto_violates_funded_commitment`
- `attestation_at_threshold_does_not_violate`
- `attestation_above_threshold_does_not_violate`
- `zero_threshold_disables_auto_violation`
- `violated_commitment_blocks_release`
- `violated_commitment_blocks_refund`
- `violated_commitment_blocks_refund_partial`
- `attestation_on_non_funded_commitment_does_not_violate`

## Documentation

`contracts/README.md` updated with:
- New entries in the public functions table for `refund_partial`,
  `set_violation_threshold`, and `get_violation_threshold`.
- Dedicated sections documenting the partial early-exit flow with worked
  arithmetic examples and the violation auto-trigger boundary rule.
- Updated error code list to include all four new `Error` variants.

closes #462
closes #465
