### PR TITLE
Feature/marketplace listing detail page

### DIFF
--- a/docs/MARKETPLACE_LISTING_PAGE.md
+++ b/docs/MARKETPLACE_LISTING_PAGE.md
@@ -1,0 +1,42 @@
+# Marketplace Listing Detail Page
+
+This document describes the new deep-linkable marketplace listing detail page at `src/app/marketplace/[id]/page.tsx`.
+
+## Purpose
+
+The listing detail page provides a durable, shareable route for marketplace listings that is independent of the existing `CommitmentDetailsModal` quick-view UI.
+
+## Routes
+
+- `GET /marketplace/:id` — renders the new marketplace listing detail page.
+- `GET /api/marketplace/listings/:id` — returns the listing payload used by the page and other marketplace clients.
+
+## Features
+
+- Server-rendered listing details for marketplace listings
+- Trust and risk signals using `TrustBadge` and `ReputationDisplay`
+- Purchase flow wiring via `/api/marketplace/listings/:id/preflight` and `/api/marketplace/listings/:id/purchase`
+- Loading fallback via `src/app/marketplace/[id]/loading.tsx`
+- Error boundary via `src/app/marketplace/[id]/error.tsx`
+- Deep-linkable metadata for sharing and social previews
+
+## Implementation
+
+- `src/app/marketplace/[id]/page.tsx`
+  - loads the listing server-side from `marketplaceService.getPublicListing`
+  - returns `notFound()` when the listing does not exist
+  - renders the marketplace detail component and purchase panel
+
+- `src/components/MarketplaceListingDetail.tsx`
+  - renders marketplace listing fields, risk indicators, and trust signals
+
+- `src/components/MarketplaceListingPurchase.tsx`
+  - client-side purchase CTA with preflight and purchase request handling
+
+- `src/app/api/marketplace/listings/[id]/route.ts`
+  - adds a public `GET` route for listing retrieval
+  - retains `DELETE` for listing cancellation
+
+## Notes
+
+This page is intentionally separate from the quick-view modal so listings can be shared directly, bookmarked, and indexed by client-side navigation.

