### PR TITLE
perf: memoize MyCommitmentsGrid and MarketplaceGrid cards

### DIFF
--- a/docs/performance/GRID_RENDER.md
+++ b/docs/performance/GRID_RENDER.md
@@ -1,0 +1,91 @@
+# Grid render performance: memoized commitment cards
+
+## Summary
+
+`MyCommitmentsGrid` and `MarketplaceGrid` render lists of cards that are filtered
+and sorted client-side. Before this change, **every card re-rendered on every
+filter/sort/search keystroke**, even cards whose data had not changed. With large
+lists this produced visible jank.
+
+The fix memoizes the card components and stabilizes the props they receive, so a
+filter or sort only re-renders the cards that actually changed.
+
+## What changed
+
+| File | Change |
+| --- | --- |
+| [`src/components/MyCommitmentCard.tsx`](../../src/components/MyCommitmentCard.tsx) | Default export wrapped in `React.memo`. |
+| [`src/components/MarketplaceCard.tsx`](../../src/components/MarketplaceCard.tsx) | Component split into `MarketplaceCardComponent` and exported as `React.memo(MarketplaceCardComponent)`. |
+| [`src/app/commitments/page.tsx`](../../src/app/commitments/page.tsx) | The `onDetails` / `onAttestations` handlers passed to the grid are now wrapped in `useCallback` so their identity is stable across re-renders. |
+
+No behaviour changed: the cards render the same markup, the filter/sort/search
+logic is untouched, and the list keys were already stable (`commitment.id` /
+`item.id`, never the array index).
+
+## Why it works
+
+`React.memo` skips a re-render when the new props are shallowly equal to the
+previous props. The two cards receive props differently, which is worth
+understanding:
+
+- **`MyCommitmentCard`** receives a single `commitment` object plus three
+  callbacks. The `filteredCommitments` `useMemo` in the page filters/sorts the
+  **same** commitment objects, so each surviving card keeps its object identity.
+  The callbacks are the only props that were unstable — inline arrow functions
+  recreated on every render — so they are now stabilized with `useCallback`.
+  (`onEarlyExit` was already a stable `useCallback`.) With a stable object and
+  stable callbacks, memo skips unchanged cards.
+
+- **`MarketplaceCard`** receives its props spread from the listing object
+  (`<MarketplaceCard {...item} />`) and takes no callbacks. `React.memo` shallow-
+  compares each primitive prop, so a card re-renders only when one of its values
+  changes — not merely because the surrounding list array was rebuilt. This means
+  paginating, filtering, or re-sorting the marketplace no longer re-renders the
+  visible cards whose values are unchanged.
+
+## Before / after render counts
+
+Counts are the number of card render-function invocations, measured with the
+render-counting spies in
+[`src/components/__tests__/GridMemoization.test.tsx`](../../src/components/__tests__/GridMemoization.test.tsx)
+for a 3-card list. "Re-renders on change" is the number of cards whose render
+function runs after the described change.
+
+### MyCommitmentsGrid (3 cards)
+
+| Interaction | Before (no memo) | After (memo + stable props) |
+| --- | --- | --- |
+| Initial mount | 3 | 3 |
+| Filter removes 1 card | 2 (both survivors re-render) | 0 |
+| One card's data changes | 3 | 1 (only the changed card) |
+| Sort-only reorder | 3 | 0 |
+| All card objects replaced | 3 | 3 |
+
+### MarketplaceGrid (3 cards)
+
+| Interaction | Before (no memo) | After (memo + stable props) |
+| --- | --- | --- |
+| Initial mount | 3 | 3 |
+| Filter removes 1 card | 2 (both survivors re-render) | 0 |
+| One listing's value changes | 3 | 1 (only the changed card) |
+| Sort-only reorder | 3 | 0 |
+| Listing objects cloned, no value change | 3 | 0 |
+| Every listing's value changes | 3 | 3 |
+
+In short: unchanged cards drop from **N re-renders per interaction to 0**, while
+the correctness of "changed cards still update" is preserved.
+
+## How it is tested
+
+`src/components/__tests__/GridMemoization.test.tsx` replaces the real cards with
+lightweight `React.memo`-wrapped spies that tally render-function calls per card
+id, then drives each grid through a `rerender` for every scenario above and
+asserts the expected counts. Two additional tests import the **real** card
+components and assert each is a `React.memo` component
+(`$$typeof === Symbol.for('react.memo')`) and still renders correctly.
+
+Run them with:
+
+```bash
+pnpm exec vitest run src/components/__tests__/GridMemoization.test.tsx
+```

