### PR TITLE
test: cover SettlementModal reason mapping

### DIFF
--- a/tests/SettlementModal.test.tsx
+++ b/tests/SettlementModal.test.tsx
@@ -19,6 +19,17 @@ function renderSettlementModal(props: Partial<React.ComponentProps<typeof Settle
 }
 
 describe('SettlementModal ineligible reasons', () => {
+  it.each([
+    ['  commitment has NOT MATURED yet  ', 'not_matured'],
+    ['Commitment has already been settled', 'already_settled'],
+    ['Commitment is disputed and cannot be settled', 'disputed'],
+    ['Commitment was closed through early exit', 'early_exit'],
+    ['Unexpected settlement preflight response', 'unknown'],
+    [undefined, 'unknown'],
+  ] as const)('maps %s to %s copy', (reason, category) => {
+    expect(getSettlementIneligibleReasonCopy(reason).category).toBe(category);
+  });
+
   it('maps a not-matured reason to a temporary layout and details CTA', () => {
     renderSettlementModal({
       ineligibleReason: 'Commitment has not matured yet and cannot be settled.',


### PR DESCRIPTION
## Summary
- add table-driven coverage for every SettlementModal ineligible-reason category
- cover mixed-case and whitespace normalization for not-matured responses
- keep the change scoped to the existing production modal test file

Closes #589

## Verification
- `npm.cmd ci`
- `npm.cmd test -- tests/SettlementModal.test.tsx`
- `npx.cmd eslint tests/SettlementModal.test.tsx`
- `git diff --check`