### PR TITLE
test: cover create commitment wizard steps

### DIFF
--- a/tests/components/CreateCommitmentStepConfigure.test.tsx
+++ b/tests/components/CreateCommitmentStepConfigure.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import CreateCommitmentStepConfigure from "../../src/components/CreateCommitmentStepConfigure";
+
+describe("CreateCommitmentStepConfigure", () => {
+  const defaultProps = {
+    amount: "1000",
+    asset: "XLM",
+    availableBalance: "2500",
+    durationDays: 60,
+    maxLossPercent: 8,
+    earlyExitPenalty: "30 XLM",
+    estimatedFees: "0.5 XLM",
+    isValid: true,
+    onChangeAmount: vi.fn(),
+    onChangeAsset: vi.fn(),
+    onChangeDuration: vi.fn(),
+    onChangeMaxLoss: vi.fn(),
+    onBack: vi.fn(),
+    onNext: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders required amount, duration, max loss, and derived value fields", () => {
+    render(<CreateCommitmentStepConfigure {...defaultProps} />);
+
+    expect(screen.getByRole("heading", { name: "Configure Parameters" })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Commitment Amount/)).toHaveValue(1000);
+    expect(screen.getByLabelText("Select asset")).toHaveValue("XLM");
+    expect(screen.getByLabelText("Duration (days) *")).toHaveValue(60);
+    expect(screen.getByRole("spinbutton", { name: /Maximum Acceptable Loss/ })).toHaveValue(8);
+    expect(screen.getByText("Early Exit Penalty")).toBeInTheDocument();
+    expect(screen.getByText("Estimated Fees")).toBeInTheDocument();
+  });
+
+  it("emits field updates for amount, asset, duration, and max-loss controls", () => {
+    render(<CreateCommitmentStepConfigure {...defaultProps} />);
+
+    fireEvent.change(screen.getByLabelText(/Commitment Amount/), { target: { value: "1250" } });
+    fireEvent.change(screen.getByLabelText("Select asset"), { target: { value: "USDC" } });
+    fireEvent.change(screen.getByLabelText("Duration (days) *"), { target: { value: "90" } });
+    fireEvent.change(screen.getByRole("spinbutton", { name: /Maximum Acceptable Loss/ }), { target: { value: "12" } });
+
+    expect(defaultProps.onChangeAmount).toHaveBeenLastCalledWith("1250");
+    expect(defaultProps.onChangeAsset).toHaveBeenCalledWith("USDC");
+    expect(defaultProps.onChangeDuration).toHaveBeenLastCalledWith(90);
+    expect(defaultProps.onChangeMaxLoss).toHaveBeenLastCalledWith(12);
+  });
+
+  it("clamps typed duration and max-loss values to protocol bounds", () => {
+    render(<CreateCommitmentStepConfigure {...defaultProps} />);
+
+    fireEvent.change(screen.getByLabelText("Duration (days) *"), { target: { value: "999" } });
+    fireEvent.change(screen.getByRole("spinbutton", { name: /Maximum Acceptable Loss/ }), { target: { value: "250" } });
+
+    expect(defaultProps.onChangeDuration).toHaveBeenLastCalledWith(365);
+    expect(defaultProps.onChangeMaxLoss).toHaveBeenLastCalledWith(100);
+  });
+
+  it("surfaces supplied amount errors and invalid duration or max-loss props", () => {
+    render(
+      <CreateCommitmentStepConfigure
+        {...defaultProps}
+        amountError="Amount exceeds available balance."
+        durationDays={0}
+        maxLossPercent={101}
+      />,
+    );
+
+    expect(screen.getByText("Amount exceeds available balance.")).toHaveAttribute("role", "alert");
+    expect(screen.getByText("Minimum duration is 1 day.")).toHaveAttribute("role", "alert");
+    expect(screen.getByText("Cannot exceed 100%.")).toHaveAttribute("role", "alert");
+    expect(screen.getByLabelText(/Commitment Amount/)).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByLabelText("Duration (days) *")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByRole("spinbutton", { name: /Maximum Acceptable Loss/ })).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("shows high max-loss warnings without blocking valid form submission", () => {
+    render(<CreateCommitmentStepConfigure {...defaultProps} maxLossPercent={85} maxLossWarning />);
+
+    expect(screen.getByText(/Setting max loss above 80%/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Continue/ }));
+
+    expect(defaultProps.onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables continue and Enter submission when the form is invalid", () => {
+    const { container } = render(<CreateCommitmentStepConfigure {...defaultProps} isValid={false} />);
+
+    const continueButton = screen.getByRole("button", { name: /Continue/ });
+    expect(continueButton).toBeDisabled();
+
+    fireEvent.click(continueButton);
+    fireEvent.keyDown(container.querySelector("form")!, { key: "Enter" });
+
+    expect(defaultProps.onNext).not.toHaveBeenCalled();
+  });
+
+  it("preserves advanced local settings while the advanced section is collapsed and reopened", () => {
+    render(<CreateCommitmentStepConfigure {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Advanced Risk Parameters" }));
+    fireEvent.change(screen.getByLabelText("Slippage Tolerance (%)"), { target: { value: "3.5" } });
+    fireEvent.change(screen.getByLabelText("Liquidation Buffer (%)"), { target: { value: "12" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Advanced Risk Parameters" }));
+    fireEvent.click(screen.getByRole("button", { name: "Advanced Risk Parameters" }));
+
+    expect(screen.getByLabelText("Slippage Tolerance (%)")).toHaveValue(3.5);
+    expect(screen.getByLabelText("Liquidation Buffer (%)")).toHaveValue(12);
+  });
+
+  it("routes back controls and Enter key submission when valid", () => {
+    const { container } = render(<CreateCommitmentStepConfigure {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "← Back" }));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    fireEvent.keyDown(container.querySelector("form")!, { key: "Enter" });
+
+    expect(defaultProps.onBack).toHaveBeenCalledTimes(2);
+    expect(defaultProps.onNext).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/components/CreateCommitmentStepSelectType.test.tsx
+++ b/tests/components/CreateCommitmentStepSelectType.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import CreateCommitmentStepSelectType from "../../src/components/CreateCommitmentStepSelectType";
+
+describe("CreateCommitmentStepSelectType", () => {
+  const defaultProps = {
+    selectedType: null as "safe" | "balanced" | "aggressive" | null,
+    onSelectType: vi.fn(),
+    onNext: vi.fn(),
+    onBack: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders all risk profile choices as an accessible radio group", () => {
+    render(<CreateCommitmentStepSelectType {...defaultProps} />);
+
+    expect(screen.getByRole("radiogroup", { name: "Commitment type" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /Safe Commitment/ })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    expect(screen.getByRole("radio", { name: /Balanced Commitment/ })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    expect(screen.getByRole("radio", { name: /Aggressive Commitment/ })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    expect(screen.getByText("Recommended")).toBeInTheDocument();
+    expect(screen.getByText("⚠ High Risk")).toBeInTheDocument();
+  });
+
+  it("marks the selected risk profile and enables continue", () => {
+    render(<CreateCommitmentStepSelectType {...defaultProps} selectedType="balanced" />);
+
+    expect(screen.getByRole("radio", { name: /Balanced Commitment/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /Continue/ })).toBeEnabled();
+  });
+
+  it("emits the selected profile when a card is clicked", () => {
+    render(<CreateCommitmentStepSelectType {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("radio", { name: /Aggressive Commitment/ }));
+
+    expect(defaultProps.onSelectType).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onSelectType).toHaveBeenCalledWith("aggressive");
+  });
+
+  it("supports keyboard selection with Enter and Space", () => {
+    render(<CreateCommitmentStepSelectType {...defaultProps} />);
+
+    const safeCard = screen.getByRole("radio", { name: /Safe Commitment/ });
+    const balancedCard = screen.getByRole("radio", { name: /Balanced Commitment/ });
+
+    fireEvent.keyDown(safeCard, { key: "Enter" });
+    fireEvent.keyDown(balancedCard, { key: " " });
+
+    expect(defaultProps.onSelectType).toHaveBeenNthCalledWith(1, "safe");
+    expect(defaultProps.onSelectType).toHaveBeenNthCalledWith(2, "balanced");
+  });
+
+  it("blocks continue until a profile is selected", () => {
+    const { rerender } = render(<CreateCommitmentStepSelectType {...defaultProps} />);
+
+    const disabledContinue = screen.getByRole("button", { name: /Continue/ });
+    expect(disabledContinue).toBeDisabled();
+    fireEvent.click(disabledContinue);
+    expect(defaultProps.onNext).not.toHaveBeenCalled();
+
+    rerender(<CreateCommitmentStepSelectType {...defaultProps} selectedType="safe" />);
+    fireEvent.click(screen.getByRole("button", { name: /Continue/ }));
+
+    expect(defaultProps.onNext).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onNext).toHaveBeenCalledWith("safe");
+  });
+
+  it("routes both back controls to onBack", () => {
+    render(<CreateCommitmentStepSelectType {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Back to Home/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(defaultProps.onBack).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/components/WizardStepper.test.tsx
+++ b/tests/components/WizardStepper.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import WizardStepper from "../../src/components/WizardStepper";
+
+describe("WizardStepper", () => {
+  it("renders the three wizard steps in order", () => {
+    render(<WizardStepper currentStep={1} />);
+
+    const progress = screen.getByRole("navigation", { name: "Wizard progress" });
+    const labels = within(progress)
+      .getAllByText(/Select Type|Configure|Review/)
+      .map((label) => label.textContent);
+
+    expect(labels).toEqual(["Select Type", "Configure", "Review"]);
+  });
+
+  it("marks the first step as the current step before configuration", () => {
+    render(<WizardStepper currentStep={1} />);
+
+    const current = screen.getByText("1");
+    expect(current).toHaveAttribute("aria-current", "step");
+    expect(screen.getByText("Select Type")).toBeInTheDocument();
+  });
+
+  it("shows prior steps as completed when advancing", () => {
+    const { container } = render(<WizardStepper currentStep={3} />);
+
+    expect(screen.getByText("3")).toHaveAttribute("aria-current", "step");
+    expect(screen.getByText("Review")).toBeInTheDocument();
+    expect(container.querySelectorAll("svg")).toHaveLength(2);
+    expect(screen.queryByText("1")).not.toBeInTheDocument();
+    expect(screen.queryByText("2")).not.toBeInTheDocument();
+  });
+
+  it("updates the active marker when moving backward", () => {
+    const { rerender } = render(<WizardStepper currentStep={3} />);
+    expect(screen.getByText("3")).toHaveAttribute("aria-current", "step");
+
+    rerender(<WizardStepper currentStep={2} />);
+
+    expect(screen.getByText("2")).toHaveAttribute("aria-current", "step");
+    expect(screen.queryByText("3")).not.toHaveAttribute("aria-current", "step");
+  });
+});

--- a/tests/setup/vitest.setup.ts
+++ b/tests/setup/vitest.setup.ts
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom/vitest';
 import { expect } from 'vitest';
 
 expect.extend({


### PR DESCRIPTION
## Summary
- add RTL/Vitest coverage for the create-commitment type selection step
- add configuration-step coverage for field updates, validation bounds, warnings, advanced-setting state preservation, and navigation controls
- add WizardStepper progress tests for active/completed/backward state rendering
- import `@testing-library/jest-dom/vitest` in the Vitest setup so the existing jest-dom matcher usage is registered consistently

Closes #593

## Validation
- `npm test -- tests/components/CreateCommitmentStepSelectType.test.tsx tests/components/CreateCommitmentStepConfigure.test.tsx tests/components/WizardStepper.test.tsx` — 3 files / 18 tests passed
- `npx eslint tests/setup/vitest.setup.ts tests/components/CreateCommitmentStepSelectType.test.tsx tests/components/CreateCommitmentStepConfigure.test.tsx tests/components/WizardStepper.test.tsx` — passed
- `git diff --check` and `git diff --cached --check` — passed before commit

## Notes
- Full `npm run lint` is currently blocked by pre-existing unrelated repository errors such as `src/app/api/commitments/[id]/settle/route.ts` parse error, `src/components/modals/CommitmentDetailsModal.tsx` JSX parse error, and existing unused/`any` lint violations outside this PR's files.
