### PR TITLE
feat: inline server-side draft validation in create wizard

### DIFF
--- a/docs/CREATE_DRAFT_VALIDATION.md
+++ b/docs/CREATE_DRAFT_VALIDATION.md
@@ -1,0 +1,142 @@
+# Create Wizard – Draft Validation
+
+`CreateCommitmentStepConfigure` calls `/api/commitments/validate` in real-time
+so server-side errors appear next to the relevant fields before the user
+advances to the review step.
+
+---
+
+## Endpoint contract
+
+**POST `/api/commitments/validate`**
+
+### Request body
+
+```json
+{
+  "ownerAddress": "G...",
+  "asset": "XLM",
+  "amount": 100,
+  "durationDays": 90,
+  "maxLossBps": 5000
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `ownerAddress` | `string` | Stellar Ed25519 public key (`G…` format) |
+| `asset` | `string` | Asset code (e.g. `XLM`, `USDC`) |
+| `amount` | `number` | Positive number |
+| `durationDays` | `number` | Integer, validated against `PARAMETER_BOUNDS` |
+| `maxLossBps` | `number` | Basis points (percent × 100). `50 %` → `5000` |
+
+### Success response – valid draft
+
+```json
+{
+  "success": true,
+  "data": {
+    "valid": true,
+    "errors": [],
+    "warnings": [
+      {
+        "code": "HIGH_RISK_LOSS_TOLERANCE",
+        "message": "Max loss tolerance of 8000 bps is high (>5000 bps).",
+        "field": "maxLossBps"
+      }
+    ]
+  }
+}
+```
+
+### Success response – invalid draft
+
+HTTP 200 with `valid: false` and a non-empty `errors` array.
+
+```json
+{
+  "success": true,
+  "data": {
+    "valid": false,
+    "errors": [
+      {
+        "code": "VALIDATION_ERROR",
+        "message": "Amount must be a positive number",
+        "field": "amount"
+      }
+    ],
+    "warnings": []
+  }
+}
+```
+
+Each error object has:
+
+| Property | Type | Description |
+|---|---|---|
+| `field` | `string` | Dot-path to the offending input (empty = root) |
+| `message` | `string` | User-safe message, safe to render in the UI |
+| `code` | `string` | Machine-readable error code |
+
+---
+
+## Component behaviour
+
+`CreateCommitmentStepConfigure` debounces every change in the configure form
+by **500 ms** before calling the validate endpoint.
+
+```
+user edits field
+        │
+        ▼  500 ms debounce
+POST /api/commitments/validate
+        │
+  ┌─────┴──────┐
+  │ valid=true │  → clear server errors, enable Continue
+  │ valid=false│  → map errors to fields, disable Continue
+  │ network err│  → clear errors (graceful fallback, do not block user)
+  └────────────┘
+```
+
+### Field mapping
+
+Errors are keyed by the `field` property and rendered directly below the
+matching input:
+
+| API `field` | UI input |
+|---|---|
+| `amount` | Commitment Amount |
+| `durationDays` | Duration |
+| `maxLossBps` | Maximum Acceptable Loss |
+| `ownerAddress` | (no visible input – wallet address) |
+| `asset` | Asset selector |
+
+### Advance guard
+
+The **Continue** button is disabled while:
+
+1. Local validation fails (`isValid` prop is `false`), **or**
+2. A server validation request is in-flight (`Validating…` label shown), **or**
+3. The last server response returned one or more errors.
+
+A network failure clears server errors and re-enables Continue so transient
+connectivity issues never permanently block the user.
+
+### Accessibility
+
+- Each error `<span>` has `role="alert"` so screen readers announce it.
+- Inputs with errors get `aria-invalid="true"`.
+- Error `<span>` IDs are referenced by the input's `aria-describedby`.
+
+---
+
+## Sending `maxLossBps`
+
+The UI stores max loss as a **percentage** (`maxLossPercent`). The component
+converts it to basis points before the request:
+
+```ts
+maxLossBps: maxLossPercent * 100
+```
+
+So `50 %` is sent as `5000 bps`.

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -7,6 +7,7 @@ import CreateCommitmentStepConfigure from "@/components/CreateCommitmentStepConf
 import CreateCommitmentStepReview from "@/components/CreateCommitmentStepReview";
 import CommitmentCreatedModal from "@/components/modals/Commitmentcreatedmodal";
 import { buildExplorerUrl, openExplorerUrl } from "@/utils/explorerLinks";
+import { useWallet } from "@/hooks/useWallet";
 
 type CommitmentType = "safe" | "balanced" | "aggressive";
 
@@ -22,6 +23,7 @@ function generateCommitmentId(): string {
 
 export default function CreateCommitment() {
   const router = useRouter();
+  const { address: ownerAddress } = useWallet();
   const [step, setStep] = useState(1);
   const [selectedType, setSelectedType] = useState<CommitmentType | null>(null);
   const [commitmentType, setCommitmentType] =
@@ -185,6 +187,7 @@ export default function CreateCommitment() {
           earlyExitPenalty={earlyExitPenalty}
           estimatedFees={estimatedFees}
           isValid={isStep2Valid}
+          ownerAddress={ownerAddress}
           onChangeAmount={setAmount}
           onChangeAsset={setAsset}
           onChangeDuration={setDurationDays}

--- a/src/components/CreateCommitmentStepConfigure.tsx
+++ b/src/components/CreateCommitmentStepConfigure.tsx
@@ -1,8 +1,16 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import WizardStepper from './WizardStepper'
 import styles from './CreateCommitmentStepConfigure.module.css'
+
+interface ServerFieldErrors {
+  amount?: string
+  durationDays?: string
+  maxLossBps?: string
+  ownerAddress?: string
+  asset?: string
+}
 
 interface CreateCommitmentStepConfigureProps {
   amount: string | number
@@ -13,6 +21,7 @@ interface CreateCommitmentStepConfigureProps {
   earlyExitPenalty: string
   estimatedFees: string
   isValid: boolean
+  ownerAddress?: string
   onChangeAmount: (value: string) => void
   onChangeAsset: (asset: string) => void
   onChangeDuration: (value: number) => void
@@ -36,6 +45,7 @@ export default function CreateCommitmentStepConfigure({
   earlyExitPenalty,
   estimatedFees,
   isValid,
+  ownerAddress = '',
   onChangeAmount,
   onChangeAsset,
   onChangeDuration,
@@ -48,6 +58,53 @@ export default function CreateCommitmentStepConfigure({
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [slippageTolerance, setSlippageTolerance] = useState(1)
   const [liquidationBuffer, setLiquidationBuffer] = useState(5)
+  const [serverErrors, setServerErrors] = useState<ServerFieldErrors>({})
+  const [serverValidating, setServerValidating] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
+
+  // Debounced server-side validation
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      abortRef.current?.abort()
+      const controller = new AbortController()
+      abortRef.current = controller
+      setServerValidating(true)
+      try {
+        const res = await fetch('/api/commitments/validate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ownerAddress,
+            asset,
+            amount,
+            durationDays,
+            maxLossBps: maxLossPercent * 100,
+          }),
+          signal: controller.signal,
+        })
+        const json = await res.json()
+        const fieldMap: ServerFieldErrors = {}
+        for (const err of json?.data?.errors ?? json?.errors ?? []) {
+          if (err.field && err.message) {
+            fieldMap[err.field as keyof ServerFieldErrors] = err.message
+          }
+        }
+        setServerErrors(fieldMap)
+      } catch {
+        // Network failure: clear errors gracefully — don't block the user
+        setServerErrors({})
+      } finally {
+        setServerValidating(false)
+      }
+    }, 500)
+    return () => {
+      clearTimeout(timer)
+      abortRef.current?.abort()
+    }
+  }, [ownerAddress, asset, amount, durationDays, maxLossPercent])
+
+  const hasServerErrors = Object.keys(serverErrors).length > 0
+  const canAdvance = isValid && !hasServerErrors && !serverValidating
 
   // Inline validation messages
   const durationError =
@@ -83,7 +140,7 @@ export default function CreateCommitmentStepConfigure({
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && isValid) onNext()
+    if (e.key === 'Enter' && canAdvance) onNext()
   }
 
   return (
@@ -115,7 +172,7 @@ export default function CreateCommitmentStepConfigure({
             <label htmlFor="amount" className={styles.label}>
               Commitment Amount <span className={styles.required}>*</span>
             </label>
-            <div className={`${styles.amountInputWrapper} ${amountError ? styles.hasError : ''}`}>
+            <div className={`${styles.amountInputWrapper} ${amountError || serverErrors.amount ? styles.hasError : ''}`}>
               <span className={styles.currencyPrefix}>$</span>
               <input
                 id="amount"
@@ -127,7 +184,7 @@ export default function CreateCommitmentStepConfigure({
                 min="0"
                 step="0.01"
                 aria-describedby="amount-helper amount-error"
-                aria-invalid={!!amountError}
+                aria-invalid={!!(amountError || serverErrors.amount)}
               />
               <select
                 className={styles.assetSelector}
@@ -144,9 +201,9 @@ export default function CreateCommitmentStepConfigure({
               <span id="amount-helper" className={styles.helperText}>
                 Available: {availableBalance} {asset}
               </span>
-              {amountError && (
+              {(amountError || serverErrors.amount) && (
                 <span id="amount-error" className={styles.errorText} role="alert">
-                  {amountError}
+                  {amountError ?? serverErrors.amount}
                 </span>
               )}
             </div>
@@ -176,21 +233,21 @@ export default function CreateCommitmentStepConfigure({
                 <input
                   id="duration"
                   type="number"
-                  className={`${styles.sliderNumberInput} ${durationError ? styles.inputError : ''}`}
+                  className={`${styles.sliderNumberInput} ${durationError || serverErrors.durationDays ? styles.inputError : ''}`}
                   value={durationDays}
                   onChange={handleDurationInputChange}
                   min="1"
                   max="365"
                   aria-describedby="duration-hint duration-error"
-                  aria-invalid={!!durationError}
+                  aria-invalid={!!(durationError || serverErrors.durationDays)}
                 />
                 <span className={styles.sliderValueLabel}>
                   {durationDays} days
                 </span>
               </div>
             </div>
-            {durationError ? (
-              <span id="duration-error" className={styles.errorText} role="alert">{durationError}</span>
+            {durationError || serverErrors.durationDays ? (
+              <span id="duration-error" className={styles.errorText} role="alert">{durationError ?? serverErrors.durationDays}</span>
             ) : (
               <p id="duration-hint" className={styles.constraintHint}>{DURATION_COPY}</p>
             )}
@@ -223,13 +280,13 @@ export default function CreateCommitmentStepConfigure({
                 <input
                   id="maxLoss"
                   type="number"
-                  className={`${styles.sliderNumberInput} ${maxLossError ? styles.inputError : ''}`}
+                  className={`${styles.sliderNumberInput} ${maxLossError || serverErrors.maxLossBps ? styles.inputError : ''}`}
                   value={maxLossPercent}
                   onChange={handleMaxLossInputChange}
                   min="0"
                   max="100"
                   aria-describedby="maxloss-hint maxloss-error"
-                  aria-invalid={!!maxLossError}
+                  aria-invalid={!!(maxLossError || serverErrors.maxLossBps)}
                 />
                 <span className={`${styles.sliderValueLabel} ${maxLossWarning ? styles.warningLabel : ''}`}>
                   {maxLossWarning && (
@@ -243,8 +300,8 @@ export default function CreateCommitmentStepConfigure({
                 </span>
               </div>
             </div>
-            {maxLossError ? (
-              <span id="maxloss-error" className={styles.errorText} role="alert">{maxLossError}</span>
+            {maxLossError || serverErrors.maxLossBps ? (
+              <span id="maxloss-error" className={styles.errorText} role="alert">{maxLossError ?? serverErrors.maxLossBps}</span>
             ) : maxLossWarning ? (
               <p className={styles.warningHint}>
                 ⚠ Setting max loss above 80% means most of your committed amount could be lost before the position closes.
@@ -372,13 +429,15 @@ export default function CreateCommitmentStepConfigure({
             type="button"
             className={styles.continueButton}
             onClick={onNext}
-            disabled={!isValid}
-            aria-disabled={!isValid}
+            disabled={!canAdvance}
+            aria-disabled={!canAdvance}
           >
-            Continue
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M5 12h14M12 5l7 7-7 7" />
-            </svg>
+            {serverValidating ? 'Validating…' : 'Continue'}
+            {!serverValidating && (
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M5 12h14M12 5l7 7-7 7" />
+              </svg>
+            )}
           </button>
         </div>
       </div>

--- a/src/components/__tests__/CreateCommitmentStepConfigure.test.tsx
+++ b/src/components/__tests__/CreateCommitmentStepConfigure.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import CreateCommitmentStepConfigure from '../CreateCommitmentStepConfigure'
+
+// ─── Default valid props ──────────────────────────────────────────────────────
+
+const defaultProps = {
+  amount: '100',
+  asset: 'XLM',
+  availableBalance: 10000,
+  durationDays: 90,
+  maxLossPercent: 50,
+  earlyExitPenalty: '3 XLM',
+  estimatedFees: '0.00 XLM',
+  isValid: true,
+  ownerAddress: 'GABC1234',
+  onChangeAmount: vi.fn(),
+  onChangeAsset: vi.fn(),
+  onChangeDuration: vi.fn(),
+  onChangeMaxLoss: vi.fn(),
+  onBack: vi.fn(),
+  onNext: vi.fn(),
+}
+
+function validResponse() {
+  return {
+    ok: true,
+    json: async () => ({ success: true, data: { valid: true, errors: [], warnings: [] } }),
+  }
+}
+
+function errorResponse(errors: { field: string; message: string }[]) {
+  return {
+    ok: true,
+    json: async () => ({ success: true, data: { valid: false, errors, warnings: [] } }),
+  }
+}
+
+// Advance fake timers past debounce and flush all pending microtasks/promises
+async function advancePastDebounce() {
+  await act(async () => {
+    vi.advanceTimersByTime(500)
+    await vi.runAllTimersAsync()
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.stubGlobal('fetch', vi.fn())
+  defaultProps.onNext.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('CreateCommitmentStepConfigure – server validation', () => {
+  it('renders without crashing and shows the Continue button', () => {
+    vi.mocked(fetch).mockResolvedValue(validResponse() as Response)
+    render(<CreateCommitmentStepConfigure {...defaultProps} />)
+    expect(
+      screen.getByRole('button', { name: /continue|validating/i })
+    ).toBeInTheDocument()
+  })
+
+  it('button is disabled while server validation is in-flight', async () => {
+    vi.mocked(fetch).mockImplementation(
+      () => new Promise(() => {/* never resolves */})
+    )
+    render(<CreateCommitmentStepConfigure {...defaultProps} />)
+
+    await act(async () => { vi.advanceTimersByTime(500) })
+
+    const btn = screen.getByRole('button', { name: /validating/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('button is enabled after a valid server response', async () => {
+    vi.mocked(fetch).mockResolvedValue(validResponse() as Response)
+    render(<CreateCommitmentStepConfigure {...defaultProps} />)
+
+    await advancePastDebounce()
+
+    const btn = screen.getByRole('button', { name: /continue/i })
+    expect(btn).not.toBeDisabled()
+  })
+
+  it('maps a single field error to the correct input', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      errorResponse([{ field: 'amount', message: 'Amount too low' }]) as Response
+    )
+    render(<CreateCommitmentStepConfigure {...defaultProps} />)
+
+    await advancePastDebounce()
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Amount too low')
+  })
+
+  it('maps multiple field errors simultaneously', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      errorResponse([
+        { field: 'amount', message: 'Amount too low' },
+        { field: 'durationDays', message: 'Duration too short' },
+      ]) as Response
+    )
+    render(<CreateCommitmentStepConfigure {...defaultProps} />)
+
+    await advancePastDebounce()
+
+    const alerts = screen.getAllByRole('alert')
+    expect(alerts.some((a) => a.textContent?.includes('Amount too low'))).toBe(true)
+    expect(alerts.some((a) => a.textContent?.includes('Duration too short'))).toBe(true)
+  })
+
+  it('blocks onNext while server errors are present', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      errorResponse([{ field: 'amount', message: 'Amount too low' }]) as Response
+    )
+    render(<CreateCommitmentStepConfigure {...defaultProps} />)
+
+    await advancePastDebounce()
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }))
+    expect(defaultProps.onNext).not.toHaveBeenCalled()
+  })
+
+  it('calls onNext after errors are cleared', async () => {
+    vi.mocked(fetch).mockResolvedValue(validResponse() as Response)
+    render(<CreateCommitmentStepConfigure {...defaultProps} />)
+
+    await advancePastDebounce()
+
+    const btn = screen.getByRole('button', { name: /continue/i })
+    expect(btn).not.toBeDisabled()
+    fireEvent.click(btn)
+    expect(defaultProps.onNext).toHaveBeenCalledTimes(1)
+  })
+
+  it('debounces – does not call fetch before 500ms', async () => {
+    vi.mocked(fetch).mockResolvedValue(validResponse() as Response)
+    render(<CreateCommitmentStepConfigure {...defaultProps} />)
+
+    await act(async () => { vi.advanceTimersByTime(400) })
+    expect(fetch).not.toHaveBeenCalled()
+
+    await advancePastDebounce()
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels previous request on rapid field changes', async () => {
+    vi.mocked(fetch).mockResolvedValue(validResponse() as Response)
+    const { rerender } = render(<CreateCommitmentStepConfigure {...defaultProps} />)
+
+    await act(async () => { vi.advanceTimersByTime(300) })
+    rerender(<CreateCommitmentStepConfigure {...defaultProps} amount="200" />)
+    await advancePastDebounce()
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears server errors and does not block on network failure (graceful fallback)', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('Network error'))
+    render(<CreateCommitmentStepConfigure {...defaultProps} />)
+
+    await advancePastDebounce()
+
+    const btn = screen.getByRole('button', { name: /continue/i })
+    expect(btn).not.toBeDisabled()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('marks amount input as aria-invalid when server returns an amount error', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      errorResponse([{ field: 'amount', message: 'Amount too low' }]) as Response
+    )
+    render(<CreateCommitmentStepConfigure {...defaultProps} />)
+
+    await advancePastDebounce()
+
+    const amountInput = screen.getByRole('spinbutton', { name: /commitment amount/i })
+    expect(amountInput).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('button is disabled when isValid=false regardless of server response', async () => {
+    vi.mocked(fetch).mockResolvedValue(validResponse() as Response)
+    render(<CreateCommitmentStepConfigure {...defaultProps} isValid={false} />)
+
+    await advancePastDebounce()
+
+    // After validation completes, button should still be disabled due to isValid=false
+    const btn = screen.getByRole('button', { name: /continue/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('sends maxLossBps (percent * 100) in the request body', async () => {
+    vi.mocked(fetch).mockResolvedValue(validResponse() as Response)
+    render(<CreateCommitmentStepConfigure {...defaultProps} maxLossPercent={30} />)
+
+    await advancePastDebounce()
+
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string)
+    expect(body.maxLossBps).toBe(3000)
+  })
+})


### PR DESCRIPTION
feat: inline server-side draft validation in create wizard
  
  Summary
  
  Wires debounced server-side validation into CreateCommitmentStepConfigure so protocol-level
  errors appear next to the relevant fields before the user reaches the review step.
  
  Changes
  
  CreateCommitmentStepConfigure.tsx
  
  - 500ms debounced POST /api/commitments/validate on every field change
  - AbortController cancels in-flight requests on rapid edits
  - Server errors mapped by field and rendered with role="alert" / aria-invalid
  - Continue button disabled while validating or when server errors are present; shows
  Validating… during in-flight requests
  - Network failures clear errors gracefully — never permanently block the user
  - New optional ownerAddress prop
  
  create/page.tsx
  
  - Passes useWallet().address as ownerAddress to the configure step
  
  src/components/__tests__/CreateCommitmentStepConfigure.test.tsx (new)
  
  - 13 tests covering debounce timing, in-flight state, field error mapping, multi-error,
  blocking advance, request cancellation, graceful network failure, aria-invalid, isValid=false
   override, and maxLossBps conversion
  
  docs/CREATE_DRAFT_VALIDATION.md (new)
  
  - Endpoint contract, request/response shapes, field mapping table, advance guard rules,
  accessibility notes
  
  Testing
  
  All 13 new tests pass (pnpm test). No previously passing tests broken by this change.

closes #635