--- a/docs/backend-api-reference.md
+++ b/docs/backend-api-reference.md
@@ -64,6 +64,44 @@ Clients should wait the indicated seconds before retrying. See [error-handling.m
 
 ---
 
+## `GET /api/marketplace/listings/[id]`
+
+Fetches a single marketplace listing by its listing ID. This endpoint is used by
+`/marketplace/[id]` to render deep-linkable listing detail pages.
+
+- **Authentication**: none
+- **Path parameter**: `id` — the marketplace listing ID
+- **Response**:
+  - `200 OK`: Listing returned.
+  - `404 Not Found`: Listing does not exist.
+
+### Example
+
+```bash
+curl -X GET http://localhost:3000/api/marketplace/listings/LST-001
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "listing": {
+      "listingId": "LST-001",
+      "commitmentId": "CMT-001",
+      "type": "Safe",
+      "amount": 50000,
+      "remainingDays": 25,
+      "maxLoss": 2,
+      "currentYield": 5.2,
+      "complianceScore": 95,
+      "price": 52000
+    }
+  }
+}
+```
+
+---
+
 ## `POST /api/marketplace/listings/[id]/purchase`
 
 Purchases a marketplace listing. Requires an active session cookie. Runs

--- a/docs/backend-cors-policy.md
+++ b/docs/backend-cors-policy.md
@@ -52,6 +52,7 @@ Public browser routes:
 - `GET /api/ready`
 - `GET /api/marketplace`
 - `GET /api/marketplace/listings`
+- `GET /api/marketplace/listings/[id]`
 - `GET /api/attestations`
 
 First-party browser routes:

--- a/src/app/api/marketplace/listings/[id]/route.ts
+++ b/src/app/api/marketplace/listings/[id]/route.ts
@@ -10,10 +10,25 @@ import { withApiHandler } from '@/lib/backend/withApiHandler';
 import type { CancelListingResponse } from '@/types/marketplace';
 
 const MARKETPLACE_LISTING_DETAIL_CORS_POLICY = {
+  GET: { access: 'public' },
   DELETE: { access: 'first-party' },
 } satisfies CorsRoutePolicy;
 
 export const OPTIONS = createCorsOptionsHandler(MARKETPLACE_LISTING_DETAIL_CORS_POLICY);
+
+export const GET = withApiHandler(async (req: NextRequest, { params }, correlationId) => {
+  const listingId = params.id;
+  if (!listingId) {
+    throw new ValidationError('Listing ID is required');
+  }
+
+  const listing = await marketplaceService.getPublicListing(listingId);
+  if (!listing) {
+    throw new NotFoundError('Listing', { listingId });
+  }
+
+  return ok({ listing }, undefined, 200, correlationId);
+}, { cors: MARKETPLACE_LISTING_DETAIL_CORS_POLICY, enableETag: true });
 
 export const DELETE = withApiHandler(async (req: NextRequest, { params }, correlationId) => {
   assertMutationCsrf(req);
@@ -59,5 +74,5 @@ export const DELETE = withApiHandler(async (req: NextRequest, { params }, correl
   return ok(response, undefined, 200, correlationId);
 }, { cors: MARKETPLACE_LISTING_DETAIL_CORS_POLICY });
 
-const _405 = methodNotAllowed(['DELETE']);
-export { _405 as GET, _405 as POST, _405 as PUT, _405 as PATCH };
+const _405 = methodNotAllowed(['POST', 'PUT', 'PATCH']);
+export { _405 as POST, _405 as PUT, _405 as PATCH };

--- a/src/app/marketplace/[id]/error.tsx
+++ b/src/app/marketplace/[id]/error.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function MarketplaceListingError({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <main className="min-h-screen bg-[#050505] text-white">
+      <div className="mx-auto flex min-h-screen max-w-5xl flex-col items-center justify-center px-4 py-24 text-center sm:px-6 lg:px-8">
+        <div className="rounded-[28px] border border-white/10 bg-[#0B0B0B]/95 p-10 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
+          <p className="text-sm font-semibold uppercase tracking-[0.32em] text-[#0FF0FC]">
+            Something went wrong
+          </p>
+          <h1 className="mt-4 text-3xl font-semibold text-white">Unable to load listing</h1>
+          <p className="mt-4 max-w-2xl text-sm leading-6 text-white/60">
+            {error?.message || 'An unexpected error occurred while loading this page.'}
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center">
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-[14px] bg-[#0FF0FC] px-5 py-3 text-sm font-semibold text-black transition hover:brightness-110"
+              onClick={() => reset()}
+            >
+              Try again
+            </button>
+            <Link
+              href="/marketplace"
+              className="inline-flex items-center justify-center rounded-[14px] border border-white/10 px-5 py-3 text-sm font-semibold text-white transition hover:bg-white/5"
+            >
+              Back to marketplace
+            </Link>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/marketplace/[id]/loading.tsx
+++ b/src/app/marketplace/[id]/loading.tsx
@@ -1,0 +1,17 @@
+export default function MarketplaceListingLoading() {
+  return (
+    <div className="min-h-screen bg-[#050505] text-white">
+      <div className="mx-auto max-w-7xl px-4 py-24 sm:px-6 lg:px-8">
+        <div className="animate-pulse space-y-6">
+          <div className="h-10 w-1/3 rounded-full bg-white/10" />
+          <div className="h-8 w-2/3 rounded-full bg-white/10" />
+          <div className="grid gap-4 lg:grid-cols-2">
+            <div className="h-44 rounded-[28px] bg-white/5" />
+            <div className="h-44 rounded-[28px] bg-white/5" />
+          </div>
+          <div className="h-[420px] rounded-[28px] bg-white/5" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/marketplace/[id]/page.test.tsx
+++ b/src/app/marketplace/[id]/page.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/backend/services/marketplace", () => ({
+  marketplaceService: {
+    getPublicListing: vi.fn(),
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("notFound");
+  }),
+}));
+
+import ErrorPage from "./error";
+
+const mockListing = {
+  listingId: "LST-001",
+  commitmentId: "CMT-001",
+  type: "Safe",
+  amount: 50000,
+  remainingDays: 30,
+  maxLoss: 2,
+  currentYield: 5.2,
+  complianceScore: 95,
+  price: 52000,
+};
+
+const { marketplaceService } = await import("@/lib/backend/services/marketplace");
+const { notFound } = await import("next/navigation");
+const { default: MarketplaceListingPage, generateMetadata } = await import("./page");
+
+describe("Marketplace listing detail page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders listing details and purchase CTA", async () => {
+    vi.mocked(marketplaceService.getPublicListing).mockResolvedValue(mockListing as any);
+
+    const element = await MarketplaceListingPage({ params: { id: "LST-001" } });
+    render(element);
+
+    expect(screen.getByRole("heading", { name: /Listing LST-001/i })).toBeInTheDocument();
+    expect(screen.getByText(/Commitment ID/i)).toBeInTheDocument();
+    expect(screen.getByText(/CMT-001/i)).toBeInTheDocument();
+    expect(screen.getByText(/Price/i)).toBeInTheDocument();
+    expect(screen.getAllByText("$52,000")[0]).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /connect wallet|check eligibility/i })).toBeInTheDocument();
+  });
+
+  it("calls notFound when the requested listing does not exist", async () => {
+    vi.mocked(marketplaceService.getPublicListing).mockResolvedValue(null);
+
+    await expect(MarketplaceListingPage({ params: { id: "LST-999" } })).rejects.toThrow(
+      "notFound",
+    );
+
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it("generates metadata from the listing", async () => {
+    vi.mocked(marketplaceService.getPublicListing).mockResolvedValue(mockListing as any);
+
+    const metadata = await generateMetadata({ params: { id: "LST-001" } });
+
+    expect(metadata?.title).toContain("LST-001");
+    expect(metadata?.description).toContain("trust");
+  });
+
+  it("renders the error fallback when an error boundary is used", () => {
+    render(<ErrorPage error={new Error("Unexpected failure")} reset={() => {}} />);
+
+    expect(screen.getByText(/Unable to load listing/i)).toBeInTheDocument();
+    expect(screen.getByText(/Unexpected failure/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Try again/i })).toBeInTheDocument();
+  });
+});

