### PR TITLE
add tests for MarketplaceCard component functionality

### DIFF
--- a/src/components/__tests__/MarketplaceCard.test.tsx
+++ b/src/components/__tests__/MarketplaceCard.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MarketplaceCard, type MarketplaceCardProps } from "@/components/MarketplaceCard";
+
+vi.mock("@/components/modals/CommitmentDetailsModal", () => ({
+  CommitmentDetailsModal: ({
+    isOpen,
+    commitmentId,
+  }: {
+    isOpen: boolean;
+    commitmentId: string;
+  }) => {
+    if (!isOpen) return null;
+
+    return <div data-testid="commitment-details-modal">{commitmentId}</div>;
+  },
+}));
+
+function makeListing(overrides: Partial<MarketplaceCardProps> = {}): MarketplaceCardProps {
+  return {
+    id: "42",
+    type: "Balanced",
+    score: 84.6,
+    amount: "$8,000",
+    duration: "60 days",
+    yield: "7.1%",
+    maxLoss: "10%",
+    owner: "0x1234567890abcdef",
+    price: "$1,100",
+    forSale: true,
+    tradeHref: "/custom-trade",
+    ...overrides,
+  };
+}
+
+describe("MarketplaceCard", () => {
+  it.each([
+    [Number.NaN, "0%"],
+    [-12, "0%"],
+    [120, "100%"],
+    [84.6, "85%"],
+  ])("clamps score %p to %s", (score, expected) => {
+    render(<MarketplaceCard {...makeListing({ score })} />);
+
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
+  it("renders short owners unchanged and truncates long owners", () => {
+    const { rerender, container } = render(
+      <MarketplaceCard {...makeListing({ owner: "short" })} />,
+    );
+
+    const ownerValue = container.querySelector("span[class*='font-mono']");
+    expect(ownerValue).toHaveTextContent("short");
+
+    rerender(
+      <MarketplaceCard
+        {...makeListing({ owner: "0123456789abcdef" })}
+      />,
+    );
+
+    expect(screen.getByText("012345...cdef")).toBeInTheDocument();
+  });
+
+  it("renders an empty owner label when the owner is blank", () => {
+    const { container } = render(<MarketplaceCard {...makeListing({ owner: "   " })} />);
+
+    const ownerValue = container.querySelector("span[class*='font-mono']");
+    expect(ownerValue).toHaveTextContent("");
+  });
+
+  it("shows the trade CTA only when the listing is for sale and uses the custom trade href", () => {
+    const { rerender } = render(<MarketplaceCard {...makeListing()} />);
+
+    const tradeLink = screen.getByRole("link", { name: /trade 42/i });
+    expect(tradeLink).toHaveAttribute("href", "/custom-trade");
+
+    rerender(<MarketplaceCard {...makeListing({ forSale: false, tradeHref: undefined })} />);
+
+    expect(screen.queryByRole("link", { name: /trade 42/i })).not.toBeInTheDocument();
+    expect(screen.getByText("Not for sale")).toBeInTheDocument();
+  });
+
+  it("opens the commitment details modal when the view button is clicked", () => {
+    render(<MarketplaceCard {...makeListing()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /view 42/i }));
+
+    expect(screen.getByTestId("commitment-details-modal")).toHaveTextContent("42");
+  });
+});


### PR DESCRIPTION
#closes 
#733 
Summary
Added a focused test suite for [MarketplaceCard.tsx](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to cover score clamping, owner address truncation, marketplace sale-state rendering, and commitment details modal activation.

What changed
Added [MarketplaceCard.test.tsx](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Verified the following behaviors:
[clampScore](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) returns 0 for NaN, 0 for negative values, 100 for values above 100, and rounds decimals correctly
[truncateAddress](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) leaves short addresses unchanged, truncates long addresses to 6…4, and handles blank/whitespace owner values
the Trade CTA/link appears only when [forSale](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is true
the Trade CTA uses [tradeHref](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) when provided
clicking the View button opens [CommitmentDetailsModal](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Testing
Ran:
.vitest run src/components/__tests__/Marketplace*.test.tsx
Result:
2 test files passed
14 tests passed
Notes
No production source code was modified.
The diff is limited to a new test file only