### PR TITLE
feat: add threshold zones and accessible annotations to VolatilityExposureMeter

### DIFF
--- a/docs/accessibility-dense-ui.md
+++ b/docs/accessibility-dense-ui.md
@@ -161,3 +161,51 @@ Before committing UI changes involving tables or dense data, verify the followin
 ---
 
 _Created as part of Issue #237. Review this guide when building new dashboard components or marketplace tables._
+
+## 8. VolatilityExposureMeter Threshold Zones
+
+The `VolatilityExposureMeter` component divides the 0–100% exposure range into three named threshold bands that align with the `CommitmentType` risk tiers used across the creation wizard.
+
+### Threshold Definitions
+
+| Band    | Range    | CommitmentType | Badge Color |
+| :------ | :------- | :------------- | :---------- |
+| Safe    | 0–33%    | Safe           | Green       |
+| Caution | 34–66%   | Balanced       | Orange      |
+| Danger  | 67–100%  | Aggressive     | Red         |
+
+### Accessibility Requirements
+
+- **Non-color annotation**: Each band is identified by a textual badge (`Safe`, `Caution`, `Danger`) rendered next to the percentage value. Color is supplementary, not the sole indicator.
+- **ARIA meter**: The bar uses `role="meter"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and `aria-valuetext`. The `aria-valuetext` includes the band name, e.g. `"67 percent, Danger zone"`.
+- **Tooltip**: An info button (`ⓘ`) expands a `role="tooltip"` panel explaining what the current band means and which commitment profile it aligns with. The button carries `aria-label="What does [Band] exposure mean?"` and `aria-expanded`.
+- **Screen-reader-only text**: The `.srOnly` CSS utility hides supplementary text visually while keeping it available to assistive technology.
+
+### Implementation Example
+
+```tsx
+<div
+  role="meter"
+  aria-valuenow={67}
+  aria-valuemin={0}
+  aria-valuemax={100}
+  aria-label="Volatility Exposure meter"
+  aria-valuetext="67 percent, Danger zone"
+>
+  …
+</div>
+<span className={styles.bandBadge}>Danger</span>
+```
+
+### Exported Utilities
+
+The following are exported from `VolatilityExposureMeter.tsx` for reuse and testing:
+
+- `clamp(value)` – Clamps a number to [0, 100].
+- `getThresholdBand(percent)` – Returns `'safe' | 'caution' | 'danger'`.
+- `THRESHOLDS` – `{ SAFE_MAX: 33, CAUTION_MAX: 66 }`.
+- `BAND_LABELS` – Human-readable label per band.
+- `BAND_TOOLTIPS` – Tooltip copy per band.
+- `RISK_PROFILE_BAND` – Maps `CommitmentType` strings to bands.
+
+_Added as part of Issue #490._

--- a/src/components/VolatilityExposureMeter/VolatilityExposureMeter.module.css
+++ b/src/components/VolatilityExposureMeter/VolatilityExposureMeter.module.css
@@ -20,10 +20,75 @@
   margin: 0;
 }
 
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .percentLabel {
   font-size: 1.125rem;
   font-weight: 700;
   color: #0FF0FC;
+}
+
+/* Threshold band badge */
+.bandBadge {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.band_safe {
+  background: rgba(0, 201, 80, 0.15);
+  color: #00C950;
+  border: 1px solid rgba(0, 201, 80, 0.3);
+}
+
+.band_caution {
+  background: rgba(255, 105, 0, 0.15);
+  color: #FF6900;
+  border: 1px solid rgba(255, 105, 0, 0.3);
+}
+
+.band_danger {
+  background: rgba(251, 44, 54, 0.15);
+  color: #FB2C36;
+  border: 1px solid rgba(251, 44, 54, 0.3);
+}
+
+/* Threshold band markers above the bar */
+.thresholdBands {
+  display: flex;
+  width: 100%;
+  height: 4px;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 4px;
+  gap: 2px;
+}
+
+.band {
+  height: 100%;
+  border-radius: 2px;
+}
+
+.bandSafe {
+  width: 33%;
+  background: rgba(0, 201, 80, 0.35);
+}
+
+.bandCaution {
+  width: 33%;
+  background: rgba(255, 105, 0, 0.35);
+}
+
+.bandDanger {
+  width: 34%;
+  background: rgba(251, 44, 54, 0.35);
 }
 
 .barTrack {
@@ -31,7 +96,7 @@
   width: 100%;
   height: 12px;
   border-radius: 8px;
-  background: #1a1a1a; /* Dark background for empty part */
+  background: #1a1a1a;
   overflow: hidden;
   margin-bottom: 8px;
 }
@@ -42,16 +107,15 @@
   top: 0;
   bottom: 0;
   border-radius: 8px;
-  overflow: hidden; /* Clips the gradient */
+  overflow: hidden;
   transition: width 300ms ease-out;
 }
 
 .barGradient {
-  width: 100vw; /* Ensure wide enough to cover the mask */
-  max-width: 600px; /* Or responsive constraint */
+  width: 100vw;
+  max-width: 600px;
   height: 100%;
   border-radius: 8px;
-  /* Specific gradient from Green -> Orange -> Red matching design */
   background: linear-gradient(
     90deg,
     #00C950 0%,
@@ -59,6 +123,7 @@
     #FB2C36 100%
   );
 }
+
 .labelsRow {
   display: flex;
   justify-content: space-between;
@@ -69,11 +134,69 @@
   margin-top: 4px;
 }
 
+/* Tooltip */
+.tooltipWrapper {
+  position: relative;
+  display: inline-block;
+  margin-top: 0.5rem;
+}
+
+.tooltipTrigger {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.875rem;
+  padding: 0;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.tooltipTrigger:hover,
+.tooltipTrigger:focus-visible {
+  color: rgba(255, 255, 255, 0.8);
+  outline: 2px solid rgba(15, 240, 252, 0.5);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.tooltip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  background: #1e1e1e;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.8);
+  line-height: 1.5;
+  white-space: normal;
+  width: 220px;
+  z-index: 10;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
 .description {
   font-size: 0.8125rem;
   color: rgba(255, 255, 255, 0.6);
   line-height: 1.45;
   margin: 0.75rem 0 0 0;
+}
+
+/* Screen-reader only utility */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 @media (max-width: 520px) {

--- a/src/components/VolatilityExposureMeter/VolatilityExposureMeter.tsx
+++ b/src/components/VolatilityExposureMeter/VolatilityExposureMeter.tsx
@@ -1,6 +1,23 @@
 'use client'
 
+import { useState } from 'react'
 import styles from './VolatilityExposureMeter.module.css'
+import {
+  clamp,
+  getThresholdBand,
+  BAND_LABELS,
+  BAND_TOOLTIPS,
+} from './thresholds'
+
+export type { ThresholdBand } from './thresholds'
+export {
+  clamp,
+  getThresholdBand,
+  THRESHOLDS,
+  BAND_LABELS,
+  BAND_TOOLTIPS,
+  RISK_PROFILE_BAND,
+} from './thresholds'
 
 export interface VolatilityExposureMeterProps {
   /** Current exposure as a percentage (0–100). Clamped when rendering. */
@@ -9,24 +26,16 @@ export interface VolatilityExposureMeterProps {
   description?: string
 }
 
-function clamp(value: number): number {
-  if (typeof value !== 'number' || Number.isNaN(value)) return 0
-  return Math.max(0, Math.min(100, value))
-}
-
-function exposureLevel(percent: number): 'low' | 'medium' | 'high' {
-  if (percent <= 33) return 'low'
-  if (percent <= 66) return 'medium'
-  return 'high'
-}
-
 export default function VolatilityExposureMeter({
   valuePercent,
   description,
 }: VolatilityExposureMeterProps) {
+  const [tooltipVisible, setTooltipVisible] = useState(false)
   const percent = clamp(valuePercent)
-  const level = exposureLevel(percent)
-  const ariaLabel = `Volatility exposure: ${percent}%, ${level} range.`
+  const band = getThresholdBand(percent)
+  const bandLabel = BAND_LABELS[band]
+  const tooltipText = BAND_TOOLTIPS[band]
+  const ariaValueText = `${Math.round(percent)} percent, ${bandLabel} zone`
 
   return (
     <section
@@ -38,30 +47,67 @@ export default function VolatilityExposureMeter({
         <h2 id="volatility-exposure-title" className={styles.title}>
           Volatility Exposure
         </h2>
-        <span className={styles.percentLabel}>{Math.round(percent)}%</span>
+        <div className={styles.headerRight}>
+          <span className={`${styles.bandBadge} ${styles[`band_${band}`]}`}>
+            {bandLabel}
+          </span>
+          <span className={styles.percentLabel}>{Math.round(percent)}%</span>
+        </div>
+      </div>
+
+      {/* Threshold band markers */}
+      <div className={styles.thresholdBands} aria-hidden="true">
+        <div className={`${styles.band} ${styles.bandSafe}`} />
+        <div className={`${styles.band} ${styles.bandCaution}`} />
+        <div className={`${styles.band} ${styles.bandDanger}`} />
       </div>
 
       <div
         className={styles.barTrack}
         role="meter"
-        aria-valuenow={percent}
+        aria-valuenow={Math.round(percent)}
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-label={ariaLabel}
-        aria-valuetext={`${percent} percent, ${level}`}
+        aria-label="Volatility Exposure meter"
+        aria-valuetext={ariaValueText}
       >
         <div
           className={styles.barMask}
           style={{ width: `${percent}%` }}
         >
-             <div className={styles.barGradient} />
+          <div className={styles.barGradient} />
         </div>
       </div>
 
       <div className={styles.labelsRow}>
-        <span>Low</span>
-        <span>Medium</span>
-        <span>High</span>
+        <span>Low (Safe)</span>
+        <span>Medium (Caution)</span>
+        <span>High (Danger)</span>
+      </div>
+
+      {/* Tooltip trigger */}
+      <div className={styles.tooltipWrapper}>
+        <button
+          type="button"
+          className={styles.tooltipTrigger}
+          aria-label={`What does ${bandLabel} exposure mean?`}
+          aria-expanded={tooltipVisible}
+          aria-controls="volatility-tooltip"
+          onClick={() => setTooltipVisible((v) => !v)}
+          onBlur={() => setTooltipVisible(false)}
+        >
+          <span aria-hidden="true">ⓘ</span>
+          <span className={styles.srOnly}>Exposure zone info</span>
+        </button>
+        {tooltipVisible && (
+          <div
+            id="volatility-tooltip"
+            role="tooltip"
+            className={styles.tooltip}
+          >
+            {tooltipText}
+          </div>
+        )}
       </div>
 
       {description && (

--- a/src/components/VolatilityExposureMeter/thresholds.ts
+++ b/src/components/VolatilityExposureMeter/thresholds.ts
@@ -1,0 +1,45 @@
+/**
+ * Threshold zone logic for VolatilityExposureMeter.
+ * Exported separately so pure-logic tests can import without JSX.
+ */
+
+/** Threshold band boundaries aligned with RiskProfile tiers. */
+export const THRESHOLDS = {
+  SAFE_MAX: 33,
+  CAUTION_MAX: 66,
+} as const
+
+export type ThresholdBand = 'safe' | 'caution' | 'danger'
+
+/** Maps CommitmentType tiers to threshold bands. */
+export const RISK_PROFILE_BAND: Record<string, ThresholdBand> = {
+  Safe: 'safe',
+  Balanced: 'caution',
+  Aggressive: 'danger',
+}
+
+export const BAND_LABELS: Record<ThresholdBand, string> = {
+  safe: 'Safe',
+  caution: 'Caution',
+  danger: 'Danger',
+}
+
+export const BAND_TOOLTIPS: Record<ThresholdBand, string> = {
+  safe:
+    'Exposure is within the Safe tier (0–33%). Aligns with a Safe commitment profile.',
+  caution:
+    'Exposure is in the Caution tier (34–66%). Aligns with a Balanced commitment profile.',
+  danger:
+    'Exposure is in the Danger tier (67–100%). Aligns with an Aggressive commitment profile.',
+}
+
+export function clamp(value: number): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) return 0
+  return Math.max(0, Math.min(100, value))
+}
+
+export function getThresholdBand(percent: number): ThresholdBand {
+  if (percent <= THRESHOLDS.SAFE_MAX) return 'safe'
+  if (percent <= THRESHOLDS.CAUTION_MAX) return 'caution'
+  return 'danger'
+}

--- a/tests/components/VolatilityExposureMeter.test.ts
+++ b/tests/components/VolatilityExposureMeter.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import {
+  clamp,
+  getThresholdBand,
+  THRESHOLDS,
+  BAND_LABELS,
+  BAND_TOOLTIPS,
+  RISK_PROFILE_BAND,
+} from '@/components/VolatilityExposureMeter/thresholds'
+
+describe('clamp', () => {
+  it('returns 0 for NaN', () => {
+    expect(clamp(NaN)).toBe(0)
+  })
+
+  it('returns 0 for non-number', () => {
+    expect(clamp('abc' as unknown as number)).toBe(0)
+  })
+
+  it('clamps negative values to 0', () => {
+    expect(clamp(-10)).toBe(0)
+  })
+
+  it('clamps values above 100 to 100', () => {
+    expect(clamp(150)).toBe(100)
+  })
+
+  it('passes through values within range', () => {
+    expect(clamp(0)).toBe(0)
+    expect(clamp(50)).toBe(50)
+    expect(clamp(100)).toBe(100)
+  })
+})
+
+describe('getThresholdBand', () => {
+  it('returns "safe" for 0', () => {
+    expect(getThresholdBand(0)).toBe('safe')
+  })
+
+  it('returns "safe" at the safe boundary (33)', () => {
+    expect(getThresholdBand(THRESHOLDS.SAFE_MAX)).toBe('safe')
+  })
+
+  it('returns "caution" just above the safe boundary (34)', () => {
+    expect(getThresholdBand(34)).toBe('caution')
+  })
+
+  it('returns "caution" at the caution boundary (66)', () => {
+    expect(getThresholdBand(THRESHOLDS.CAUTION_MAX)).toBe('caution')
+  })
+
+  it('returns "danger" just above the caution boundary (67)', () => {
+    expect(getThresholdBand(67)).toBe('danger')
+  })
+
+  it('returns "danger" at 100', () => {
+    expect(getThresholdBand(100)).toBe('danger')
+  })
+
+  it('returns "safe" for mid-safe range (16)', () => {
+    expect(getThresholdBand(16)).toBe('safe')
+  })
+
+  it('returns "caution" for mid-caution range (50)', () => {
+    expect(getThresholdBand(50)).toBe('caution')
+  })
+
+  it('returns "danger" for mid-danger range (85)', () => {
+    expect(getThresholdBand(85)).toBe('danger')
+  })
+})
+
+describe('BAND_LABELS', () => {
+  it('has a label for each band', () => {
+    expect(BAND_LABELS.safe).toBe('Safe')
+    expect(BAND_LABELS.caution).toBe('Caution')
+    expect(BAND_LABELS.danger).toBe('Danger')
+  })
+})
+
+describe('BAND_TOOLTIPS', () => {
+  it('has a tooltip for each band', () => {
+    expect(BAND_TOOLTIPS.safe).toContain('Safe tier')
+    expect(BAND_TOOLTIPS.caution).toContain('Caution tier')
+    expect(BAND_TOOLTIPS.danger).toContain('Danger tier')
+  })
+
+  it('safe tooltip mentions 0–33%', () => {
+    expect(BAND_TOOLTIPS.safe).toContain('0–33%')
+  })
+
+  it('caution tooltip mentions 34–66%', () => {
+    expect(BAND_TOOLTIPS.caution).toContain('34–66%')
+  })
+
+  it('danger tooltip mentions 67–100%', () => {
+    expect(BAND_TOOLTIPS.danger).toContain('67–100%')
+  })
+})
+
+describe('RISK_PROFILE_BAND alignment', () => {
+  it('maps Safe commitment type to safe band', () => {
+    expect(RISK_PROFILE_BAND['Safe']).toBe('safe')
+  })
+
+  it('maps Balanced commitment type to caution band', () => {
+    expect(RISK_PROFILE_BAND['Balanced']).toBe('caution')
+  })
+
+  it('maps Aggressive commitment type to danger band', () => {
+    expect(RISK_PROFILE_BAND['Aggressive']).toBe('danger')
+  })
+})
+
+describe('threshold boundary consistency', () => {
+  it('safe band covers 0 to SAFE_MAX inclusive', () => {
+    for (let i = 0; i <= THRESHOLDS.SAFE_MAX; i++) {
+      expect(getThresholdBand(i)).toBe('safe')
+    }
+  })
+
+  it('caution band covers SAFE_MAX+1 to CAUTION_MAX inclusive', () => {
+    for (let i = THRESHOLDS.SAFE_MAX + 1; i <= THRESHOLDS.CAUTION_MAX; i++) {
+      expect(getThresholdBand(i)).toBe('caution')
+    }
+  })
+
+  it('danger band covers CAUTION_MAX+1 to 100 inclusive', () => {
+    for (let i = THRESHOLDS.CAUTION_MAX + 1; i <= 100; i++) {
+      expect(getThresholdBand(i)).toBe('danger')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Resolves #490

Adds colored threshold bands, non-color textual annotations, a tooltip, and improved ARIA semantics to `VolatilityExposureMeter`.

## Changes

### `src/components/VolatilityExposureMeter/thresholds.ts` (new)
Pure logic module extracted for testability:
- `clamp(value)` — clamps to [0, 100]
- `getThresholdBand(percent)` — returns `'safe' | 'caution' | 'danger'`
- `THRESHOLDS` — `{ SAFE_MAX: 33, CAUTION_MAX: 66 }`
- `BAND_LABELS`, `BAND_TOOLTIPS`, `RISK_PROFILE_BAND`

### `VolatilityExposureMeter.tsx`
- Threshold band marker strip above the bar (aria-hidden, visual only)
- Textual band badge (`Safe` / `Caution` / `Danger`) next to the percentage — satisfies non-color-only requirement
- Tooltip button (`ⓘ`) with `aria-expanded`, `aria-controls`, and `role="tooltip"` panel explaining the current band and its `CommitmentType` alignment
- `aria-valuetext` now includes band name: `"67 percent, Danger zone"`
- `.srOnly` utility for screen-reader-only text

### `VolatilityExposureMeter.module.css`
- Band badge styles (green/orange/red with matching borders)
- Threshold band marker strip styles
- Tooltip and trigger styles with focus-visible outline

### `tests/components/VolatilityExposureMeter.test.ts` (new)
25 unit tests covering:
- `clamp`: NaN, non-number, negative, overflow, in-range
- `getThresholdBand`: boundaries, midpoints, all three bands
- `BAND_LABELS` and `BAND_TOOLTIPS` content
- `RISK_PROFILE_BAND` mapping for all three `CommitmentType` values
- Full boundary sweep (0–100) for each band

### `docs/accessibility-dense-ui.md`
New section 8 documenting threshold definitions, ARIA requirements, implementation example, and exported utilities.

## Test output

```
Test Files  37 passed (37)
      Tests  649 passed (649)
```