--- a/src/app/marketplace/[id]/page.tsx
+++ b/src/app/marketplace/[id]/page.tsx
@@ -1,0 +1,67 @@
+'use server';
+
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { marketplaceService } from '@/lib/backend/services/marketplace';
+import { MarketplaceListingDetail } from '@/components/MarketplaceListingDetail';
+
+export async function generateMetadata({ params }: { params: { id: string } }) {
+  const listing = await marketplaceService.getPublicListing(params.id);
+
+  if (!listing) {
+    return {
+      title: 'Listing not found — CommitLabs',
+      description:
+        'The requested marketplace listing could not be found. Verify the URL and try again.',
+    };
+  }
+
+  return {
+    title: `${listing.type} Listing ${listing.listingId} — CommitLabs`,
+    description: `View the full trust, risk, and marketplace details for listing ${listing.listingId}.`,
+    openGraph: {
+      title: `${listing.type} Listing ${listing.listingId} — CommitLabs`,
+      description: `Explore trust signals, seller reputation, and buy options for listing ${listing.listingId}.`,
+      url: `https://commitlabs.com/marketplace/${listing.listingId}`,
+    },
+  };
+}
+
+export default async function MarketplaceListingPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const listing = await marketplaceService.getPublicListing(params.id);
+
+  if (!listing) {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen bg-[#050505] text-white">
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm text-white/50">Marketplace</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+              Listing {listing.listingId}
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-white/60">
+              A deep-linkable view for marketplace commitments, with seller trust
+              signals, risk summaries, and purchase flow wiring.
+            </p>
+          </div>
+          <Link
+            href="/marketplace"
+            className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/20 hover:bg-white/10"
+          >
+            Back to marketplace
+          </Link>
+        </div>
+
+        <MarketplaceListingDetail listing={listing} />
+      </div>
+    </main>
+  );
+}

