### PR TITLE
Add commitment dispute submission flow

### DIFF
--- a/src/app/commitments/[id]/page.tsx
+++ b/src/app/commitments/[id]/page.tsx
@@ -1,114 +1,136 @@
-'use client';
+"use client";
 
-import React from 'react';
-import Link from 'next/link';
-import { notFound } from 'next/navigation';
-import CommitmentHealthMetrics from '@/components/dashboard/CommitmentHealthMetrics';
-import CommitmentDetailAllocationConstraints from '@/components/CommitmentDetailAllocationConstraints';
-import { CommitmentDetailNftSection } from '@/components/dashboard/CommitmentDetailNftSection';
-import { CommitmentDetailParameters } from '@/components/CommitmentDetailParameters/CommitmentDetailParameters';
-import RecentAttestationsPanel from '@/components/RecentAttestationsPanel/RecentAttestationsPanel';
-import { openExplorerUrl } from '@/utils/explorerLinks';
+import React from "react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import CommitmentHealthMetrics from "@/components/dashboard/CommitmentHealthMetrics";
+import CommitmentDetailAllocationConstraints from "@/components/CommitmentDetailAllocationConstraints";
+import { CommitmentDetailNftSection } from "@/components/dashboard/CommitmentDetailNftSection";
+import { CommitmentDetailParameters } from "@/components/CommitmentDetailParameters/CommitmentDetailParameters";
+import { CommitmentDetailActions } from "@/components/CommitmentDetailActions";
+import RecentAttestationsPanel from "@/components/RecentAttestationsPanel/RecentAttestationsPanel";
+import { openExplorerUrl } from "@/utils/explorerLinks";
 
 // Mock Commitments
 const MOCK_COMMITMENTS: Record<
   string,
