### PR TITLE
feat: add settlement modal lifecycle states

### DIFF
--- a/src/components/modals/SettlementModal.tsx
+++ b/src/components/modals/SettlementModal.tsx
@@ -3,7 +3,8 @@
 import Link from 'next/link';
 import { AlertTriangle, CheckCircle2, Clock3, FileSearch, RotateCcw, X } from 'lucide-react';
 
-export type SettlementModalState = 'ineligible' | 'settled';
+export type SettlementModalState = 'eligible' | 'processing' | 'error' | 'ineligible' | 'settled';
+export type SettlementProcessingStep = 'initiating' | 'confirming' | 'finalizing';
 
 type SettlementReasonCategory = 'not_matured' | 'already_settled' | 'disputed' | 'early_exit' | 'unknown';
 
@@ -13,6 +14,11 @@ export interface SettlementModalProps {
   state: SettlementModalState;
   ineligibleReason?: string;
   settlementAmount?: string;
+  processingStep?: SettlementProcessingStep;
+  errorMessage?: string;
+  isSettlementActionDisabled?: boolean;
+  onConfirmSettlement?: () => void;
+  onRetrySettlement?: () => void;
   onReturnToDashboard: () => void;
   onClose?: () => void;
 }
@@ -35,6 +41,24 @@ const UNKNOWN_REASON_COPY: IneligibleReasonCopy = {
     'We could not match this settlement response to a known reason. Review the commitment details before trying again.',
   ctaLabel: 'Review commitment details',
 };