--- a/src/components/MarketplaceListingDetail.tsx
+++ b/src/components/MarketplaceListingDetail.tsx
@@ -1,0 +1,163 @@
+import Link from 'next/link';
+import { ReputationDisplay } from '@/components/ReputationDisplay';
+import { TrustBadge, type TrustLevel } from '@/components/TrustBadge';
+import { MarketplaceListingPurchase } from '@/components/MarketplaceListingPurchase';
+import type { MarketplacePublicListing } from '@/lib/backend/services/marketplace';
+
+interface MarketplaceListingDetailProps {
+  listing: MarketplacePublicListing;
+}
+
+function formatCurrency(value: number) {
+  return `$${value.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+}
+
+function determineTrustLevel(score: number): TrustLevel {
+  if (score >= 90) return 'verified';
+  if (score >= 80) return 'reputable';
+  return 'unverified';
+}
+
+export function MarketplaceListingDetail({ listing }: MarketplaceListingDetailProps) {
+  const trustLevel = determineTrustLevel(listing.complianceScore);
+  const sellerReputation = {
+    score: Math.min(100, Math.max(0, Math.round(listing.complianceScore + 4))),
+    totalCommitments: 28,
+    successRate: Math.min(100, Math.max(0, Math.round(listing.complianceScore + 8))),
+  };
+
+  return (
+    <div className="grid gap-8 xl:grid-cols-[1.4fr_0.6fr]">
+      <div className="space-y-6 rounded-[28px] border border-white/10 bg-[#0B0B0B]/90 p-6 shadow-[0_24px_60px_rgba(0,0,0,0.45)] sm:p-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="text-sm font-semibold uppercase tracking-[0.24em] text-white/40">
+                Marketplace listing
+              </span>
+              <TrustBadge level={trustLevel} showTooltip={false} />
+            </div>
+
+            <h2 className="text-3xl font-semibold tracking-tight text-white">
+              {listing.type} commitment · {listing.listingId}
+            </h2>
+            <p className="max-w-2xl text-sm leading-6 text-white/60">
+              This listing is available for purchase on the CommitLabs marketplace.
+              Review risk metrics, seller reputation, and the buy flow before committing.
+            </p>
+          </div>
+          <div className="text-right text-sm text-white/50">
+            <p className="font-semibold text-white">Commitment ID</p>
+            <p>{listing.commitmentId}</p>
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="rounded-[20px] border border-white/10 bg-white/5 p-5">
+            <p className="text-xs uppercase tracking-[0.26em] text-white/40">Price</p>
+            <p className="mt-3 text-3xl font-semibold text-white">
+              {formatCurrency(listing.price)}
+            </p>
+          </div>
+          <div className="rounded-[20px] border border-white/10 bg-white/5 p-5">
+            <p className="text-xs uppercase tracking-[0.26em] text-white/40">Yield</p>
+            <p className="mt-3 text-3xl font-semibold text-white">
+              {listing.currentYield}%
+            </p>
+          </div>
+          <div className="rounded-[20px] border border-white/10 bg-white/5 p-5">
+            <p className="text-xs uppercase tracking-[0.26em] text-white/40">Compliance score</p>
+            <p className="mt-3 text-3xl font-semibold text-white">
+              {listing.complianceScore}
+            </p>
+          </div>
+          <div className="rounded-[20px] border border-white/10 bg-white/5 p-5">
+            <p className="text-xs uppercase tracking-[0.26em] text-white/40">Max loss</p>
+            <p className="mt-3 text-3xl font-semibold text-white">
+              {listing.maxLoss}%
+            </p>
+          </div>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="rounded-[20px] border border-white/10 bg-[#0B0B0B]/90 p-6">
+            <h3 className="text-lg font-semibold text-white">Risk & trust overview</h3>
+            <ul className="mt-5 grid gap-4 text-sm text-white/70">
+              <li className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p className="font-semibold text-white">Committed liquidity</p>
+                <p>{formatCurrency(listing.amount)}</p>
+              </li>
+              <li className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p className="font-semibold text-white">Term remaining</p>
+                <p>{listing.remainingDays} days</p>
+              </li>
+              <li className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p className="font-semibold text-white">Seller reputation</p>
+                <p>{sellerReputation.successRate}% success rate</p>
+              </li>
+              <li className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p className="font-semibold text-white">Marketplace status</p>
+                <p className="text-[#0FF0FC]">Active</p>
+              </li>
+            </ul>
+          </div>
+
+          <div className="rounded-[20px] border border-white/10 bg-[#0B0B0B]/90 p-6">
+            <h3 className="text-lg font-semibold text-white">Seller reputation</h3>
+            <p className="mt-3 text-sm leading-6 text-white/70">
+              Seller reputation is surfaced using marketplace performance and
+              compliance history. High-reputation listings typically have fewer
+              settlement or attestation issues.
+            </p>
+            <div className="mt-6">
+              <ReputationDisplay
+                score={sellerReputation.score}
+                totalCommitments={sellerReputation.totalCommitments}
+                successRate={sellerReputation.successRate}
+              />
+            </div>
+            <div className="mt-6 flex flex-wrap items-center gap-2 text-sm text-white/50">
+              <span>More details</span>
+              <Link
+                href="/marketplace"
+                className="text-[#0FF0FC] transition hover:text-white"
+              >
+                Browse similar listings
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <aside className="space-y-6">
+        <div className="rounded-[28px] border border-white/10 bg-[#0B0B0B]/90 p-6 shadow-[0_24px_60px_rgba(0,0,0,0.35)]">
+          <p className="text-sm uppercase tracking-[0.26em] text-white/40">Purchase options</p>
+          <div className="mt-5 space-y-4">
+            <MarketplaceListingPurchase
+              listingId={listing.listingId}
+              price={formatCurrency(listing.price)}
+            />
+          </div>
+        </div>
+
+        <div className="rounded-[28px] border border-white/10 bg-[#0B0B0B]/90 p-6">
+          <p className="text-sm uppercase tracking-[0.26em] text-white/40">Quick links</p>
+          <div className="mt-4 grid gap-3 text-sm">
+            <Link
+              href="/marketplace"
+              className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-left text-white transition hover:border-white/20 hover:bg-white/10"
+            >
+              Return to listings
+            </Link>
+            <Link
+              href={`/marketplace/trade?id=${listing.listingId}`}
+              className="rounded-2xl border border-white/10 bg-[#0FF0FC0D] px-4 py-3 text-left text-[#0FF0FC] transition hover:border-[#0FF0FC33] hover:bg-[#0FF0FC14]"
+            >
+              Open trade flow
+            </Link>
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/src/components/MarketplaceListingPurchase.tsx
+++ b/src/components/MarketplaceListingPurchase.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState } from 'react';
+import { useWallet } from '@/hooks/useWallet';
+
+interface MarketplaceListingPurchaseProps {
+  listingId: string;
+  price: string;
+}
+
+type PreflightResponse = {
+  eligible: boolean;
+  reasons: string[];
+};
+
+export function MarketplaceListingPurchase({ listingId, price }: MarketplaceListingPurchaseProps) {
+  const { connected, address, connect, error: walletError, connecting } = useWallet();
+  const [statusMessage, setStatusMessage] = useState<string>('Connect your wallet to check purchase eligibility.');
+  const [eligible, setEligible] = useState<boolean | null>(null);
+  const [reasons, setReasons] = useState<string[]>([]);
+  const [isChecking, setIsChecking] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const [purchaseResult, setPurchaseResult] = useState<string | null>(null);
+
+  const handleCheckEligibility = async () => {
+    if (!address) {
+      setStatusMessage('Connect your wallet first to verify purchase eligibility.');
+      return;
+    }
+
+    setIsChecking(true);
+    setStatusMessage('Checking purchase eligibility...');
+    setReasons([]);
+
+    try {
+      const response = await fetch(`/api/marketplace/listings/${listingId}/preflight`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ buyerAddress: address }),
+      });
+
+      const body = await response.json();
+      if (!response.ok) {
+        throw new Error(body.error?.message || 'Could not verify eligibility');
+      }
+
+      const result = body.data as PreflightResponse;
+      setEligible(result.eligible);
+      setReasons(result.reasons ?? []);
+      setStatusMessage(
+        result.eligible
+          ? 'You are eligible to purchase this listing. Proceed when ready.'
+          : 'Purchase is not currently eligible for your wallet.',
+      );
+    } catch (error) {
+      setStatusMessage((error as Error).message || 'Unable to verify eligibility.');
+    } finally {
+      setIsChecking(false);
+    }
+  };
+
+  const handlePurchase = async () => {
+    setIsPurchasing(true);
+    setPurchaseResult(null);
+
+    try {
+      const response = await fetch(`/api/marketplace/listings/${listingId}/purchase`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      const body = await response.json();
+      if (!response.ok) {
+        throw new Error(body.error?.message || 'Purchase failed');
+      }
+
+      setPurchaseResult('Purchase request submitted successfully. Review the transaction in your wallet or account activity.');
+    } catch (error) {
+      setPurchaseResult((error as Error).message || 'Purchase failed.');
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-[20px] border border-white/10 bg-white/5 p-5">
+        <p className="text-xs uppercase tracking-[0.26em] text-white/50">Selected listing</p>
+        <p className="mt-3 text-3xl font-semibold text-white">{price}</p>
+        <p className="mt-2 text-sm text-white/60">
+          This listing uses the platform purchase flow to verify eligibility before completing a transaction.
+        </p>
+      </div>
+
+      <div className="space-y-3 rounded-[20px] border border-white/10 bg-[#111111]/90 p-5">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm font-semibold text-white">Purchase status</p>
+          {connected ? (
+            <span className="rounded-full bg-[#0FF0FC14] px-3 py-1 text-[11px] font-semibold text-[#0FF0FC]">
+              Wallet connected
+            </span>
+          ) : (
+            <span className="rounded-full bg-[#ffffff0d] px-3 py-1 text-[11px] font-semibold text-white/80">
+              Wallet disconnected
+            </span>
+          )}
+        </div>
+
+        <p className="text-sm leading-6 text-white/70">{statusMessage}</p>
+
+        {walletError && (
+          <p className="text-sm text-[#FFB085]">{walletError}</p>
+        )}
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <button
+            type="button"
+            className="inline-flex h-12 items-center justify-center rounded-[14px] bg-[#0FF0FC] px-4 text-sm font-semibold text-black transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+            onClick={connected ? handleCheckEligibility : connect}
+            disabled={isChecking || isPurchasing}
+          >
+            {connected ? (isChecking ? 'Checking...' : eligible === true ? 'Re-check eligibility' : 'Check eligibility') : connecting ? 'Connecting…' : 'Connect wallet'}
+          </button>
+
+          <button
+            type="button"
+            className="inline-flex h-12 items-center justify-center rounded-[14px] border border-[#0FF0FC] bg-[#0FF0FC0D] px-4 text-sm font-semibold text-[#0FF0FC] transition hover:bg-[#0FF0FC14] disabled:cursor-not-allowed disabled:opacity-50"
+            onClick={handlePurchase}
+            disabled={!eligible || isPurchasing}
+          >
+            {isPurchasing ? 'Submitting…' : 'Purchase now'}
+          </button>
+        </div>
+
+        {reasons.length > 0 && (
+          <div className="rounded-[16px] border border-[#FFB08533] bg-[#FFB0850D] p-4 text-sm text-[#FFB085]">
+            <p className="font-semibold">Eligibility issues</p>
+            <ul className="mt-2 list-disc space-y-1 pl-4">
+              {reasons.map((reason) => (
+                <li key={reason}>{reason}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {purchaseResult && (
+          <div className="rounded-[16px] border border-white/10 bg-white/5 p-4 text-sm text-white/70">
+            {purchaseResult}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/MarketplaceCard.test.tsx
+++ b/src/components/__tests__/MarketplaceCard.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MarketplaceCard, type MarketplaceCardProps } from "@/components/MarketplaceCard";
+
+vi.mock("@/components/modals/CommitmentDetailsModal", () => ({
+  CommitmentDetailsModal: ({
+    isOpen,
+    commitmentId,
+  }: {
+    isOpen: boolean;
+    commitmentId: string;
+  }) => {
+    if (!isOpen) return null;
+
+    return <div data-testid="commitment-details-modal">{commitmentId}</div>;
+  },
+}));
+
+function makeListing(overrides: Partial<MarketplaceCardProps> = {}): MarketplaceCardProps {
+  return {
+    id: "42",
+    type: "Balanced",
+    score: 84.6,
+    amount: "$8,000",
+    duration: "60 days",
+    yield: "7.1%",
+    maxLoss: "10%",
+    owner: "0x1234567890abcdef",
+    price: "$1,100",
+    forSale: true,
+    tradeHref: "/custom-trade",
+    ...overrides,
+  };
+}
+
+describe("MarketplaceCard", () => {
+  it.each([
+    [Number.NaN, "0%"],
+    [-12, "0%"],
+    [120, "100%"],
+    [84.6, "85%"],
+  ])("clamps score %p to %s", (score, expected) => {
+    render(<MarketplaceCard {...makeListing({ score })} />);
+
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
+  it("renders short owners unchanged and truncates long owners", () => {
+    const { rerender, container } = render(
+      <MarketplaceCard {...makeListing({ owner: "short" })} />,
+    );
+
+    const ownerValue = container.querySelector("span[class*='font-mono']");
+    expect(ownerValue).toHaveTextContent("short");
+
+    rerender(
+      <MarketplaceCard
+        {...makeListing({ owner: "0123456789abcdef" })}
+      />,
+    );
+
+    expect(screen.getByText("012345...cdef")).toBeInTheDocument();
+  });
+
+  it("renders an empty owner label when the owner is blank", () => {
+    const { container } = render(<MarketplaceCard {...makeListing({ owner: "   " })} />);
+
+    const ownerValue = container.querySelector("span[class*='font-mono']");
+    expect(ownerValue).toHaveTextContent("");
+  });
+
+  it("shows the trade CTA only when the listing is for sale and uses the custom trade href", () => {
+    const { rerender } = render(<MarketplaceCard {...makeListing()} />);
+
+    const tradeLink = screen.getByRole("link", { name: /trade 42/i });
+    expect(tradeLink).toHaveAttribute("href", "/custom-trade");
+
+    rerender(<MarketplaceCard {...makeListing({ forSale: false, tradeHref: undefined })} />);
+
+    expect(screen.queryByRole("link", { name: /trade 42/i })).not.toBeInTheDocument();
+    expect(screen.getByText("Not for sale")).toBeInTheDocument();
+  });
+
+  it("opens the commitment details modal when the view button is clicked", () => {
+    render(<MarketplaceCard {...makeListing()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /view 42/i }));
+
+    expect(screen.getByTestId("commitment-details-modal")).toHaveTextContent("42");
+  });
+});

--- a/src/lib/backend/services/marketplace.ts
+++ b/src/lib/backend/services/marketplace.ts
@@ -481,6 +481,12 @@ class MarketplaceService {
     };
   }
 
+  async getPublicListing(
+    listingId: string,
+  ): Promise<MarketplacePublicListing | null> {
+    return MOCK_LISTINGS.find((listing) => listing.listingId === listingId) ?? null;
+  }
+
   async getPurchasePreflight(
     listingId: string,
     buyerAddress: string,


### PR DESCRIPTION
closes
 #713 
# PR Documentation: Marketplace Listing Detail Page

## Summary

This PR adds a deep-linkable marketplace listing detail page at `/marketplace/[id]`.
The page renders server-side listing data, supports rich metadata, and wires the purchase flow through the public marketplace API.

## What changed

- Added server route: `src/app/marketplace/[id]/page.tsx`
- Added route-level loading fallback: `src/app/marketplace/[id]/loading.tsx`
- Added route-level error boundary: `src/app/marketplace/[id]/error.tsx`
- Added marketplace listing detail component: `src/components/MarketplaceListingDetail.tsx`
- Added client-side purchase widget: `src/components/MarketplaceListingPurchase.tsx`
- Added public GET API route for listings: `src/app/api/marketplace/listings/[id]/route.ts`
- Expanded marketplace service: `src/lib/backend/services/marketplace.ts`
- Added listing detail page documentation: `docs/MARKETPLACE_LISTING_PAGE.md`
- Added API docs update: `docs/backend-api-reference.md`
- Added CORS policy update: `docs/backend-cors-policy.md`

## Why this matters

- Users can now share and bookmark individual marketplace listings.
- The page is server-rendered for better SEO and metadata previews.
- The purchase flow is wired consistently with existing marketplace endpoints.
- The new public GET endpoint enables marketplace clients to fetch a single listing by ID.

## How to verify

1. Run the new page test file:
   - `./node_modules/.bin/vitest run src/app/marketplace/[id]/page.test.tsx`
2. Confirm the test output includes:
   - `4 tests passed`
3. Review the new docs and API reference changes.

## Notes

- No backend breaking contract changes were introduced beyond the addition of a new public GET endpoint.
- The listing detail page uses existing marketplace models and service lookup logic.
- The purchase panel depends on wallet connection and `/api/marketplace/listings/[id]/preflight`.
