### PR TITLE
feat: paginate owner commitment ids

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -133,7 +133,8 @@ create_commitment ──► fund_escrow ──► release
 | `unpause()` | Admin-only resume writes. |
 | `is_paused()` | Read pause state. |
 | `get_commitment(commitment_id)` | Read a single commitment. |
-| `get_owner_commitments(owner)` | List commitment ids for an owner. |
+| `get_owner_commitments(owner, start, limit)` | List a bounded page of commitment ids for an owner. |
+| `get_user_commitment_ids_page(owner, start, limit)` | Backend fallback reader for a bounded page of owner commitment ids. |
 | `get_attestations(commitment_id)` | Read historical attestation records. |
 | `get_default_penalty(risk)` | Read the default penalty for a risk profile. |
 | `set_admin(new_admin)` | Rotate the admin address. |
@@ -142,6 +143,12 @@ create_commitment ──► fund_escrow ──► release
 ### Attestation history
 
 Compliance scores recorded via `record_attestation` are appended to an on-chain historical log. Use `get_attestations` to retrieve the full timeline.
+
+### Owner commitment pagination
+
+Use `get_owner_commitments(owner, start, limit)` to read owner commitment ids in bounded pages. `start` is a zero-based offset into the owner's index and `limit` is clamped to the contract's maximum page size of 100 ids, so oversized client requests cannot return an unbounded payload. A zero `limit` or a `start` beyond the current index length returns an empty vector.
+
+`get_user_commitment_ids(owner)` remains available as a first-page backend fallback and returns at most 100 ids. Use `get_user_commitment_ids_page(owner, start, limit)` when callers need subsequent pages through the fallback naming path.
 
 ### `early_exit_commitment` entrypoint
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -42,6 +42,9 @@ const MAX_PENALTY_BPS: u32 = 10_000;
 /// simulation/result size limits.
 const MAX_USER_COMMITMENTS_READ: u32 = 100;
 
+/// Maximum number of owner commitment ids returned by a single paginated read.
+const MAX_OWNER_COMMITMENTS_PAGE_LIMIT: u32 = 100;
+
 /// Storage keys for persistent contract state.
 #[contracttype]
 #[derive(Clone)]
@@ -1333,21 +1336,41 @@ impl EscrowContract {
         commitments
     }
 
-    /// Return the list of commitment ids owned by an address using the backend's
-    /// fallback reader name.
+    /// Return the first bounded page of commitment ids owned by an address using
+    /// the backend's fallback reader name.
     pub fn get_user_commitment_ids(env: Env, owner: Address) -> Vec<u64> {
-        Self::owner_commitment_ids(&env, owner)
+        Self::owner_commitment_ids_page(&env, owner, 0, MAX_OWNER_COMMITMENTS_PAGE_LIMIT)
     }
 
-    /// Return the list of commitment ids owned by an address.
+    /// Return a paginated list of commitment ids owned by an address using the
+    /// backend's fallback reader name.
+    pub fn get_user_commitment_ids_page(
+        env: Env,
+        owner: Address,
+        start: u32,
+        limit: u32,
+    ) -> Vec<u64> {
+        Self::owner_commitment_ids_page(&env, owner, start, limit)
+    }
+
+    /// Return a bounded page of commitment ids owned by an address.
+    ///
+    /// `start` is a zero-based offset into the owner's commitment id index.
+    /// `limit` is clamped to `MAX_OWNER_COMMITMENTS_PAGE_LIMIT` so callers
+    /// cannot request an unbounded payload.
     ///
     /// # Authorization
     /// None; read-only operation
     ///
     /// # Returns