-  { id: string; type: string; duration: number; maxLoss: number; earlyExitPenaltyPercent?: number }
+  {
+    id: string;
+    type: string;
+    duration: number;
+    maxLoss: number;
+    earlyExitPenaltyPercent?: number;
+  }
 > = {
-  '1': { id: '1', type: 'Balanced', duration: 60, maxLoss: 8, earlyExitPenaltyPercent: 3 },
-  '2': { id: '2', type: 'Safe', duration: 30, maxLoss: 2, earlyExitPenaltyPercent: 3 },
+  "1": {
+    id: "1",
+    type: "Balanced",
+    duration: 60,
+    maxLoss: 8,
+    earlyExitPenaltyPercent: 3,
+  },
+  "2": {
+    id: "2",
+    type: "Safe",
+    duration: 30,
+    maxLoss: 2,
+    earlyExitPenaltyPercent: 3,
+  },
 };
 
 // Mock data for health metrics
 const MOCK_COMPLIANCE_DATA = [
-    { date: 'Jan 1', complianceScore: 98 },
-    { date: 'Jan 5', complianceScore: 97 },
-    { date: 'Jan 10', complianceScore: 99 },
-    { date: 'Jan 15', complianceScore: 95 },
-    { date: 'Jan 20', complianceScore: 98 },
-    { date: 'Jan 25', complianceScore: 100 },
-    { date: 'Jan 30', complianceScore: 99 },
+  { date: "Jan 1", complianceScore: 98 },
+  { date: "Jan 5", complianceScore: 97 },
+  { date: "Jan 10", complianceScore: 99 },
+  { date: "Jan 15", complianceScore: 95 },
+  { date: "Jan 20", complianceScore: 98 },
+  { date: "Jan 25", complianceScore: 100 },
+  { date: "Jan 30", complianceScore: 99 },
 ];
 
 const MOCK_DRAWDOWN_DATA = [
-    { date: 'Jan 10', drawdownPercent: 0 },
-    { date: 'Jan 15', drawdownPercent: 0.35 },
-    { date: 'Jan 20', drawdownPercent: 0.58 },
-    { date: 'Jan 25', drawdownPercent: 0.52 },
-    { date: 'Jan 28', drawdownPercent: 0.78 },
+  { date: "Jan 10", drawdownPercent: 0 },
+  { date: "Jan 15", drawdownPercent: 0.35 },
+  { date: "Jan 20", drawdownPercent: 0.58 },
+  { date: "Jan 25", drawdownPercent: 0.52 },
+  { date: "Jan 28", drawdownPercent: 0.78 },
 ];
 
 const MOCK_VALUE_HISTORY_DATA = [
-    { date: 'Jan 10', currentValue: 50000, initialAmount: 50000 },
-    { date: 'Jan 15', currentValue: 52000, initialAmount: 50000 },
-    { date: 'Jan 20', currentValue: 51500, initialAmount: 50000 },
-    { date: 'Jan 25', currentValue: 53000, initialAmount: 50000 },
-    { date: 'Jan 28', currentValue: 54000, initialAmount: 50000 },
+  { date: "Jan 10", currentValue: 50000, initialAmount: 50000 },
+  { date: "Jan 15", currentValue: 52000, initialAmount: 50000 },
+  { date: "Jan 20", currentValue: 51500, initialAmount: 50000 },
+  { date: "Jan 25", currentValue: 53000, initialAmount: 50000 },
+  { date: "Jan 28", currentValue: 54000, initialAmount: 50000 },
 ];
 
 const MOCK_FEE_GENERATION_DATA = [
-    { date: 'Jan 10', feeAmount: 25 },
-    { date: 'Jan 15', feeAmount: 45 },
-    { date: 'Jan 20', feeAmount: 78 },
-    { date: 'Jan 25', feeAmount: 92 },
-    { date: 'Jan 28', feeAmount: 125 },
+  { date: "Jan 10", feeAmount: 25 },
+  { date: "Jan 15", feeAmount: 45 },
+  { date: "Jan 20", feeAmount: 78 },
+  { date: "Jan 25", feeAmount: 92 },
+  { date: "Jan 28", feeAmount: 125 },
 ];
 
 const MOCK_ATTESTATIONS = [
-    {
-        id: '1',
-        title: 'Daily Compliance Check',
-        description: 'All parameters within acceptable ranges. No violations detected.',
-        txHash: '0xabcdef1234567890abcdef1234567890',
-        timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000),
-        severity: 'ok' as const,
-    },
-    {
-        id: '2',
-        title: 'Allocation Verified',
-        description: 'Portfolio allocation meets all constraints. Safe protocol usage confirmed.',
-        txHash: '0x123456789abcdef123456789abcdef',
-        timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000),
-        severity: 'ok' as const,
-    },
-    {
-        id: '3',
-        title: 'Increased Volatility',
-        description: 'Market volatility increased. Monitoring drawdown levels closely.',
-        txHash: '0x567890abcdef1234567890abcdef1234',
-        timestamp: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
-        severity: 'warning' as const,
-    },
-    {
-        id: '4',
-        title: 'Weekly Review',
-        description: 'Commitment performing well. All rules followed consistently.',
-        txHash: '0x90abcd1234567890abcd345678',
-        timestamp: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
-        severity: 'ok' as const,
-    },
-    {
-        id: '5',
-        title: 'Commitment Created',
-        description: 'Initial commitment parameters set and validated on-chain.',
-        txHash: '0xdef1234567890abcdef890abc',
-        timestamp: new Date(Date.now() - 18 * 24 * 60 * 60 * 1000),
-        severity: 'ok' as const,
-    },
+  {
+    id: "1",
+    title: "Daily Compliance Check",
+    description:
+      "All parameters within acceptable ranges. No violations detected.",
+    txHash: "0xabcdef1234567890abcdef1234567890",
+    timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000),
+    severity: "ok" as const,
+  },
+  {
+    id: "2",
+    title: "Allocation Verified",
+    description:
+      "Portfolio allocation meets all constraints. Safe protocol usage confirmed.",
+    txHash: "0x123456789abcdef123456789abcdef",
+    timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    severity: "ok" as const,
+  },
+  {
+    id: "3",
+    title: "Increased Volatility",
+    description:
+      "Market volatility increased. Monitoring drawdown levels closely.",
+    txHash: "0x567890abcdef1234567890abcdef1234",
+    timestamp: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
+    severity: "warning" as const,
+  },
+  {
+    id: "4",
+    title: "Weekly Review",
+    description: "Commitment performing well. All rules followed consistently.",
+    txHash: "0x90abcd1234567890abcd345678",
+    timestamp: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
+    severity: "ok" as const,
+  },
+  {
+    id: "5",
+    title: "Commitment Created",
+    description: "Initial commitment parameters set and validated on-chain.",
+    txHash: "0xdef1234567890abcdef890abc",
+    timestamp: new Date(Date.now() - 18 * 24 * 60 * 60 * 1000),
+    severity: "ok" as const,
+  },
 ];
 
 const MOCK_ATTESTATION_SUMMARY = {
-    complianceCount: 4,
-    warningCount: 1,
-    violationCount: 0,
+  complianceCount: 4,
+  warningCount: 1,
+  violationCount: 0,
 };
 
 // Mock data for the NFT section
 const MOCK_NFT_DATA = {
-    tokenId: '123456789',
-    ownerAddress: `G${'A'.repeat(55)}`,
-    contractAddress: `C${'B'.repeat(55)}`,
-    mintDate: 'Jan 10, 2026',
+  tokenId: "123456789",
+  ownerAddress: `G${"A".repeat(55)}`,
+  contractAddress: `C${"B".repeat(55)}`,
+  mintDate: "Jan 10, 2026",
 };
 
 function getCommitmentById(id: string) {
@@ -116,114 +138,139 @@ function getCommitmentById(id: string) {
 }
 
 export default function CommitmentDetailPage({
-    params,
+  params,
 }: {
-    params: { id: string };
+  params: { id: string };
 }) {
-    const commitment = getCommitmentById(params.id)
-    if (!commitment) notFound()
+  const commitment = getCommitmentById(params.id);
+  if (!commitment) notFound();
 
-    const durationLabel = `${commitment.duration} days`
-    const maxLossLabel = `${commitment.maxLoss}%`
-    const commitmentTypeLabel = commitment.type
-    const earlyExitPenaltyLabel = `${commitment.earlyExitPenaltyPercent ?? 3}%`
-    
-    const handleCopy = async (text: string, label: string) => {
-        if (navigator.clipboard && navigator.clipboard.writeText) {
-            try {
-                await navigator.clipboard.writeText(text);
-                alert(`${label} Copied!`); 
-            } catch (err) {
-                console.error('Failed to copy!', err);
-            }
-        }
-    };
+  const durationLabel = `${commitment.duration} days`;
+  const maxLossLabel = `${commitment.maxLoss}%`;
+  const commitmentTypeLabel = commitment.type;
+  const earlyExitPenaltyLabel = `${commitment.earlyExitPenaltyPercent ?? 3}%`;
 
-    const handleViewDetails = () => console.log('View Details clicked');
-    const handleViewExplorer = () => openExplorerUrl('contract', MOCK_NFT_DATA.contractAddress, 'testnet');
-    const handleTransfer = () => console.log('Transfer clicked');
+  const handleCopy = async (text: string, label: string) => {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        alert(`${label} Copied!`);
+      } catch (err) {
+        console.error("Failed to copy!", err);
+      }
+    }
+  };
 
