### PR TITLE
[639] Add RTL tests for TrustBadge covering all trust levels, tooltip, and accessibility

### DIFF
--- a/docs/testing/TRUST_BADGE_TESTS.md
+++ b/docs/testing/TRUST_BADGE_TESTS.md
@@ -1,0 +1,21 @@
+# TrustBadge Test Coverage
+
+This document summarizes the RTL/Vitest coverage for `src/components/TrustBadge.tsx`.
+
+## Cases covered
+
+| Area | Assertions |
+| :--- | :--------- |
+| Trust levels | `verified`, `reputable`, and `unverified` each render the expected label, icon (`svg`), and color class |
+| Tooltip | Tooltip content is present with `role="tooltip"` when `showTooltip` is true; omitted when false |
+| Accessibility | Badge uses `role="status"`, `aria-label`, and `aria-describedby` linked to the tooltip id |
+| Non-color signal | Visible text label is present and exposed as the accessible name |
+| className merge | Custom classes are merged with default badge styling |
+| Fallback | Unknown levels fall back to the unverified badge configuration |
+| Edge cases | Empty `className` preserves default layout and color classes |
+
+## Running tests
+
+```bash
+pnpm test src/components/__tests__/TrustBadge.test.tsx
+```

--- a/src/components/TrustBadge.tsx
+++ b/src/components/TrustBadge.tsx
@@ -44,14 +44,24 @@ export const TrustBadge: React.FC<TrustBadgeProps> = ({
   };
 
   const config = getBadgeConfig();
+  const tooltipId = `trust-badge-tooltip-${level}`;
 
   return (
-    <div className={`group relative inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full border text-[10px] font-bold uppercase tracking-wider ${config.colorClass} ${className}`}>
-      {config.icon}
-      {config.label}
-      
+    <div
+      className={`group relative inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full border text-[10px] font-bold uppercase tracking-wider ${config.colorClass} ${className}`}
+      role="status"
+      aria-label={config.label}
+      aria-describedby={showTooltip ? tooltipId : undefined}
+    >
+      <span aria-hidden="true">{config.icon}</span>
+      <span>{config.label}</span>
+
       {showTooltip && (
-        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-48 p-2 rounded-lg bg-[#1A1A1A] border border-white/10 shadow-2xl opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 text-[11px] normal-case tracking-normal font-medium leading-relaxed text-white/70">
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-48 p-2 rounded-lg bg-[#1A1A1A] border border-white/10 shadow-2xl opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 text-[11px] normal-case tracking-normal font-medium leading-relaxed text-white/70"
+        >
           <p>{config.description}</p>
           <div className="mt-1 flex items-center gap-1 text-[9px] text-[#0FF0FC]">
             <Info className="w-2.5 h-2.5" />

--- a/src/components/__tests__/TrustBadge.test.tsx
+++ b/src/components/__tests__/TrustBadge.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TrustBadge, type TrustLevel } from "@/components/TrustBadge";
+
+const TRUST_LEVELS: Array<{
+  level: TrustLevel;
+  label: string;
+  description: string;
+  colorClass: string;
+}> = [
+  {
+    level: "verified",
+    label: "Verified Seller",
+    description:
+      "Identity and historical performance have been verified by Commitlabs.",
+    colorClass: "text-[#00C950]",
+  },
+  {
+    level: "reputable",
+    label: "Top Reputation",
+    description:
+      "Seller has a high successful commitment rate and positive community feedback.",
+    colorClass: "text-[#51A2FF]",
+  },
+  {
+    level: "unverified",
+    label: "Self-Reported",
+    description:
+      "This seller has not yet completed the verification process. Exercise caution.",
+    colorClass: "text-white/40",
+  },
+];
+
+describe("TrustBadge", () => {
+  it.each(TRUST_LEVELS)(
+    "renders the $level label, icon, and color class",
+    ({ level, label, colorClass }) => {
+      render(<TrustBadge level={level} />);
+
+      const badge = screen.getByRole("status", { name: label });
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent(label);
+      expect(badge.className).toContain(colorClass);
+      expect(badge.querySelector("svg")).toBeInTheDocument();
+    },
+  );
+
+  it.each(TRUST_LEVELS)(
+    "exposes accessible labelling for the $level badge",
+    ({ level, label, description }) => {
+      render(<TrustBadge level={level} showTooltip />);
+
+      const badge = screen.getByRole("status", { name: label });
+      expect(badge).toHaveAttribute("aria-label", label);
+      expect(badge).toHaveAttribute(
+        "aria-describedby",
+        `trust-badge-tooltip-${level}`,
+      );
+
+      const tooltip = screen.getByRole("tooltip");
+      expect(tooltip).toHaveAttribute("id", `trust-badge-tooltip-${level}`);
+      expect(tooltip).toHaveTextContent(description);
+      expect(tooltip).toHaveTextContent("Learn about trust levels");
+    },
+  );
+
+  it("does not render tooltip content when showTooltip is false", () => {
+    render(<TrustBadge level="verified" showTooltip={false} />);
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: "Verified Seller" }),
+    ).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("merges custom className with default badge styles", () => {
+    render(
+      <TrustBadge
+        level="verified"
+        className="custom-trust-badge"
+        showTooltip={false}
+      />,
+    );
+
+    const badge = screen.getByRole("status", { name: "Verified Seller" });
+    expect(badge.className).toContain("custom-trust-badge");
+    expect(badge.className).toContain("text-[#00C950]");
+  });
+
+  it("uses visible text labels so color is not the sole trust signal", () => {
+    render(<TrustBadge level="verified" showTooltip={false} />);
+
+    const badge = screen.getByRole("status", { name: "Verified Seller" });
+    expect(badge).toHaveAccessibleName("Verified Seller");
+    expect(screen.getByText("Verified Seller")).toBeVisible();
+  });
+
+  it("falls back to unverified config for unknown trust levels", () => {
+    render(
+      <TrustBadge
+        level={"unknown" as TrustLevel}
+        showTooltip={false}
+      />,
+    );
+
+    const badge = screen.getByRole("status", { name: "Self-Reported" });
+    expect(badge).toHaveTextContent("Self-Reported");
+    expect(badge.className).toContain("text-white/40");
+  });
+
+  it("handles empty className without breaking layout classes", () => {
+    render(<TrustBadge level="reputable" className="" showTooltip={false} />);
+
+    const badge = screen.getByRole("status", { name: "Top Reputation" });
+    expect(badge.className).toContain("text-[#51A2FF]");
+    expect(badge.className).toContain("rounded-full");
+  });
+});


### PR DESCRIPTION
## Summary

- Add comprehensive Vitest + RTL coverage for `TrustBadge` across all trust levels, tooltip visibility, className merging, and fallback behavior.
- Improve badge accessibility with `role="status"`, `aria-label`, and tooltip `aria-describedby` wiring.
- Document covered cases in `docs/testing/TRUST_BADGE_TESTS.md`.

## Test plan

- [x] `pnpm test src/components/__tests__/TrustBadge.test.tsx`
- [x] Verified label/icon/color mapping for verified, reputable, and unverified levels
- [x] Verified tooltip on/off behavior and accessible labelling

Closes #639