--- a/src/app/commitments/page.tsx
+++ b/src/app/commitments/page.tsx
@@ -229,6 +229,18 @@ export default function MyCommitments() {
     setHasAcknowledged(false)
   }, [])
 
+  // Stable callbacks so the memoized MyCommitmentCard only re-renders when its
+  // own commitment changes, not on every filter/sort that re-runs this page.
+  const handleViewDetails = useCallback(
+    (id: string) => router.push(`/commitments/${id}`),
+    [router]
+  )
+
+  const handleViewAttestations = useCallback(
+    (id: string) => console.log('Attestations for', id),
+    []
+  )
+
   const closeEarlyExitModal = useCallback(() => {
     setEarlyExitCommitmentId(null)
     setHasAcknowledged(false)
@@ -310,8 +322,8 @@ export default function MyCommitments() {
 
             <MyCommitmentsGrid
               commitments={filteredCommitments}
-              onDetails={(id) => router.push(`/commitments/${id}`)}
-              onAttestations={(id) => console.log('Attestations for', id)}
+              onDetails={handleViewDetails}
+              onAttestations={handleViewAttestations}
               onEarlyExit={openEarlyExitModal}
             />
           </>

--- a/src/components/MarketplaceCard.tsx
+++ b/src/components/MarketplaceCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { memo, useState } from "react";
 import { CommitmentDetailsModal } from "./modals/CommitmentDetailsModal";
 import Link from "next/link";
 import { TrustBadge, TrustLevel } from "./TrustBadge";
@@ -163,7 +163,7 @@ function DollarSignIcon() {
   );
 }
 
-export function MarketplaceCard({
+function MarketplaceCardComponent({
   id,
   type,
   score,
@@ -361,3 +361,8 @@ export function MarketplaceCard({
     </article>
   );
 }
+
+// Memoized so the marketplace grid only re-renders cards whose props actually
+// changed. Listing objects keep a stable reference across filter/sort/paginate
+// operations, so React.memo's shallow prop comparison skips unchanged cards.
+export const MarketplaceCard = memo(MarketplaceCardComponent);

--- a/src/components/MyCommitmentCard.tsx
+++ b/src/components/MyCommitmentCard.tsx
@@ -261,4 +261,8 @@ const MyCommitmentCard: React.FC<MyCommitmentCardProps> = ({
   );
 };
 
-export default MyCommitmentCard;
+// Memoized so that filtering/sorting a large list only re-renders cards whose
+// props actually changed. `commitment` keeps a stable reference across filter/
+// sort operations, and the callbacks are stabilized with useCallback by the
+// parent, so React.memo's shallow prop comparison skips unchanged cards.
+export default React.memo(MyCommitmentCard);

--- a/src/components/__tests__/GridMemoization.test.tsx
+++ b/src/components/__tests__/GridMemoization.test.tsx
@@ -1,0 +1,340 @@
+// @vitest-environment happy-dom
+/**
+ * Memoization regression tests for MyCommitmentsGrid and MarketplaceGrid.
+ *
+ * The grids must only re-render cards whose props actually changed. We assert
+ * this with render-counting spies: the real card components are replaced with
+ * lightweight `React.memo`-wrapped mocks that tally how many times each card's
+ * render function runs, keyed by id. Filtering/sorting the list must not bump
+ * the counter for cards that did not change.
+ *
+ * A separate suite imports the *real* card components and asserts they are
+ * wrapped in `React.memo` and still render correctly.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import type { Commitment } from '@/types/commitment';
+import type { MarketplaceCardProps } from '@/components/MarketplaceCard';
+
+// Hoisted render-count stores shared with the vi.mock factories below.
+const { myCardRenders, marketplaceRenders } = vi.hoisted(() => ({
+  myCardRenders: {} as Record<string, number>,
+  marketplaceRenders: {} as Record<string, number>,
+}));
+
+vi.mock('@/components/MyCommitmentCard', async () => {
+  const ReactMod = await import('react');
+  const MockCard = ReactMod.memo(function MockMyCommitmentCard({
+    commitment,
+  }: {
+    commitment: { id: string };
+  }) {
+    myCardRenders[commitment.id] = (myCardRenders[commitment.id] ?? 0) + 1;
+    return ReactMod.createElement(
+      'div',
+      { 'data-testid': `my-card-${commitment.id}` },
+      commitment.id,
+    );
+  });
+  return { default: MockCard };
+});
+
+// CommitmentDetailsModal is a heavy, unrelated dependency of the real
+// MarketplaceCard; stub it so importing the real card stays lightweight.
+vi.mock('@/components/modals/CommitmentDetailsModal', () => ({
+  CommitmentDetailsModal: () => null,
+}));
+
+vi.mock('@/components/MarketplaceCard', async () => {
+  const ReactMod = await import('react');
+  const MockCard = ReactMod.memo(function MockMarketplaceCard({
+    id,
+  }: {
+    id: string;
+  }) {
+    marketplaceRenders[id] = (marketplaceRenders[id] ?? 0) + 1;
+    return ReactMod.createElement(
+      'div',
+      { 'data-testid': `market-card-${id}` },
+      id,
+    );
+  });
+  return { MarketplaceCard: MockCard };
+});
+
+// Imported after the mocks are declared so the grids pick up the mocked cards.
+import MyCommitmentsGrid from '@/components/MyCommitmentsGrid';
+import { MarketplaceGrid } from '@/components/MarketplaceGrid';
+
+// Stable callbacks shared across rerenders, mirroring the useCallback-stabilized
+// handlers the real page passes down. If these changed identity per render,
+// React.memo could not skip unchanged cards.
+const noopDetails = (_id: string) => undefined;
+const noopAttestations = (_id: string) => undefined;
+const noopEarlyExit = (_id: string) => undefined;
+
+function makeCommitment(id: string, overrides: Partial<Commitment> = {}): Commitment {
+  return {
+    id,
+    type: 'Safe',
+    status: 'Active',
+    asset: 'XLM',
+    amount: '50,000',
+    currentValue: '52,600',
+    changePercent: 5.2,
+    durationProgress: 75,
+    daysRemaining: 15,
+    complianceScore: 95,
+    maxLoss: '2%',
+    currentDrawdown: '0.8%',
+    createdDate: 'Jan 10, 2026',
+    expiryDate: 'Feb 9, 2026',
+    ...overrides,
+  };
+}
+
+function makeListing(id: string, overrides: Partial<MarketplaceCardProps> = {}): MarketplaceCardProps {
+  return {
+    id,
+    type: 'Safe',
+    score: 95,
+    amount: '$50,000',
+    duration: '25 days',
+    yield: '5.2%',
+    maxLoss: '2%',
+    owner: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+    price: '$52,000',
+    forSale: true,
+    ...overrides,
+  };
+}
+
+function resetCounts(store: Record<string, number>) {
+  for (const key of Object.keys(store)) {
+    delete store[key];
+  }
+}
+
+describe('MyCommitmentsGrid memoization', () => {
+  beforeEach(() => resetCounts(myCardRenders));
+
+  function renderGrid(commitments: Commitment[]) {
+    return render(
+      <MyCommitmentsGrid
+        commitments={commitments}
+        onDetails={noopDetails}
+        onAttestations={noopAttestations}
+        onEarlyExit={noopEarlyExit}
+      />,
+    );
+  }
+
+  it('renders one card per commitment with a stable id key', () => {
+    const items = [makeCommitment('A'), makeCommitment('B'), makeCommitment('C')];
+    renderGrid(items);
+
+    // The count label is split across nodes (`<span>3</span> commitments found`).
+    expect(screen.getByText('commitments found')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(myCardRenders).toEqual({ A: 1, B: 1, C: 1 });
+  });
+
+  it('does not re-render the surviving cards when one is filtered out', () => {
+    const items = [makeCommitment('A'), makeCommitment('B'), makeCommitment('C')];
+    const { rerender } = renderGrid(items);
+    resetCounts(myCardRenders);
+
+    // Simulate a filter that removes B; A and C keep their object identity.
+    rerender(
+      <MyCommitmentsGrid
+        commitments={[items[0], items[2]]}
+        onDetails={noopDetails}
+        onAttestations={noopAttestations}
+        onEarlyExit={noopEarlyExit}
+      />,
+    );
+
+    expect(screen.queryByTestId('my-card-B')).toBeNull();
+    expect(myCardRenders.A).toBeUndefined();
+    expect(myCardRenders.C).toBeUndefined();
+  });
+
+  it('re-renders only the card whose data changed', () => {
+    const items = [makeCommitment('A'), makeCommitment('B'), makeCommitment('C')];
+    const { rerender } = renderGrid(items);
+    resetCounts(myCardRenders);
+
+    // Replace only B with a new object; A and C keep their identity.
+    const nextB = makeCommitment('B', { amount: '999,999' });
+    rerender(
+      <MyCommitmentsGrid
+        commitments={[items[0], nextB, items[2]]}
+        onDetails={noopDetails}
+        onAttestations={noopAttestations}
+        onEarlyExit={noopEarlyExit}
+      />,
+    );
+
+    expect(myCardRenders).toEqual({ B: 1 });
+  });
+
+  it('does not re-render any card on a sort-only reorder', () => {
+    const items = [makeCommitment('A'), makeCommitment('B'), makeCommitment('C')];
+    const { rerender } = renderGrid(items);
+    resetCounts(myCardRenders);
+
+    // Same object references, reordered.
+    rerender(
+      <MyCommitmentsGrid
+        commitments={[items[2], items[0], items[1]]}
+        onDetails={noopDetails}
+        onAttestations={noopAttestations}
+        onEarlyExit={noopEarlyExit}
+      />,
+    );
+
+    expect(myCardRenders).toEqual({});
+  });
+
+  it('re-renders every card when all item references change', () => {
+    const items = [makeCommitment('A'), makeCommitment('B'), makeCommitment('C')];
+    const { rerender } = renderGrid(items);
+    resetCounts(myCardRenders);
+
+    const fresh = items.map((c) => ({ ...c }));
+    rerender(
+      <MyCommitmentsGrid
+        commitments={fresh}
+        onDetails={noopDetails}
+        onAttestations={noopAttestations}
+        onEarlyExit={noopEarlyExit}
+      />,
+    );
+
+    expect(myCardRenders).toEqual({ A: 1, B: 1, C: 1 });
+  });
+
+  it('shows the empty state and renders no cards when results are empty', () => {
+    renderGrid([]);
+
+    expect(screen.getByText('commitments found')).toBeInTheDocument();
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(
+      screen.getByText('No commitments found matching your filters.'),
+    ).toBeInTheDocument();
+    expect(myCardRenders).toEqual({});
+  });
+});
+
+describe('MarketplaceGrid memoization', () => {
+  beforeEach(() => resetCounts(marketplaceRenders));
+
+  it('renders one card per listing', () => {
+    const items = [makeListing('001'), makeListing('002'), makeListing('003')];
+    render(<MarketplaceGrid items={items} />);
+
+    expect(marketplaceRenders).toEqual({ '001': 1, '002': 1, '003': 1 });
+  });
+
+  it('does not re-render surviving cards when one is filtered out', () => {
+    const items = [makeListing('001'), makeListing('002'), makeListing('003')];
+    const { rerender } = render(<MarketplaceGrid items={items} />);
+    resetCounts(marketplaceRenders);
+
+    rerender(<MarketplaceGrid items={[items[0], items[2]]} />);
+
+    expect(screen.queryByTestId('market-card-002')).toBeNull();
+    expect(marketplaceRenders['001']).toBeUndefined();
+    expect(marketplaceRenders['003']).toBeUndefined();
+  });
+
+  it('re-renders only the card whose data changed', () => {
+    const items = [makeListing('001'), makeListing('002'), makeListing('003')];
+    const { rerender } = render(<MarketplaceGrid items={items} />);
+    resetCounts(marketplaceRenders);
+
+    const next002 = makeListing('002', { price: '$999,999' });
+    rerender(<MarketplaceGrid items={[items[0], next002, items[2]]} />);
+
+    expect(marketplaceRenders).toEqual({ '002': 1 });
+  });
+
+  it('does not re-render any card on a sort-only reorder', () => {
+    const items = [makeListing('001'), makeListing('002'), makeListing('003')];
+    const { rerender } = render(<MarketplaceGrid items={items} />);
+    resetCounts(marketplaceRenders);
+
+    rerender(<MarketplaceGrid items={[items[2], items[0], items[1]]} />);
+
+    expect(marketplaceRenders).toEqual({});
+  });
+
+  it('re-renders every card when every listing changes value', () => {
+    const items = [makeListing('001'), makeListing('002'), makeListing('003')];
+    const { rerender } = render(<MarketplaceGrid items={items} />);
+    resetCounts(marketplaceRenders);
+
+    // MarketplaceCard receives spread primitive props, so a re-render happens
+    // only when a value actually changes — not merely on a new object identity.
+    const fresh = items.map((i) => ({ ...i, price: '$999,999' }));
+    rerender(<MarketplaceGrid items={fresh} />);
+
+    expect(marketplaceRenders).toEqual({ '001': 1, '002': 1, '003': 1 });
+  });
+
+  it('does not re-render cards when item objects are cloned without value changes', () => {
+    const items = [makeListing('001'), makeListing('002'), makeListing('003')];
+    const { rerender } = render(<MarketplaceGrid items={items} />);
+    resetCounts(marketplaceRenders);
+
+    // New object identities but identical primitive values -> memo skips them.
+    const cloned = items.map((i) => ({ ...i }));
+    rerender(<MarketplaceGrid items={cloned} />);
+
+    expect(marketplaceRenders).toEqual({});
+  });
+
+  it('shows the empty state when there are no items', () => {
+    render(<MarketplaceGrid items={[]} />);
+
+    expect(screen.getByText('No commitments available')).toBeInTheDocument();
+    expect(marketplaceRenders).toEqual({});
+  });
+});
+
+describe('card components are wrapped in React.memo', () => {
+  const memoType = Symbol.for('react.memo');
+
+  it('MyCommitmentCard is a memo component and still renders', async () => {
+    const actual = await vi.importActual<typeof import('@/components/MyCommitmentCard')>(
+      '@/components/MyCommitmentCard',
+    );
+    const RealCard = actual.default as unknown as { $$typeof: symbol };
+    expect(RealCard.$$typeof).toBe(memoType);
+
+    const Card = actual.default;
+    render(
+      <Card
+        commitment={makeCommitment('CMT-REAL', { status: 'Active' })}
+        onDetails={noopDetails}
+        onAttestations={noopAttestations}
+        onEarlyExit={noopEarlyExit}
+      />,
+    );
+    expect(screen.getByText('CMT-REAL')).toBeInTheDocument();
+  });
+
+  it('MarketplaceCard is a memo component and still renders', async () => {
+    const actual = await vi.importActual<typeof import('@/components/MarketplaceCard')>(
+      '@/components/MarketplaceCard',
+    );
+    const RealCard = actual.MarketplaceCard as unknown as { $$typeof: symbol };
+    expect(RealCard.$$typeof).toBe(memoType);
+
+    const Card = actual.MarketplaceCard;
+    render(<Card {...makeListing('042', { forSale: false })} />);
+    expect(screen.getByText('#CMT-042')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #659 

## Summary

`MyCommitmentsGrid` and `MarketplaceGrid` re-rendered every card on each
filter, sort, or search change because the card components were not memoized
and some callbacks passed down were recreated on every render. With large
lists this produced visible jank during filtering.

This PR memoizes both card components and stabilizes the props they receive,
so a filter or sort only re-renders the cards that actually changed. There is
no behavioural change.

## Changes

| File | Change |
| --- | --- |
| `src/components/MyCommitmentCard.tsx` | Default export wrapped in `React.memo`. |
| `src/components/MarketplaceCard.tsx` | Split into `MarketplaceCardComponent` and exported as `React.memo(MarketplaceCardComponent)`. |
| `src/app/commitments/page.tsx` | `onDetails` / `onAttestations` handlers passed to the grid are now wrapped in `useCallback` so their identity is stable across re-renders. |
| `src/components/__tests__/GridMemoization.test.tsx` | New render-counting test suite (15 tests). |
| `docs/performance/GRID_RENDER.md` | Before/after render-count documentation. |

## Why it works

- `MyCommitmentCard` receives a single `commitment` object plus three
  callbacks. The `filteredCommitments` memo filters/sorts the same objects, so
  surviving cards keep their identity. The only unstable props were the inline
  `onDetails` / `onAttestations` arrows, now stabilized with `useCallback`
  (`onEarlyExit` was already stable).
- `MarketplaceCard` receives spread primitive props and no callbacks, so
  `React.memo` shallow-compares each value and re-renders a card only when one
  of its values changes.
- Both grids already used stable `id` keys (never the array index).

## Render counts (3-card list)

MyCommitmentsGrid

| Interaction | Before | After |
| --- | --- | --- |
| Filter removes one card | 2 | 0 |
| One card's data changes | 3 | 1 |
| Sort-only reorder | 3 | 0 |
| All card objects replaced | 3 | 3 |

MarketplaceGrid

| Interaction | Before | After |
| --- | --- | --- |
| Filter removes one card | 2 | 0 |
| One listing's value changes | 3 | 1 |
| Sort-only reorder | 3 | 0 |
| Objects cloned, no value change | 3 | 0 |
| Every listing's value changes | 3 | 3 |

## Testing

`src/components/__tests__/GridMemoization.test.tsx` replaces the real cards
with `React.memo`-wrapped spies that tally render-function calls per card id,
then drives each grid through a rerender for every scenario above. Two further
tests import the real card components and assert each is a `React.memo`
component and still renders correctly.