-    return (
-        <main id="main-content" className="min-h-screen bg-[#050505] text-[#f5f5f7] p-4 sm:p-8 lg:p-12">
-            <div className="max-w-7xl mx-auto space-y-8">
-                
-                <header className="flex flex-col gap-4">
-                    <Link
-                        href="/commitments"
-                        className="text-[#666] hover:text-[#0ff0fc] transition-colors text-sm w-fit"
-                        aria-label="Back to My Commitments"
-                    >
-                        ← Back to My Commitments
-                    </Link>
-                    <div className="flex items-center justify-between">
-                        <div>
-                            <h1 className="text-3xl sm:text-4xl font-bold bg-clip-text text-transparent bg-linear-to-b from-white to-[#99a1af]">
-                                {commitment.type} Commitment #{commitment.id}
-                            </h1>
-                            <p className="text-[#99a1af] mt-2">
-                                Active • {commitment.type} Strategy
-                            </p>
-                        </div>
-                        <div className="hidden sm:block">
-                            <span className="px-4 py-2 bg-[#1a1a1a] border border-[#222] rounded-lg text-[#0ff0fc] text-sm font-medium">
-                                Active
-                            </span>
-                        </div>
-                    </div>
-                </header>
+  const handleViewDetails = () => console.log("View Details clicked");
+  const handleViewExplorer = () =>
+    openExplorerUrl("contract", MOCK_NFT_DATA.contractAddress, "testnet");
+  const handleTransfer = () => console.log("Transfer clicked");
 
-                <div className="bg-[#0a0a0a] rounded-2xl p-6 border border-[#222]">
-                    <CommitmentDetailParameters
-                        durationLabel={durationLabel}
-                        maxLossLabel={maxLossLabel}
-                        commitmentTypeLabel={commitmentTypeLabel}
-                        earlyExitPenaltyLabel={earlyExitPenaltyLabel}
-                    />
-                </div>
-
-                <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-start">
-                    <div className="lg:col-span-2 space-y-8">
-                        <CommitmentHealthMetrics 
-                            complianceData={MOCK_COMPLIANCE_DATA}
-                            drawdownData={MOCK_DRAWDOWN_DATA}
-                            valueHistoryData={MOCK_VALUE_HISTORY_DATA}
-                            feeGenerationData={MOCK_FEE_GENERATION_DATA}
-                            thresholdPercent={0.5}
-                            volatilityPercent={35}
-                        />
-
-                        <RecentAttestationsPanel
-                            attestations={MOCK_ATTESTATIONS}
-                            summary={MOCK_ATTESTATION_SUMMARY}
-                            onSelectAttestation={(id) => console.log('Selected attestation:', id)}
-                            onViewAll={() => console.log('View all attestations')}
-                        />
-                        
-                        <CommitmentDetailAllocationConstraints 
-                            constraints={[
-                                { id: '1', text: 'Max 50% allocation to any single protocol' },
-                                { id: '2', text: 'Only whitelisted DeFi protocols allowed' },
-                                { id: '3', text: 'Minimum 20% must remain in stablecoins' },
-                            ]}
-                        />
-                    </div>
-
-                    <div className="lg:col-span-1 w-full">
-                        <CommitmentDetailNftSection 
-                            tokenId={MOCK_NFT_DATA.tokenId}
-                            ownerAddress={MOCK_NFT_DATA.ownerAddress}
-                            contractAddress={MOCK_NFT_DATA.contractAddress}
-                            mintDate={MOCK_NFT_DATA.mintDate}
-                            onCopyTokenId={() => handleCopy(MOCK_NFT_DATA.tokenId, 'Token ID')}
-                            onCopyOwner={() => handleCopy(MOCK_NFT_DATA.ownerAddress, 'Owner Address')}
-                            onCopyContract={() => handleCopy(MOCK_NFT_DATA.contractAddress, 'Contract Address')}
-                            onViewDetails={handleViewDetails}
-                            onViewOnExplorer={handleViewExplorer}
-                            onTransfer={handleTransfer}
-                        />
-                    </div>
-                </div>
+  return (
+    <main
+      id="main-content"
+      className="min-h-screen bg-[#050505] text-[#f5f5f7] p-4 sm:p-8 lg:p-12"
+    >
+      <div className="max-w-7xl mx-auto space-y-8">
+        <header className="flex flex-col gap-4">
+          <Link
+            href="/commitments"
+            className="text-[#666] hover:text-[#0ff0fc] transition-colors text-sm w-fit"
+            aria-label="Back to My Commitments"
+          >
+            ← Back to My Commitments
+          </Link>
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-3xl sm:text-4xl font-bold bg-clip-text text-transparent bg-linear-to-b from-white to-[#99a1af]">
+                {commitment.type} Commitment #{commitment.id}
+              </h1>
+              <p className="text-[#99a1af] mt-2">
+                Active • {commitment.type} Strategy
+              </p>
             </div>
-        </main>
-    );
+            <div className="hidden sm:block">
+              <span className="px-4 py-2 bg-[#1a1a1a] border border-[#222] rounded-lg text-[#0ff0fc] text-sm font-medium">
+                Active
+              </span>
+            </div>
+          </div>
+        </header>
+
+        <div className="bg-[#0a0a0a] rounded-2xl p-6 border border-[#222]">
+          <CommitmentDetailParameters
+            durationLabel={durationLabel}
+            maxLossLabel={maxLossLabel}
+            commitmentTypeLabel={commitmentTypeLabel}
+            earlyExitPenaltyLabel={earlyExitPenaltyLabel}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-start">
+          <div className="lg:col-span-2 space-y-8">
+            <CommitmentHealthMetrics
+              complianceData={MOCK_COMPLIANCE_DATA}
+              drawdownData={MOCK_DRAWDOWN_DATA}
+              valueHistoryData={MOCK_VALUE_HISTORY_DATA}
+              feeGenerationData={MOCK_FEE_GENERATION_DATA}
+              thresholdPercent={0.5}
+              volatilityPercent={35}
+            />
+
+            <RecentAttestationsPanel
+              attestations={MOCK_ATTESTATIONS}
+              summary={MOCK_ATTESTATION_SUMMARY}
+              onSelectAttestation={(id) =>
+                console.log("Selected attestation:", id)
+              }
+              onViewAll={() => console.log("View all attestations")}
+            />
+
+            <CommitmentDetailAllocationConstraints
+              constraints={[
+                { id: "1", text: "Max 50% allocation to any single protocol" },
+                { id: "2", text: "Only whitelisted DeFi protocols allowed" },
+                { id: "3", text: "Minimum 20% must remain in stablecoins" },
+              ]}
+            />
+          </div>
+
+          <div className="lg:col-span-1 w-full">
+            <CommitmentDetailNftSection
+              tokenId={MOCK_NFT_DATA.tokenId}
+              ownerAddress={MOCK_NFT_DATA.ownerAddress}
+              contractAddress={MOCK_NFT_DATA.contractAddress}
+              mintDate={MOCK_NFT_DATA.mintDate}
+              onCopyTokenId={() =>
+                handleCopy(MOCK_NFT_DATA.tokenId, "Token ID")
+              }
+              onCopyOwner={() =>
+                handleCopy(MOCK_NFT_DATA.ownerAddress, "Owner Address")
+              }
+              onCopyContract={() =>
+                handleCopy(MOCK_NFT_DATA.contractAddress, "Contract Address")
+              }
+              onViewDetails={handleViewDetails}
+              onViewOnExplorer={handleViewExplorer}
+              onTransfer={handleTransfer}
+            />
+
+            <div className="mt-8 rounded-2xl border border-[#222] bg-[#0a0a0a] p-6">
+              <CommitmentDetailActions
+                canEarlyExit
+                commitmentId={commitment.id}
+                callerAddress={MOCK_NFT_DATA.ownerAddress}
+                onEarlyExit={() => console.log("Early exit clicked")}
+                onViewAttestations={() =>
+                  console.log("View attestations clicked")
+                }
+                onExportData={() => console.log("Export data clicked")}
+                onReportIssue={() => console.log("Report issue clicked")}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
 }

--- a/src/components/CommitmentDetailActions.tsx
+++ b/src/components/CommitmentDetailActions.tsx
@@ -1,22 +1,98 @@
-import React from 'react';
-import { FiLogOut, FiFileText, FiDownload, FiAlertCircle } from 'react-icons/fi';
+import React, { useState } from "react";
+import {
+  FiLogOut,
+  FiFileText,
+  FiDownload,
+  FiAlertCircle,
+} from "react-icons/fi";
+import { DisputeFormValues, DisputeModal } from "./dispute/DisputeModal";
 
 interface CommitmentDetailActionsProps {
   canEarlyExit: boolean;
+  commitmentId?: string;
+  callerAddress?: string;
   onEarlyExit: () => void;
   onViewAttestations: () => void;
   onExportData: () => void;
   onReportIssue: () => void;
 }
 
-export function CommitmentDetailActions ({
+export function CommitmentDetailActions({
   canEarlyExit,
+  commitmentId,
+  callerAddress,
   onEarlyExit,
   onViewAttestations,
   onExportData,
   onReportIssue,
-
 }: CommitmentDetailActionsProps) {
+  const [isDisputeOpen, setIsDisputeOpen] = useState(false);
+  const [isSubmittingDispute, setIsSubmittingDispute] = useState(false);
+  const [disputeError, setDisputeError] = useState<string | null>(null);
+  const [disputeSuccess, setDisputeSuccess] = useState<string | null>(null);
+
+  const isDisputed = Boolean(disputeSuccess);
+
+  const handleOpenDispute = () => {
+    if (!commitmentId) {
+      onReportIssue();
+      return;
+    }
+
+    setDisputeError(null);
+    setIsDisputeOpen(true);
+  };
+
+  const handleSubmitDispute = async ({
+    category,
+    reasonText,
+  }: DisputeFormValues) => {
+    if (!commitmentId) {
+      return;
+    }
+
+    setIsSubmittingDispute(true);
+    setDisputeError(null);
+
+    try {
+      const response = await fetch(`/api/commitments/${commitmentId}/dispute`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          reason: `[${category}] ${reasonText}`,
+          evidence: `category:${category}`,
+          callerAddress,
+        }),
+      });
+
+      if (!response.ok) {
+        let message = "Unable to open dispute. Please retry.";
+
+        try {
+          const body = await response.json();
+          message = body?.error?.message ?? body?.message ?? message;
+        } catch {
+          // Keep the generic message if the response is not JSON.
+        }
+
+        throw new Error(message);
+      }
+
+      setDisputeSuccess(
+        "Dispute opened. This commitment is now marked as Disputed.",
+      );
+      setIsDisputeOpen(false);
+    } catch (error) {
+      setDisputeError(
+        error instanceof Error ? error.message : "Unable to open dispute.",
+      );
+    } finally {
+      setIsSubmittingDispute(false);
+    }
+  };
+
   return (
     <div className="w-full ">
       {/* Section Heading */}
@@ -24,8 +100,10 @@ export function CommitmentDetailActions ({
 
       {/* Primary Actions */}
       <div className="mb-8">
-        <h3 className="text-white text-base font-semibold mb-4">Primary Actions</h3>
-        
+        <h3 className="text-white text-base font-semibold mb-4">
+          Primary Actions
+        </h3>
+
         {/* Early Exit Button */}
         <button
           onClick={canEarlyExit ? onEarlyExit : undefined}
@@ -34,28 +112,35 @@ export function CommitmentDetailActions ({
             w-full rounded-3xl px-8 py-6
             border-2 transition-all duration-300
             flex items-center gap-6 justify-center
-            ${canEarlyExit 
-              ? 'bg-[#0A0A0A] border-[#F97316] shadow-[0_4px_24px_rgba(249,115,22,0.2),inset_0_1px_0_rgba(249,115,22,0.1)] hover:shadow-[0_8px_32px_rgba(249,115,22,0.3),inset_0_1px_0_rgba(249,115,22,0.2)] cursor-pointer hover:bg-[#161616]' 
-              : 'bg-[#161616] border-[#F97316]/30 opacity-50 cursor-not-allowed'
+            ${
+              canEarlyExit
+                ? "bg-[#0A0A0A] border-[#F97316] shadow-[0_4px_24px_rgba(249,115,22,0.2),inset_0_1px_0_rgba(249,115,22,0.1)] hover:shadow-[0_8px_32px_rgba(249,115,22,0.3),inset_0_1px_0_rgba(249,115,22,0.2)] cursor-pointer hover:bg-[#161616]"
+                : "bg-[#161616] border-[#F97316]/30 opacity-50 cursor-not-allowed"
             }
           `}
           aria-label="Early Exit - Exit before expiry (penalty applies)"
         >
           {/* Icon */}
-          <FiLogOut className="text-[#F97316]" size={28}/>
-          
+          <FiLogOut className="text-[#F97316]" size={28} />
+
           {/* Text Content */}
           <div className=" text-left">
-            <div className="text-[#F97316] text-xl font-semibold mb-1">Early Exit</div>
-            <div className="text-white/50 text-sm">Exit before expiry (penalty applies)</div>
+            <div className="text-[#F97316] text-xl font-semibold mb-1">
+              Early Exit
+            </div>
+            <div className="text-white/50 text-sm">
+              Exit before expiry (penalty applies)
+            </div>
           </div>
         </button>
       </div>
 
       {/* Additional Actions */}
       <div className="mb-8">
-        <h3 className="text-white text-base font-semibold mb-4">Additional Actions</h3>
-        
+        <h3 className="text-white text-base font-semibold mb-4">
+          Additional Actions
+        </h3>
+
         <div className="space-y-3">
           {/* View Full Attestation History */}
           <button
@@ -71,8 +156,8 @@ export function CommitmentDetailActions ({
             aria-label="View Full Attestation History"
           >
             {/* Icon */}
-            <FiFileText className="text-white/70" size={22}/>
-            
+            <FiFileText className="text-white/70" size={22} />
+
             {/* Text */}
             <span className="text-white text-base flex-1 text-left font-medium">
               View Full Attestation History
@@ -93,8 +178,8 @@ export function CommitmentDetailActions ({
             aria-label="Export Commitment Data"
           >
             {/* Icon */}
-            <FiDownload className="text-white/70" size={22}/>
-            
+            <FiDownload className="text-white/70" size={22} />
+
             {/* Text */}
             <span className="text-white text-base flex-1 text-left font-medium">
               Export Commitment Data
@@ -103,7 +188,8 @@ export function CommitmentDetailActions ({
 
           {/* Report an Issue */}
           <button
-            onClick={onReportIssue}
+            onClick={handleOpenDispute}
+            disabled={isDisputed}
             className="
               w-full rounded-2xl px-6 py-4
               bg-[#161616] border border-[#232323]
@@ -111,34 +197,56 @@ export function CommitmentDetailActions ({
               transition-all duration-200
               flex items-center gap-4
               cursor-pointer
+              disabled:cursor-not-allowed disabled:opacity-60
             "
-            aria-label="Report an Issue"
+            aria-label={isDisputed ? "Commitment is disputed" : "Open dispute"}
           >
             {/* Icon */}
-            <FiAlertCircle className="text-white/70" size={22}/>
-            
+            <FiAlertCircle className="text-white/70" size={22} />
+
             {/* Text */}
             <span className="text-white text-base flex-1 text-left font-medium">
-              Report an Issue
+              {isDisputed ? "Disputed" : "Open Dispute"}
             </span>
           </button>
         </div>
       </div>
 
+      {disputeSuccess ? (
+        <p
+          role="status"
+          className="mb-6 rounded-2xl border border-emerald-400/30 bg-emerald-950/30 px-4 py-3 text-sm text-emerald-100"
+        >
+          {disputeSuccess}
+        </p>
+      ) : null}
+
       {/* Helper Note */}
-      <div className="
+      <div
+        className="
         rounded-3xl px-6 py-5
         bg-[#0a1516] border border-[#0a282a]
         flex items-start gap-4 
-      ">
-       
-        
+      "
+      >
         {/* Helper Text */}
         <p className="text-white/50 text-sm leading-relaxed ">
-           All actions are recorded on-chain and can be verified through attestations. Contact support if you encounter any issues.
+          All actions are recorded on-chain and can be verified through
+          attestations. Contact support if you encounter any issues.
         </p>
       </div>
+
+      {commitmentId ? (
+        <DisputeModal
+          commitmentId={commitmentId}
+          isOpen={isDisputeOpen}
+          isSubmitting={isSubmittingDispute}
+          errorMessage={disputeError}
+          successMessage={disputeSuccess}
+          onCancel={() => setIsDisputeOpen(false)}
+          onSubmit={handleSubmitDispute}
+        />
+      ) : null}
     </div>
   );
-};
-
+}

--- a/src/components/dispute/DisputeModal.tsx
+++ b/src/components/dispute/DisputeModal.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+
+export type DisputeReasonCategory =
+  | "ValueMismatch"
+  | "NonCompliance"
+  | "FraudSuspicion"
+  | "OperationalFailure"
+  | "Other";
+
+export interface DisputeFormValues {
+  category: DisputeReasonCategory;
+  reasonText: string;
+}
+
+interface DisputeModalProps {
+  commitmentId: string;
+  isOpen: boolean;
+  isSubmitting?: boolean;
+  errorMessage?: string | null;
+  successMessage?: string | null;
+  onCancel: () => void;
+  onSubmit: (values: DisputeFormValues) => void | Promise<void>;
+}
+
+const REASON_OPTIONS: Array<{
+  value: DisputeReasonCategory;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "ValueMismatch",
+    label: "Value mismatch",
+    description:
+      "Reported value, amount, or payout terms do not match the commitment.",
+  },
+  {
+    value: "NonCompliance",
+    label: "Non-compliance",
+    description:
+      "The commitment appears to violate its stated compliance rules.",
+  },
+  {
+    value: "FraudSuspicion",
+    label: "Fraud suspicion",
+    description: "There are signs of misrepresentation or suspicious activity.",
+  },
+  {
+    value: "OperationalFailure",
+    label: "Operational failure",
+    description:
+      "An operational or execution issue prevents normal settlement.",
+  },
+  {
+    value: "Other",
+    label: "Other",
+    description: "Use when none of the listed categories fit the dispute.",
+  },
+];
+
+const MAX_REASON_LENGTH = 500;
+
+export function DisputeModal({
+  commitmentId,
+  isOpen,
+  isSubmitting = false,
+  errorMessage,
+  successMessage,
+  onCancel,
+  onSubmit,
+}: DisputeModalProps) {
+  const [category, setCategory] =
+    useState<DisputeReasonCategory>("ValueMismatch");
+  const [reasonText, setReasonText] = useState("");
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+
+  const trimmedReason = reasonText.trim();
+  const reasonTooLong = reasonText.length > MAX_REASON_LENGTH;
+  const reasonMissing = hasSubmitted && trimmedReason.length === 0;
+  const canSubmit = trimmedReason.length > 0 && !reasonTooLong && !isSubmitting;
+  const submitDisabled = isSubmitting || reasonTooLong;
+
+  const selectedReason = useMemo(
+    () => REASON_OPTIONS.find((option) => option.value === category),
+    [category],
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setHasSubmitted(true);
+
+    if (!canSubmit) {
+      return;
+    }
+
+    await onSubmit({ category, reasonText: trimmedReason });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-8"
+      role="presentation"
+    >
+      <div
+        className="w-full max-w-xl rounded-3xl border border-[#253335] bg-[#0a0a0a] p-6 shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dispute-modal-title"
+        aria-describedby="dispute-modal-description"
+      >
+        <div className="mb-5 flex items-start justify-between gap-4">
+          <div>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#0ff0fc]">
+              Frozen state request
+            </p>
+            <h2
+              id="dispute-modal-title"
+              className="text-2xl font-semibold text-white"
+            >
+              Open dispute
+            </h2>
+            <p
+              id="dispute-modal-description"
+              className="mt-2 text-sm leading-6 text-white/60"
+            >
+              Categorize the issue and add details for commitment {commitmentId}
+              .
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-full border border-white/10 px-3 py-2 text-sm text-white/70 transition hover:border-white/30 hover:text-white"
+            aria-label="Close dispute modal"
+          >
+            Close
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-white">
+              Reason category
+            </span>
+            <select
+              value={category}
+              onChange={(event) =>
+                setCategory(event.target.value as DisputeReasonCategory)
+              }
+              className="w-full rounded-2xl border border-[#1f3436] bg-[#101314] px-4 py-3 text-white outline-none transition focus:border-[#0ff0fc]"
+            >
+              {REASON_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {selectedReason ? (
+            <p className="rounded-2xl border border-[#0a282a] bg-[#0a1516] px-4 py-3 text-sm leading-6 text-white/60">
+              {selectedReason.description}
+            </p>
+          ) : null}
+
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-white">
+              Detail text
+            </span>
+            <textarea
+              value={reasonText}
+              onChange={(event) => setReasonText(event.target.value)}
+              maxLength={MAX_REASON_LENGTH + 1}
+              rows={5}
+              className="w-full resize-none rounded-2xl border border-[#1f3436] bg-[#101314] px-4 py-3 text-white outline-none transition placeholder:text-white/30 focus:border-[#0ff0fc]"
+              placeholder="Describe the mismatch, violation, or failure."
+              aria-invalid={reasonMissing || reasonTooLong}
+              aria-describedby="dispute-reason-help"
+            />
+          </label>
+
+          <div
+            id="dispute-reason-help"
+            className="flex items-center justify-between gap-4 text-xs text-white/50"
+          >
+            <span>Required. Maximum 500 characters.</span>
+            <span>{reasonText.length}/500</span>
+          </div>
+
+          {reasonMissing ? (
+            <p role="alert" className="text-sm text-[#ff8a04]">
+              Add detail text before opening the dispute.
+            </p>
+          ) : null}
+
+          {reasonTooLong ? (
+            <p role="alert" className="text-sm text-[#ff8a04]">
+              Reason text must be 500 characters or less.
+            </p>
+          ) : null}
+
+          {errorMessage ? (
+            <p
+              role="alert"
+              className="rounded-2xl border border-red-500/30 bg-red-950/30 px-4 py-3 text-sm text-red-100"
+            >
+              {errorMessage}
+            </p>
+          ) : null}
+
+          {successMessage ? (
+            <p
+              role="status"
+              className="rounded-2xl border border-emerald-400/30 bg-emerald-950/30 px-4 py-3 text-sm text-emerald-100"
+            >
+              {successMessage}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-2xl border border-white/10 px-5 py-3 font-medium text-white/70 transition hover:border-white/30 hover:text-white"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitDisabled}
+              className="rounded-2xl border border-[#0b5d61] bg-[#0a2122] px-5 py-3 font-semibold text-white transition hover:bg-[#0d2a2c] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSubmitting ? "Opening dispute..." : "Open dispute"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export { REASON_OPTIONS };

--- a/tests/components/CommitmentDetailActions.test.tsx
+++ b/tests/components/CommitmentDetailActions.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from "react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CommitmentDetailActions } from "../../src/components/CommitmentDetailActions";
+
+const actionProps = {
+  canEarlyExit: true,
+  commitmentId: "CMT-001",
+  callerAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  onEarlyExit: vi.fn(),
+  onViewAttestations: vi.fn(),
+  onExportData: vi.fn(),
+  onReportIssue: vi.fn(),
+};
+
+describe("CommitmentDetailActions", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens a dispute modal from the actions panel", () => {
+    render(<CommitmentDetailActions {...actionProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /open dispute/i }));
+
+    expect(
+      screen.getByRole("dialog", { name: /open dispute/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("posts a categorized dispute and reflects the Disputed state", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        data: { disputeId: "DSP-001", status: "Disputed" },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<CommitmentDetailActions {...actionProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /open dispute/i }));
+    fireEvent.change(screen.getByLabelText(/reason category/i), {
+      target: { value: "OperationalFailure" },
+    });
+    fireEvent.change(screen.getByLabelText(/detail text/i), {
+      target: { value: "Oracle job failed and prevented settlement." },
+    });
+    fireEvent.click(
+      within(screen.getByRole("dialog", { name: /open dispute/i })).getByRole(
+        "button",
+        { name: /^open dispute$/i },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/commitments/CMT-001/dispute",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            reason:
+              "[OperationalFailure] Oracle job failed and prevented settlement.",
+            evidence: "category:OperationalFailure",
+            callerAddress: actionProps.callerAddress,
+          }),
+        },
+      );
+    });
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      /now marked as disputed/i,
+    );
+    expect(
+      screen.getByRole("button", { name: /commitment is disputed/i }),
+    ).toBeDisabled();
+  });
+
+  it("surfaces API failures inside the modal", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: vi.fn().mockResolvedValue({
+          error: { message: "Commitment is already in dispute." },
+        }),
+      }),
+    );
+
+    render(<CommitmentDetailActions {...actionProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /open dispute/i }));
+    fireEvent.change(screen.getByLabelText(/detail text/i), {
+      target: { value: "Duplicate dispute attempt." },
+    });
+    fireEvent.click(
+      within(screen.getByRole("dialog", { name: /open dispute/i })).getByRole(
+        "button",
+        { name: /^open dispute$/i },
+      ),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Commitment is already in dispute.",
+    );
+  });
+});

--- a/tests/components/DisputeModal.test.tsx
+++ b/tests/components/DisputeModal.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DisputeModal } from "../../src/components/dispute/DisputeModal";
+
+const defaultProps = {
+  commitmentId: "CMT-001",
+  isOpen: true,
+  onCancel: vi.fn(),
+  onSubmit: vi.fn(),
+};
+
+describe("DisputeModal", () => {
+  it("renders the category selector and reason input", () => {
+    render(<DisputeModal {...defaultProps} />);
+
+    expect(
+      screen.getByRole("dialog", { name: /open dispute/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/reason category/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/detail text/i)).toBeInTheDocument();
+    expect(screen.getByText(/commitment CMT-001/i)).toBeInTheDocument();
+  });
+
+  it("requires detail text before submitting", () => {
+    const onSubmit = vi.fn();
+    render(<DisputeModal {...defaultProps} onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^open dispute$/i }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/add detail text/i);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits category and trimmed detail text", () => {
+    const onSubmit = vi.fn();
+    render(<DisputeModal {...defaultProps} onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/reason category/i), {
+      target: { value: "FraudSuspicion" },
+    });
+    fireEvent.change(screen.getByLabelText(/detail text/i), {
+      target: { value: "  Seller submitted contradictory evidence.  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^open dispute$/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      category: "FraudSuspicion",
+      reasonText: "Seller submitted contradictory evidence.",
+    });
+  });
+
+  it("shows success and API error messages", () => {
+    const { rerender } = render(
+      <DisputeModal {...defaultProps} successMessage="Dispute opened." />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("Dispute opened.");
+
+    rerender(
+      <DisputeModal {...defaultProps} errorMessage="Already disputed." />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Already disputed.");
+  });
+});


### PR DESCRIPTION
Closes #588

## Summary
- Add a categorized dispute modal for commitment detail actions.
- Wire dispute submission to the existing commitment dispute API endpoint.
- Mark the action panel as Disputed after a successful submission and prevent duplicate opens.
- Add focused component coverage for validation, API payloads, success state, and failure messaging.

## Validation
- Focused dispute modal/actions component tests passed: 7 tests.
- Prettier check passed for changed files.
- ESLint passed for changed component and test files.
- Full project TypeScript check is currently blocked by pre-existing parse errors in unrelated files outside this change.

Payout: Base USDC `0xe87b4889baeee4ed60a1b2bfc7b3a6a17bce4ad6`
