### PR TITLE
[codex] Harden Stellar explorer links

### DIFF
--- a/src/app/TransactionProgressModal.tsx
+++ b/src/app/TransactionProgressModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { buildExplorerUrl, openExplorerUrl } from '@/utils/explorerLinks';
 
 export type TransactionState =
   | 'IDLE'
@@ -86,6 +87,8 @@ export default function TransactionProgressModal({
   onSuccessAction,
 }: TransactionProgressModalProps) {
   if (!isOpen || state === 'IDLE') return null;
+
+  const txExplorerUrl = buildExplorerUrl('tx', txHash);
 
   // -- State Configuration Helpers --
   const getHeader = () => {
@@ -220,8 +223,8 @@ export default function TransactionProgressModal({
       const isTimeout = errorCode === 'RPC_TIMEOUT';
 
       const handlePrimaryClick = () => {
-        if (isTimeout && txHash) {
-          window.open(`https://stellar.expert/explorer/public/tx/${txHash}`, '_blank', 'noopener,noreferrer');
+        if (isTimeout && txExplorerUrl) {
+          openExplorerUrl('tx', txHash);
         } else if (mapping.primary === 'Fund Wallet' || mapping.primary === 'Contact Support') {
            // Handle external redirect logic here if applicable, otherwise fallback to generic
           onClose(); 
@@ -292,13 +295,13 @@ export default function TransactionProgressModal({
           </p>
 
           {/* Explorer Link Slot */}
-          {txHash && (state === 'SUCCESS' || state === 'ERROR' || state === 'PROCESSING') && (
+          {txExplorerUrl && (state === 'SUCCESS' || state === 'ERROR' || state === 'PROCESSING') && (
             <div className="mt-6 p-3 w-full rounded-lg bg-white/5 border border-white/5 flex items-center justify-between">
               <span className="text-xs text-white/40 font-mono truncate max-w-[200px]">
                 {txHash}
               </span>
               <a 
-                href={`https://stellar.expert/explorer/public/tx/${txHash}`}
+                href={txExplorerUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-xs text-white/70 hover:text-[#00C950] flex items-center gap-1.5 font-medium transition-colors"

--- a/src/app/commitments/[id]/page.tsx
+++ b/src/app/commitments/[id]/page.tsx
@@ -8,6 +8,7 @@ import CommitmentDetailAllocationConstraints from '@/components/CommitmentDetail
 import { CommitmentDetailNftSection } from '@/components/dashboard/CommitmentDetailNftSection';
 import { CommitmentDetailParameters } from '@/components/CommitmentDetailParameters/CommitmentDetailParameters';
 import RecentAttestationsPanel from '@/components/RecentAttestationsPanel/RecentAttestationsPanel';
+import { openExplorerUrl } from '@/utils/explorerLinks';
 
 // Mock Commitments
 const MOCK_COMMITMENTS: Record<
@@ -105,8 +106,8 @@ const MOCK_ATTESTATION_SUMMARY = {
 // Mock data for the NFT section
 const MOCK_NFT_DATA = {
     tokenId: '123456789',
-    ownerAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
-    contractAddress: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+    ownerAddress: `G${'A'.repeat(55)}`,
+    contractAddress: `C${'B'.repeat(55)}`,
     mintDate: 'Jan 10, 2026',
 };
 
@@ -139,7 +140,7 @@ export default function CommitmentDetailPage({
     };
 
     const handleViewDetails = () => console.log('View Details clicked');
-    const handleViewExplorer = () => console.log('View Explorer clicked');
+    const handleViewExplorer = () => openExplorerUrl('contract', MOCK_NFT_DATA.contractAddress, 'testnet');
     const handleTransfer = () => console.log('Transfer clicked');
 
     return (

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -6,6 +6,7 @@ import CreateCommitmentStepSelectType from "@/components/CreateCommitmentStepSel
 import CreateCommitmentStepConfigure from "@/components/CreateCommitmentStepConfigure";
 import CreateCommitmentStepReview from "@/components/CreateCommitmentStepReview";
 import CommitmentCreatedModal from "@/components/modals/Commitmentcreatedmodal";
+import { buildExplorerUrl, openExplorerUrl } from "@/utils/explorerLinks";
 
 type CommitmentType = "safe" | "balanced" | "aggressive";
 
@@ -154,9 +155,10 @@ export default function CreateCommitment() {
   };
 
   const handleViewOnExplorer = () => {
-    const explorerUrl = `https://stellar.expert/explorer/testnet/tx/${commitmentId}`;
-    window.open(explorerUrl, "_blank");
+    openExplorerUrl("tx", commitmentId, "testnet");
   };
+
+  const commitmentExplorerUrl = buildExplorerUrl("tx", commitmentId, "testnet");
 
   const handleEditStep = (targetStep: 1 | 2) => {
     setStep(targetStep);
@@ -210,7 +212,7 @@ export default function CreateCommitment() {
             onViewCommitment={handleViewCommitment}
             onCreateAnother={handleCreateAnother}
             onClose={handleCloseModal}
-            onViewOnExplorer={handleViewOnExplorer}
+            onViewOnExplorer={commitmentExplorerUrl ? handleViewOnExplorer : undefined}
           />
         </>
       )}

--- a/src/app/transaction-error/page.tsx
+++ b/src/app/transaction-error/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect, useMemo, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import ErrorLayout from '@/components/ErrorLayout'
 import ErrorButton from '@/components/ErrorButton'
+import { buildExplorerUrl } from '@/utils/explorerLinks'
 import styles from './page.module.css'
 
 type TransactionErrorCategory = 'rejected' | 'timed-out' | 'failed'
@@ -113,6 +114,7 @@ function TransactionErrorContent() {
   const errorMessage = searchParams.get('message') || content.description
   const txHash = searchParams.get('hash')
   const errorCode = searchParams.get('code')
+  const txExplorerUrl = buildExplorerUrl('tx', txHash)
 
   useEffect(() => {
     headingRef.current?.focus()
@@ -212,9 +214,9 @@ function TransactionErrorContent() {
         <ErrorButton href="/commitments/overview" variant="secondary">
           Go to Dashboard
         </ErrorButton>
-        {txHash && (
+        {txExplorerUrl && (
           <ErrorButton
-            href={`https://stellar.expert/explorer/public/tx/${encodeURIComponent(txHash)}`}
+            href={txExplorerUrl}
             variant="secondary"
             isExternal
           >

--- a/src/utils/__tests__/explorerLinks.test.ts
+++ b/src/utils/__tests__/explorerLinks.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest'
+import { buildExplorerUrl, openExplorerUrl } from '../explorerLinks'
+
+const validTxHash = 'a'.repeat(64)
+const validAccount = `G${'A'.repeat(55)}`
+const validContract = `C${'B'.repeat(55)}`
+
+describe('explorerLinks', () => {
+  it('builds explorer URLs for validated Stellar identifiers', () => {
+    expect(buildExplorerUrl('tx', validTxHash)).toBe(
+      `https://stellar.expert/explorer/public/tx/${validTxHash}`,
+    )
+    expect(buildExplorerUrl('account', validAccount, 'testnet')).toBe(
+      `https://stellar.expert/explorer/testnet/account/${validAccount}`,
+    )
+    expect(buildExplorerUrl('contract', validContract, 'testnet')).toBe(
+      `https://stellar.expert/explorer/testnet/contract/${validContract}`,
+    )
+    expect(buildExplorerUrl('token', 'USDC:GDQOE23Y3XE45JQFOD5A')).toBe(
+      'https://stellar.expert/explorer/public/asset/USDC%3AGDQOE23Y3XE45JQFOD5A',
+    )
+  })
+
+  it('rejects malformed or ambiguous identifiers', () => {
+    expect(buildExplorerUrl('tx', 'abc 123')).toBeNull()
+    expect(buildExplorerUrl('tx', '0x1234')).toBeNull()
+    expect(buildExplorerUrl('account', validContract)).toBeNull()
+    expect(buildExplorerUrl('contract', validAccount)).toBeNull()
+    expect(buildExplorerUrl('token', '../account/GATTACK')).toBeNull()
+    expect(buildExplorerUrl('token', ' USDC')).toBeNull()
+  })
+
+  it('opens validated URLs with noopener and noreferrer', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+    expect(openExplorerUrl('tx', validTxHash)).toBe(true)
+    expect(openSpy).toHaveBeenCalledWith(
+      `https://stellar.expert/explorer/public/tx/${validTxHash}`,
+      '_blank',
+      'noopener,noreferrer',
+    )
+
+    expect(openExplorerUrl('tx', 'abc 123')).toBe(false)
+    expect(openSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/utils/explorerLinks.ts
+++ b/src/utils/explorerLinks.ts
@@ -1,0 +1,56 @@
+export type ExplorerLinkKind = 'account' | 'contract' | 'tx' | 'token'
+export type ExplorerNetwork = 'public' | 'testnet'
+
+const EXPLORER_ORIGIN = 'https://stellar.expert'
+const VALID_NETWORKS = new Set<ExplorerNetwork>(['public', 'testnet'])
+const TX_HASH_PATTERN = /^[A-Fa-f0-9]{64}$/
+const ACCOUNT_PATTERN = /^G[A-Z2-7]{55}$/
+const CONTRACT_PATTERN = /^C[A-Z2-7]{55}$/
+const TOKEN_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/
+
+const PATH_BY_KIND: Record<ExplorerLinkKind, string> = {
+  account: 'account',
+  contract: 'contract',
+  tx: 'tx',
+  token: 'asset',
+}
+
+function isValidIdentifier(kind: ExplorerLinkKind, id: string): boolean {
+  if (id !== id.trim()) return false
+
+  switch (kind) {
+    case 'account':
+      return ACCOUNT_PATTERN.test(id)
+    case 'contract':
+      return CONTRACT_PATTERN.test(id)
+    case 'tx':
+      return TX_HASH_PATTERN.test(id)
+    case 'token':
+      return TOKEN_PATTERN.test(id)
+  }
+}
+
+export function buildExplorerUrl(
+  kind: ExplorerLinkKind,
+  id: string | null | undefined,
+  network: ExplorerNetwork = 'public',
+): string | null {
+  if (!id || !VALID_NETWORKS.has(network) || !isValidIdentifier(kind, id)) {
+    return null
+  }
+
+  const url = new URL(`/explorer/${network}/${PATH_BY_KIND[kind]}/${encodeURIComponent(id)}`, EXPLORER_ORIGIN)
+  return url.toString()
+}
+
+export function openExplorerUrl(
+  kind: ExplorerLinkKind,
+  id: string | null | undefined,
+  network?: ExplorerNetwork,
+): boolean {
+  const url = buildExplorerUrl(kind, id, network)
+  if (!url) return false
+
+  window.open(url, '_blank', 'noopener,noreferrer')
+  return true
+}

--- a/tests/transaction-error-page.test.tsx
+++ b/tests/transaction-error-page.test.tsx
@@ -60,7 +60,7 @@ describe('transaction error page recovery actions', () => {
   it('renders timeout recovery with an explorer check before retry guidance', () => {
     params = new URLSearchParams({
       code: 'GATEWAY_TIMEOUT',
-      hash: 'abc 123',
+      hash: 'a'.repeat(64),
     })
 
     render(React.createElement(TransactionError))
@@ -70,14 +70,14 @@ describe('transaction error page recovery actions', () => {
     expect(screen.getByText('Avoid submitting the same signed transaction twice.')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Check Explorer' })).toHaveAttribute(
       'href',
-      'https://stellar.expert/explorer/public/tx/abc%20123',
+      `https://stellar.expert/explorer/public/tx/${'a'.repeat(64)}`,
     )
   })
 
   it('renders failed transaction recovery for normalized chain call failures', () => {
     params = new URLSearchParams({
       code: 'BLOCKCHAIN_CALL_FAILED',
-      hash: 'deadbeef',
+      hash: 'b'.repeat(64),
     })
 
     render(React.createElement(TransactionError))
@@ -87,7 +87,19 @@ describe('transaction error page recovery actions', () => {
     expect(screen.getByText('Check whether the smart contract rejected the operation.')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'View on Explorer' })).toHaveAttribute(
       'href',
-      'https://stellar.expert/explorer/public/tx/deadbeef',
+      `https://stellar.expert/explorer/public/tx/${'b'.repeat(64)}`,
     )
+  })
+
+  it('does not render explorer links for malformed transaction hashes', () => {
+    params = new URLSearchParams({
+      code: 'GATEWAY_TIMEOUT',
+      hash: 'abc 123',
+    })
+
+    render(React.createElement(TransactionError))
+
+    expect(screen.getByText('abc 123')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Check Explorer' })).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

- add a shared Stellar explorer link helper that validates transaction hashes
  and Stellar-style identifiers before constructing external URLs
- update transaction-progress, transaction-error, create-commitment, and
  commitment-detail explorer flows to use the shared helper
- open explorer links with `noopener,noreferrer` and avoid rendering malformed
  explorer links

## Why

Issue #597 asks for explorer and external-link hardening. The previous code
constructed Stellar explorer URLs inline in several UI paths, which made it
easy for malformed values to become clickable external links and left link
opening behavior inconsistent.

## Testing

- `npm test -- --run src/utils/__tests__/explorerLinks.test.ts tests/transaction-error-page.test.tsx src/components/__tests__/CommitmentDetailNftSection.test.tsx`
- `npx eslint src/utils/explorerLinks.ts src/utils/__tests__/explorerLinks.test.ts src/app/TransactionProgressModal.tsx src/app/transaction-error/page.tsx src/app/create/page.tsx 'src/app/commitments/[id]/page.tsx' tests/transaction-error-page.test.tsx`

Note: full `npm run lint` still fails on unrelated pre-existing baseline issues
in untouched files.

Closes #597