+
+const SETTLEMENT_PROGRESS_STEPS: Array<{ key: SettlementProcessingStep; label: string; description: string }> = [
+  {
+    key: 'initiating',
+    label: 'Initiating',
+    description: 'Preparing the settlement request.',
+  },
+  {
+    key: 'confirming',
+    label: 'Confirming on Stellar',
+    description: 'Waiting for the Stellar transaction to confirm.',
+  },
+  {
+    key: 'finalizing',
+    label: 'Finalizing',
+    description: 'Recording the final settlement state.',
+  },
+];
 
 export function getSettlementIneligibleReasonCopy(reason?: string): IneligibleReasonCopy {
   const normalizedReason = reason?.toLowerCase().trim() ?? '';
@@ -127,6 +151,11 @@ export default function SettlementModal({
   state,
   ineligibleReason,
   settlementAmount,
+  processingStep = 'initiating',
+  errorMessage,
+  isSettlementActionDisabled = false,
+  onConfirmSettlement,
+  onRetrySettlement,
   onReturnToDashboard,
   onClose,
 }: SettlementModalProps) {
@@ -136,9 +165,31 @@ export default function SettlementModal({
   const reasonCopy = getSettlementIneligibleReasonCopy(ineligibleReason);
   const toneClasses = getToneClasses(reasonCopy.tone);
   const ReasonIcon = toneClasses.icon;
-  const titleId = state === 'ineligible' ? 'settlement-ineligible-title' : 'settlement-success-title';
-  const descriptionId =
-    state === 'ineligible' ? 'settlement-ineligible-description' : 'settlement-success-description';
+  const titleId = `settlement-${state}-title`;
+  const descriptionId = `settlement-${state}-description`;
+  const processingStepIndex = SETTLEMENT_PROGRESS_STEPS.findIndex((step) => step.key === processingStep);
+  const activeProcessingIndex = processingStepIndex === -1 ? 0 : processingStepIndex;
+  const headerTitle = {
+    eligible: 'Ready to settle',
+    processing: 'Settlement in progress',
+    error: 'Settlement needs attention',
+    ineligible: 'Settlement unavailable',
+    settled: 'Settlement complete',
+  }[state];
+  const headerTone =
+    state === 'ineligible'
+      ? toneClasses
+      : state === 'error'
+        ? {
+            border: 'border-[#FF8A04]/30',
+            bg: 'bg-[#FF8A04]/10',
+            text: 'text-[#FF8A04]',
+          }
+        : {
+            border: 'border-[#0FF0FC]/30',
+            bg: 'bg-[#0FF0FC]/10',
+            text: 'text-[#0FF0FC]',
+          };
 
   return (
     <div
@@ -155,10 +206,14 @@ export default function SettlementModal({
         <div className="mb-7 flex items-start justify-between gap-4">
           <div className="flex items-center gap-4">
             <div
-              className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border ${toneClasses.border} ${toneClasses.bg}`}
+              className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border ${headerTone.border} ${headerTone.bg}`}
             >
               {state === 'ineligible' ? (
                 <ReasonIcon className={`h-7 w-7 ${toneClasses.text}`} aria-hidden="true" />
+              ) : state === 'processing' ? (
+                <Clock3 className="h-7 w-7 text-[#0FF0FC]" aria-hidden="true" />
+              ) : state === 'error' ? (
+                <AlertTriangle className="h-7 w-7 text-[#FF8A04]" aria-hidden="true" />
               ) : (
                 <CheckCircle2 className="h-7 w-7 text-[#0FF0FC]" aria-hidden="true" />
               )}
@@ -166,7 +221,7 @@ export default function SettlementModal({
             <div>
               <p className="mb-1 text-xs font-bold uppercase tracking-widest text-white/45">Settlement</p>
               <h2 id={titleId} className="text-2xl font-bold leading-tight text-white">
-                {state === 'ineligible' ? 'Settlement unavailable' : 'Settlement complete'}
+                {headerTitle}
               </h2>
             </div>
           </div>
@@ -232,6 +287,110 @@ export default function SettlementModal({
               >
                 {reasonCopy.ctaLabel}
               </Link>
+            </div>
+          </div>
+        ) : state === 'eligible' ? (
+          <div className="space-y-6">
+            <p id={descriptionId} className="text-sm leading-6 text-white/70">
+              This commitment is eligible for settlement. Review the previewed amount before starting the on-chain
+              settlement flow.
+            </p>
+
+            <div className="rounded-2xl border border-[#0FF0FC]/20 bg-[#0FF0FC]/10 p-5">
+              <p className="text-xs font-bold uppercase tracking-widest text-white/45">Previewed settlement amount</p>
+              <p className="mt-2 text-2xl font-bold text-[#0FF0FC]">{settlementAmount ?? 'Pending preview'}</p>
+              <p className="mt-3 text-sm leading-6 text-white/65">
+                This value should come from the settlement preview route before the user confirms settlement.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={onReturnToDashboard}
+                className="flex flex-1 items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-sm font-bold text-white transition hover:bg-white/10"
+              >
+                <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                Return to dashboard
+              </button>
+              <button
+                type="button"
+                onClick={onConfirmSettlement}
+                disabled={!onConfirmSettlement || isSettlementActionDisabled}
+                className="flex flex-1 items-center justify-center rounded-2xl bg-[#0FF0FC] px-5 py-4 text-sm font-bold text-black transition hover:bg-[#7df8ff] active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Confirm settlement
+              </button>
+            </div>
+          </div>
+        ) : state === 'processing' ? (
+          <div className="space-y-6">
+            <p id={descriptionId} className="text-sm leading-6 text-white/70">
+              Settlement is moving through the on-chain flow. Keep this window open until the final state is recorded.
+            </p>
+
+            <ol className="space-y-3" aria-label="Settlement progress">
+              {SETTLEMENT_PROGRESS_STEPS.map((step, index) => {
+                const isComplete = index < activeProcessingIndex;
+                const isActive = index === activeProcessingIndex;
+
+                return (
+                  <li
+                    key={step.key}
+                    className={`rounded-2xl border p-4 ${
+                      isActive
+                        ? 'border-[#0FF0FC]/30 bg-[#0FF0FC]/10'
+                        : isComplete
+                          ? 'border-white/10 bg-white/[0.04]'
+                          : 'border-white/[0.06] bg-white/[0.02]'
+                    }`}
+                  >
+                    <div className="flex items-start gap-3">
+                      <span
+                        className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
+                          isComplete || isActive ? 'bg-[#0FF0FC] text-black' : 'bg-white/10 text-white/45'
+                        }`}
+                        aria-hidden="true"
+                      >
+                        {isComplete ? 'OK' : index + 1}
+                      </span>
+                      <div>
+                        <p className="font-bold text-white">{step.label}</p>
+                        <p className="mt-1 text-sm leading-6 text-white/65">{step.description}</p>
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ol>
+          </div>
+        ) : state === 'error' ? (
+          <div className="space-y-6">
+            <div className="rounded-2xl border border-[#FF8A04]/30 bg-[#FF8A04]/10 p-5" role="alert">
+              <h3 className="mb-2 text-lg font-bold text-white">Settlement could not be completed</h3>
+              <p id={descriptionId} className="text-sm leading-6 text-white/75">
+                {errorMessage ??
+                  'The settlement flow stopped before reaching a final state. You can retry settlement or return to the dashboard.'}
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={onReturnToDashboard}
+                className="flex flex-1 items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-sm font-bold text-white transition hover:bg-white/10"
+              >
+                <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                Return to dashboard
+              </button>
+              <button
+                type="button"
+                onClick={onRetrySettlement}
+                disabled={!onRetrySettlement || isSettlementActionDisabled}
+                className="flex flex-1 items-center justify-center rounded-2xl bg-[#FF8A04] px-5 py-4 text-sm font-bold text-black transition hover:bg-[#ffad4d] active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Retry settlement
+              </button>
             </div>
           </div>
         ) : (

--- a/tests/SettlementModal.test.tsx
+++ b/tests/SettlementModal.test.tsx
@@ -157,12 +157,78 @@ describe('SettlementModal ineligible reasons', () => {
       onReturnToDashboard,
     });
 
-    expect(screen.getByRole('dialog').getAttribute('aria-labelledby')).toBe('settlement-success-title');
+    expect(screen.getByRole('dialog').getAttribute('aria-labelledby')).toBe('settlement-settled-title');
     expect(screen.getByText('Settlement complete')).toBeTruthy();
     expect(screen.getByText('100 XLM')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Return to dashboard' }));
 
+    expect(onReturnToDashboard).toHaveBeenCalledOnce();
+  });
+
+  it('renders an eligible confirmation state with the previewed settlement amount', () => {
+    const onConfirmSettlement = vi.fn();
+
+    renderSettlementModal({
+      state: 'eligible',
+      settlementAmount: '125 XLM',
+      onConfirmSettlement,
+    });
+
+    expect(screen.getByRole('dialog').getAttribute('aria-labelledby')).toBe('settlement-eligible-title');
+    expect(screen.getByText('Ready to settle')).toBeTruthy();
+    expect(screen.getByText('Previewed settlement amount')).toBeTruthy();
+    expect(screen.getByText('125 XLM')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm settlement' }));
+
+    expect(onConfirmSettlement).toHaveBeenCalledOnce();
+  });
+
+  it('disables eligible confirmation when no settlement handler is provided', () => {
+    renderSettlementModal({
+      state: 'eligible',
+      settlementAmount: '125 XLM',
+    });
+
+    expect(screen.getByRole('button', { name: 'Confirm settlement' }).hasAttribute('disabled')).toBe(true);
+  });
+
+  it.each([
+    ['initiating', 'Initiating'],
+    ['confirming', 'Confirming on Stellar'],
+    ['finalizing', 'Finalizing'],
+  ] as const)('renders the processing stepper at the %s step', (processingStep, label) => {
+    renderSettlementModal({
+      state: 'processing',
+      processingStep,
+    });
+
+    expect(screen.getByRole('dialog').getAttribute('aria-labelledby')).toBe('settlement-processing-title');
+    expect(screen.getByText('Settlement in progress')).toBeTruthy();
+    expect(screen.getByLabelText('Settlement progress')).toBeTruthy();
+    expect(screen.getByText(label)).toBeTruthy();
+  });
+
+  it('renders a recoverable error state with retry and dashboard actions', () => {
+    const onRetrySettlement = vi.fn();
+    const onReturnToDashboard = vi.fn();
+
+    renderSettlementModal({
+      state: 'error',
+      errorMessage: 'The transaction timed out before finalization.',
+      onRetrySettlement,
+      onReturnToDashboard,
+    });
+
+    expect(screen.getByRole('dialog').getAttribute('aria-labelledby')).toBe('settlement-error-title');
+    expect(screen.getByText('Settlement needs attention')).toBeTruthy();
+    expect(screen.getByText('The transaction timed out before finalization.')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry settlement' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Return to dashboard' }));
+
+    expect(onRetrySettlement).toHaveBeenCalledOnce();
     expect(onReturnToDashboard).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
Closes #580.

## Summary
- Extend `SettlementModalState` with `eligible`, `processing`, and `error` while preserving the existing `ineligible` and `settled` paths.
- Add an eligible confirmation view that displays the previewed settlement amount and exposes a confirm action.
- Add a 3-step processing indicator for Initiating, Confirming on Stellar, and Finalizing.
- Add a recoverable error view with retry and return-to-dashboard actions.
- Expand `tests/SettlementModal.test.tsx` to cover eligible, disabled confirmation, each processing step, error retry, settled, and existing ineligible reason mappings.

## Validation
- Static local checks confirmed both changed files are ASCII-only and include the new states.
- Could not run the full test command locally because this API-only workflow did not clone/install the project dependencies after GitHub clone timeouts; the PR includes focused test coverage for the requested modal states.