-    /// A vector of commitment ids owned by the address
-    pub fn get_owner_commitments(env: Env, owner: Address) -> Vec<u64> {
-        Self::owner_commitment_ids(&env, owner)
+    /// A vector of commitment ids owned by the address for the requested page
+    pub fn get_owner_commitments(
+        env: Env,
+        owner: Address,
+        start: u32,
+        limit: u32,
+    ) -> Vec<u64> {
+        Self::owner_commitment_ids_page(&env, owner, start, limit)
     }
 
     /// Retrieve the dispute record for a commitment. Returns `None` if no
@@ -1592,6 +1615,30 @@ impl EscrowContract {
             .persistent()
             .get(&DataKey::OwnerIndex(owner))
             .unwrap_or_else(|| Vec::new(env))
+    }
+
+    fn owner_commitment_ids_page(
+        env: &Env,
+        owner: Address,
+        start: u32,
+        limit: u32,
+    ) -> Vec<u64> {
+        let ids = Self::owner_commitment_ids(env, owner);
+        let capped_limit = limit.min(MAX_OWNER_COMMITMENTS_PAGE_LIMIT);
+        let mut page = Vec::new(env);
+
+        if capped_limit == 0 || start >= ids.len() {
+            return page;
+        }
+
+        let end = start.saturating_add(capped_limit).min(ids.len());
+        let mut index = start;
+        while index < end {
+            page.push_back(ids.get(index).unwrap());
+            index += 1;
+        }
+
+        page
     }
 
     /// Remove `id` from `owner`'s OwnerIndex list.

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -479,10 +479,84 @@ fn owner_index_tracks_commitments() {
     let b = f
         .client
         .create_commitment(&owner, &f.asset, &200, &RiskProfile::Balanced, &30, &300, &Map::new(&f.env));
-    let ids = f.client.get_owner_commitments(&owner);
+    let ids = f
+        .client
+        .get_owner_commitments(&owner, &0, &MAX_OWNER_COMMITMENTS_PAGE_LIMIT);
     assert_eq!(ids.len(), 2);
     assert_eq!(ids.get(0).unwrap(), a);
     assert_eq!(ids.get(1).unwrap(), b);
+}
+
+#[test]
+fn get_owner_commitments_pages_results() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+    let mut created_ids = Vec::new(&f.env);
+
+    for index in 0..5 {
+        let id = f.client.create_commitment(
+            &owner,
+            &f.asset,
+            &(100 + index as i128),
+            &RiskProfile::Safe,
+            &30,
+            &200,
+            &Map::new(&f.env),
+        );
+        created_ids.push_back(id);
+    }
+
+    let page = f.client.get_owner_commitments(&owner, &1, &2);
+
+    assert_eq!(page.len(), 2);
+    assert_eq!(page.get(0).unwrap(), created_ids.get(1).unwrap());
+    assert_eq!(page.get(1).unwrap(), created_ids.get(2).unwrap());
+}
+
+#[test]
+fn get_owner_commitments_caps_limit_and_handles_boundaries() {
+    let f = setup();
+    let owner = Address::generate(&f.env);
+
+    for index in 0..(MAX_OWNER_COMMITMENTS_PAGE_LIMIT + 5) {
+        f.client.create_commitment(
+            &owner,
+            &f.asset,
+            &(100 + index as i128),
+            &RiskProfile::Safe,
+            &30,
+            &200,
+            &Map::new(&f.env),
+        );
+    }
+
+    let capped = f.client.get_owner_commitments(
+        &owner,
+        &0,
+        &(MAX_OWNER_COMMITMENTS_PAGE_LIMIT + 5),
+    );
+    let tail = f.client.get_owner_commitments(
+        &owner,
+        &MAX_OWNER_COMMITMENTS_PAGE_LIMIT,
+        &10,
+    );
+    let empty_limit = f.client.get_owner_commitments(&owner, &0, &0);
+    let out_of_range = f.client.get_owner_commitments(
+        &owner,
+        &(MAX_OWNER_COMMITMENTS_PAGE_LIMIT + 5),
+        &10,
+    );
+
+    assert_eq!(capped.len(), MAX_OWNER_COMMITMENTS_PAGE_LIMIT);
+    assert_eq!(
+        capped.get(MAX_OWNER_COMMITMENTS_PAGE_LIMIT - 1).unwrap(),
+        MAX_OWNER_COMMITMENTS_PAGE_LIMIT as u64 - 1
+    );
+    assert_eq!(tail.len(), 5);
+    assert_eq!(tail.get(0).unwrap(), MAX_OWNER_COMMITMENTS_PAGE_LIMIT as u64);
+    assert_eq!(tail.get(4).unwrap(), MAX_OWNER_COMMITMENTS_PAGE_LIMIT as u64 + 4);
+    assert_eq!(empty_limit.len(), 0);
+    assert_eq!(out_of_range.len(), 0);
 }
 
 #[test]
@@ -544,10 +618,14 @@ fn get_user_commitments_is_bounded() {
     }
 
     let commitments = f.client.get_user_commitments(&owner);
-    let ids = f.client.get_user_commitment_ids(&owner);
+    let ids = f.client.get_user_commitment_ids_page(
+        &owner,
+        &0,
+        &(MAX_USER_COMMITMENTS_READ + 5),
+    );
 
     assert_eq!(commitments.len(), MAX_USER_COMMITMENTS_READ);
-    assert_eq!(ids.len(), MAX_USER_COMMITMENTS_READ + 5);
+    assert_eq!(ids.len(), MAX_OWNER_COMMITMENTS_PAGE_LIMIT);
     assert_eq!(commitments.get(0).unwrap().id, ids.get(0).unwrap());
     assert_eq!(
         commitments
@@ -693,4 +771,3 @@ fn owner_index_ttl_tracks_the_latest_commitment_maturity() {
         .as_contract(&f.contract_id, || f.env.storage().persistent().get_ttl(&DataKey::OwnerIndex(owner)));
     assert_eq!(owner_index_ttl, expected_ttl);
 }
-


### PR DESCRIPTION

Closes #476

Changes
Added pagination to get_owner_commitments(owner, start, limit) so owner commitment reads stay bounded.
Added get_user_commitment_ids_page(owner, start, limit) for the backend fallback path.
Kept get_user_commitment_ids(owner) as a first-page bounded reader.
Added boundary-focused tests for paging, zero limits, and out-of-range offsets.
Updated contracts/README.md to document the paginated API.
