### PR TITLE
feat: implement attestation history timeline

### DIFF
--- a/src/components/AttestationHistory.tsx
+++ b/src/components/AttestationHistory.tsx
@@ -1,23 +1,419 @@
-// Placeholder component for displaying attestation history
-// This will show all attestations for a commitment
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { AlertTriangle, CheckCircle2, RefreshCw } from "lucide-react";
+import { Skeleton } from "@/components/Skeleton";
+import type { Attestation } from "@/lib/types/domain";
 
 interface AttestationHistoryProps {
-  commitmentId: string
+  commitmentId: string;
 }
 
-export default function AttestationHistory({ commitmentId }: AttestationHistoryProps) {
+type LoadState = "idle" | "loading" | "loaded" | "error";
+
+interface AttestationHistoryItem {
+  id: string;
+  commitmentId: string;
+  kind: string;
+  observedAt: string;
+  attestor: string;
+  complianceScore?: number;
+  violation: boolean;
+  title: string;
+  description?: string;
+  txHash?: string;
+}
+
+interface AttestationApiResponse {
+  success?: boolean;
+  data?: {
+    attestations?: unknown[];
+  };
+  attestations?: unknown[];
+}
+
+const VIOLATION_THRESHOLD = 70;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readNestedNumber(
+  record: Record<string, unknown>,
+  keys: string[],
+): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return Math.max(0, Math.min(100, Math.round(value)));
+    }
+    if (typeof value === "string" && value.trim() !== "") {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return Math.max(0, Math.min(100, Math.round(parsed)));
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function readString(
+  record: Record<string, unknown>,
+  keys: string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim() !== "") {
+      return value.trim();
+    }
+  }
+
+  return undefined;
+}
+
+function formatKind(value: string): string {
+  return value
+    .replace(/[_-]/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown time";
+
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function formatTrendDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
+function truncateAddress(value: string): string {
+  if (!value || value === "Unknown attestor") return value;
+  if (value.length <= 14) return value;
+
+  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+}
+
+function normalizeAttestation(value: unknown): AttestationHistoryItem | null {
+  if (!isRecord(value)) return null;
+
+  const details = isRecord(value.details) ? value.details : {};
+  const data = isRecord(value.data) ? value.data : {};
+  const commitmentId = readString(value, ["commitmentId", "commitment_id"]);
+  const observedAt =
+    readString(value, ["observedAt", "timestamp", "recordedAt", "createdAt"]) ??
+    readString(details, ["timestamp", "observedAt"]) ??
+    new Date(0).toISOString();
+
+  if (!commitmentId) return null;
+
+  const kind =
+    readString(value, ["kind", "attestationType", "type"]) ??
+    readString(details, ["type", "attestationType"]) ??
+    "attestation";
+  const complianceScore =
+    readNestedNumber(value, ["complianceScore", "compliance_score"]) ??
+    readNestedNumber(details, ["complianceScore", "compliance_score"]) ??
+    readNestedNumber(data, ["complianceScore", "compliance_score"]);
+  const explicitViolation =
+    value.violation === true ||
+    details.violation === true ||
+    value.verdict === "fail" ||
+    value.severity === "violation" ||
+    details.severity === "violation";
+
+  return {
+    id:
+      readString(value, ["id", "attestationId", "attestation_id"]) ??
+      `${commitmentId}:${observedAt}:${kind}`,
+    commitmentId,
+    kind,
+    observedAt,
+    attestor:
+      readString(value, ["attestor", "attestorAddress", "verifiedBy"]) ??
+      readString(details, ["attestor", "attestorAddress", "verifiedBy"]) ??
+      "Unknown attestor",
+    complianceScore,
+    violation:
+      explicitViolation ||
+      (typeof complianceScore === "number" &&
+        complianceScore < VIOLATION_THRESHOLD),
+    title: readString(value, ["title"]) ?? `${formatKind(kind)} attestation`,
+    description:
+      readString(value, ["description"]) ??
+      readString(details, ["notes", "reason"]),
+    txHash: readString(value, ["txHash", "transactionHash"]),
+  };
+}
+
+function extractAttestations(response: AttestationApiResponse): unknown[] {
+  if (Array.isArray(response.data?.attestations)) {
+    return response.data.attestations;
+  }
+
+  if (Array.isArray(response.attestations)) {
+    return response.attestations;
+  }
+
+  return [];
+}
+
+export default function AttestationHistory({
+  commitmentId,
+}: AttestationHistoryProps) {
+  const [items, setItems] = useState<AttestationHistoryItem[]>([]);
+  const [state, setState] = useState<LoadState>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const loadAttestations = useCallback(async () => {
+    setState("loading");
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/attestations?commitmentId=${encodeURIComponent(commitmentId)}`,
+      );
+
+      if (!response.ok) {
+        throw new Error("Unable to load attestation history.");
+      }
+
+      const payload = (await response.json()) as AttestationApiResponse;
+      const normalized = extractAttestations(payload)
+        .map((entry) => normalizeAttestation(entry as Attestation))
+        .filter((entry): entry is AttestationHistoryItem => Boolean(entry))
+        .filter((entry) => entry.commitmentId === commitmentId)
+        .sort(
+          (a, b) =>
+            new Date(a.observedAt).getTime() - new Date(b.observedAt).getTime(),
+        );
+
+      setItems(normalized);
+      setState("loaded");
+    } catch (err) {
+      setItems([]);
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Unable to load attestation history.",
+      );
+      setState("error");
+    }
+  }, [commitmentId]);
+
+  useEffect(() => {
+    void loadAttestations();
+  }, [loadAttestations]);
+
+  const trendData = useMemo(
+    () =>
+      items
+        .filter((item) => typeof item.complianceScore === "number")
+        .map((item) => ({
+          date: formatTrendDate(item.observedAt),
+          complianceScore: item.complianceScore ?? 0,
+        })),
+    [items],
+  );
+
   return (
-    <div>
-      {/* TODO: Implement attestation history with:
-        - List of all attestations
-        - Timestamps
-        - Attestation types
-        - Compliance status
-        - Health metrics over time
-        - Charts/graphs
-      */}
-      <p>Attestation History component - Commitment ID: {commitmentId}</p>
-    </div>
-  )
-}
+    <section
+      aria-labelledby="attestation-history-title"
+      className="rounded-2xl border border-[#222] bg-[#0a0a0a] p-5 text-white"
+    >
+      <div className="mb-5 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 id="attestation-history-title" className="text-xl font-semibold">
+            Attestation History
+          </h2>
+          <p className="mt-1 text-sm text-[#99a1af]">
+            Commitment {commitmentId}
+          </p>
+        </div>
+        <span className="rounded-full border border-[#263238] bg-[#111] px-3 py-1 text-xs font-medium text-[#99a1af]">
+          Violation threshold: below {VIOLATION_THRESHOLD}
+        </span>
+      </div>
 
+      {state === "loading" && (
+        <div aria-label="Loading attestation history" className="space-y-4">
+          <Skeleton height={190} rounded="xl" />
+          {[0, 1, 2].map((item) => (
+            <div
+              key={item}
+              className="rounded-xl border border-[#222] bg-[#111] p-4"
+            >
+              <Skeleton width={180} height={20} className="mb-3" />
+              <Skeleton width="80%" height={16} className="mb-2" />
+              <Skeleton width="55%" height={16} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {state === "error" && (
+        <div
+          role="alert"
+          className="rounded-xl border border-[#4a2a2a] bg-[#180d0d] p-4"
+        >
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 h-5 w-5 flex-none text-[#f87171]" />
+            <div className="min-w-0 flex-1">
+              <p className="font-medium text-[#fecaca]">{error}</p>
+              <p className="mt-1 text-sm text-[#fca5a5]">
+                The timeline is unavailable, but the commitment page can stay
+                usable.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={loadAttestations}
+              className="inline-flex items-center gap-2 rounded-lg border border-[#7f1d1d] px-3 py-2 text-sm font-medium text-[#fecaca] transition hover:bg-[#2a1111]"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Retry
+            </button>
+          </div>
+        </div>
+      )}
+
+      {state === "loaded" && items.length === 0 && (
+        <div className="rounded-xl border border-dashed border-[#333] bg-[#111] p-6 text-center">
+          <p className="font-medium text-white">
+            No attestations recorded for this commitment yet.
+          </p>
+          <p className="mt-2 text-sm text-[#99a1af]">
+            New health checks and rule events will appear here once they are
+            recorded.
+          </p>
+        </div>
+      )}
+
+      {state === "loaded" && items.length > 0 && (
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+          <div
+            data-testid="attestation-trend-chart"
+            className="min-h-[260px] rounded-xl border border-[#222] bg-[#111] p-4"
+          >
+            <div className="mb-4">
+              <h3 className="font-semibold">Compliance trend</h3>
+              <p className="text-sm text-[#99a1af]">
+                Score movement across recorded attestations.
+              </p>
+            </div>
+            {trendData.length > 0 ? (
+              <ResponsiveContainer width="100%" height={190}>
+                <LineChart data={trendData}>
+                  <CartesianGrid stroke="#222" strokeDasharray="3 3" />
+                  <XAxis
+                    dataKey="date"
+                    stroke="#666"
+                    tick={{ fill: "#99a1af", fontSize: 12 }}
+                  />
+                  <YAxis
+                    domain={[0, 100]}
+                    stroke="#666"
+                    tick={{ fill: "#99a1af", fontSize: 12 }}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      background: "#111",
+                      border: "1px solid #333",
+                      borderRadius: "8px",
+                      color: "#fff",
+                    }}
+                  />
+                  <Line
+                    dataKey="complianceScore"
+                    dot={{ fill: "#4ade80", r: 4 }}
+                    stroke="#4ade80"
+                    strokeWidth={2}
+                    type="monotone"
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            ) : (
+              <p className="rounded-lg border border-[#222] bg-[#0a0a0a] p-4 text-sm text-[#99a1af]">
+                No numeric compliance scores are available for charting.
+              </p>
+            )}
+          </div>
+
+          <ol className="space-y-3" aria-label="Attestation timeline">
+            {items.map((item) => {
+              const scoreLabel =
+                typeof item.complianceScore === "number"
+                  ? `${item.complianceScore}%`
+                  : "No score";
+
+              return (
+                <li
+                  key={item.id}
+                  className="rounded-xl border border-[#222] bg-[#111] p-4"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <p className="text-sm text-[#99a1af]">
+                        {formatTimestamp(item.observedAt)}
+                      </p>
+                      <h3 className="mt-1 font-semibold">{item.title}</h3>
+                      <p className="mt-1 text-sm text-[#99a1af]">
+                        {formatKind(item.kind)} by{" "}
+                        <span className="font-mono text-[#d1d5db]">
+                          {truncateAddress(item.attestor)}
+                        </span>
+                      </p>
+                      {item.description && (
+                        <p className="mt-2 text-sm text-[#d1d5db]">
+                          {item.description}
+                        </p>
+                      )}
+                    </div>
+
+                    <div className="flex flex-none items-center gap-2">
+                      <span className="rounded-full border border-[#333] px-3 py-1 text-sm font-semibold">
+                        {scoreLabel}
+                      </span>
+                      <span
+                        className={
+                          item.violation
+                            ? "inline-flex items-center gap-1 rounded-full border border-[#7f1d1d] bg-[#2a1111] px-3 py-1 text-sm font-medium text-[#fca5a5]"
+                            : "inline-flex items-center gap-1 rounded-full border border-[#14532d] bg-[#102016] px-3 py-1 text-sm font-medium text-[#86efac]"
+                        }
+                      >
+                        <CheckCircle2 className="h-4 w-4" />
+                        {item.violation ? "Violation" : "Pass"}
+                      </span>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/__tests__/AttestationHistory.test.tsx
+++ b/src/components/__tests__/AttestationHistory.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import AttestationHistory from "@/components/AttestationHistory";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) =>
+    children,
+  LineChart: ({ children }: { children: React.ReactNode }) => children,
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Line: () => null,
+}));
+
+function jsonResponse(payload: unknown, ok = true) {
+  return {
+    ok,
+    json: async () => payload,
+  } as Response;
+}
+
+function fetchMock() {
+  return global.fetch as unknown as ReturnType<typeof vi.fn>;
+}
+
+function mockMatchMedia() {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+describe("AttestationHistory", () => {
+  beforeEach(() => {
+    mockMatchMedia();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("shows the loading state while attestation records are requested", async () => {
+    let resolveFetch: (response: Response) => void = () => {};
+    fetchMock().mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    render(<AttestationHistory commitmentId="CMT-123" />);
+
+    expect(
+      screen.getByLabelText("Loading attestation history"),
+    ).toBeInTheDocument();
+
+    resolveFetch(
+      jsonResponse({
+        success: true,
+        data: { attestations: [] },
+      }),
+    );
+
+    expect(
+      await screen.findByText(
+        "No attestations recorded for this commitment yet.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("filters records by commitment id, sorts them chronologically, and renders scores", async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        data: {
+          attestations: [
+            {
+              id: "other",
+              commitmentId: "CMT-999",
+              kind: "health_check",
+              observedAt: "2026-06-21T08:00:00Z",
+              details: { complianceScore: 88 },
+            },
+            {
+              id: "latest",
+              commitmentId: "CMT-123",
+              kind: "drawdown",
+              title: "Drawdown threshold check",
+              observedAt: "2026-06-21T10:00:00Z",
+              attestor: "GABCDEFGHIJKLMNOPQRSTUVWXYZ23456789",
+              details: {
+                complianceScore: 0,
+                notes: "Drawdown moved beyond the allowed band.",
+              },
+            },
+            {
+              id: "first",
+              commitmentId: "CMT-123",
+              kind: "health_check",
+              title: "Daily health check",
+              observedAt: "2026-06-21T09:00:00Z",
+              verifiedBy: "GATTESTOR0000000000000000000000000000000001",
+              details: { complianceScore: 100 },
+            },
+          ],
+        },
+      }),
+    );
+
+    render(<AttestationHistory commitmentId="CMT-123" />);
+
+    expect(await screen.findByText("Daily health check")).toBeInTheDocument();
+    expect(screen.getByText("Drawdown threshold check")).toBeInTheDocument();
+    expect(screen.queryByText("CMT-999")).not.toBeInTheDocument();
+
+    const renderedTitles = screen
+      .getAllByRole("listitem")
+      .map((item) => item.textContent ?? "");
+    expect(renderedTitles[0]).toContain("Daily health check");
+    expect(renderedTitles[1]).toContain("Drawdown threshold check");
+
+    expect(screen.getByText("100%")).toBeInTheDocument();
+    expect(screen.getByText("0%")).toBeInTheDocument();
+    expect(screen.getByText("GATTES...0001")).toBeInTheDocument();
+    expect(screen.getByText("GABCDE...6789")).toBeInTheDocument();
+    expect(screen.getByText("Pass")).toBeInTheDocument();
+    expect(screen.getByText("Violation")).toBeInTheDocument();
+    expect(screen.getByTestId("attestation-trend-chart")).toBeInTheDocument();
+  });
+
+  it("renders an empty state when the API has no matching records", async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({
+        attestations: [
+          {
+            id: "other",
+            commitmentId: "CMT-OTHER",
+            observedAt: "2026-06-21T10:00:00Z",
+          },
+        ],
+      }),
+    );
+
+    render(<AttestationHistory commitmentId="CMT-123" />);
+
+    expect(
+      await screen.findByText(
+        "No attestations recorded for this commitment yet.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a retryable error state when the request fails", async () => {
+    fetchMock()
+      .mockRejectedValueOnce(new Error("Network unavailable"))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          data: {
+            attestations: [
+              {
+                id: "recovered",
+                commitmentId: "CMT-123",
+                kind: "health_check",
+                title: "Recovered attestation",
+                observedAt: "2026-06-21T09:00:00Z",
+                details: { complianceScore: 95 },
+              },
+            ],
+          },
+        }),
+      );
+
+    render(<AttestationHistory commitmentId="CMT-123" />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Network unavailable",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(
+      await screen.findByText("Recovered attestation"),
+    ).toBeInTheDocument();
+  });
+
+  it("handles records without numeric compliance scores", async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        data: {
+          attestations: [
+            {
+              id: "manual",
+              commitmentId: "CMT-123",
+              kind: "manual_review",
+              observedAt: "2026-06-21T09:00:00Z",
+              attestorAddress: "GMANUALREVIEW00000000000000000000000000001",
+              description: "Manual reviewer left a note.",
+            },
+          ],
+        },
+      }),
+    );
+
+    render(<AttestationHistory commitmentId="CMT-123" />);
+
+    expect(
+      await screen.findByText("Manual Review attestation"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No score")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No numeric compliance scores are available for charting.",
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #578.

## Summary
- replace the placeholder AttestationHistory component with an API-backed timeline filtered by commitment id
- render compliance scores, pass/violation badges, attestor/timestamp details, and a Recharts trend panel
- add loading, empty, and retryable error states plus RTL coverage for edge cases

## Validation
- npm exec -- vitest run src/components/__tests__/AttestationHistory.test.tsx
- npm exec -- eslint src/components/AttestationHistory.tsx src/components/__tests__/AttestationHistory.test.tsx
- npm exec -- prettier --check src/components/AttestationHistory.tsx src/components/__tests__/AttestationHistory.test.tsx
- git diff --check