### PR TITLE
feat: validate NEXT_PUBLIC env vars with a typed module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,67 @@
 # =============================================================================
 # Commitlabs - Environment Variable Reference
 # Copy this file to .env.local (git-ignored) and fill in your values.
-# All validation is enforced by src/lib/backend/env.ts (Zod schema).
+#
+# Validation:
+# - Backend env vars: src/lib/backend/env.ts (Zod schema)
+# - Client env vars (NEXT_PUBLIC_*): src/lib/clientEnv.ts (Zod schema)
 # =============================================================================
 
 # -----------------------------------------------------------------------------
-# Soroban RPC (required in development / production)
-# Use the private var for server-only routes; the NEXT_PUBLIC_ var is exposed
-# to the browser. The private var takes precedence when both are set.
-# Must be a valid URL when provided.
+# Client-Side Environment Variables (NEXT_PUBLIC_*)
+# These variables are exposed to the browser and validated by src/lib/clientEnv.ts.
+# Never include secrets in NEXT_PUBLIC_* variables.
 # -----------------------------------------------------------------------------
+
+# Soroban RPC endpoint (client-accessible)
+# Used by the frontend for blockchain interactions.
+# Must be a valid URL when provided.
 NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org:443
+
+# Stellar network passphrase (client-accessible)
+# Defaults to testnet value when not set.
+NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# Contract addresses (client-accessible)
+# These are the public contract addresses used by the frontend.
+# For server-side routes, use the non-public variants (e.g., COMMITMENT_CORE_CONTRACT).
+NEXT_PUBLIC_COMMITMENT_NFT_CONTRACT=
+NEXT_PUBLIC_COMMITMENT_CORE_CONTRACT=
+NEXT_PUBLIC_ATTESTATION_ENGINE_CONTRACT=
+
+# Contract configuration (client-accessible)
+# JSON blob defining multiple contract versions. See docs/config.md for structure.
+# NEXT_PUBLIC_CONTRACTS_JSON={"v1":{"commitmentNFT":{"address":"C..."},"commitmentCore":{"address":"C..."}}}
+
+# Active contract version (client-accessible)
+# Selects which configured version to use (defaults to "v1").
+NEXT_PUBLIC_ACTIVE_CONTRACT_VERSION=v1
+
+# Mock mode flag (client-accessible)
+# Set to "true" to use mock data instead of real blockchain interactions.
+NEXT_PUBLIC_USE_MOCKS=true
+
+# Application URLs (client-accessible)
+# Used for CORS configuration and generating links.
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# -----------------------------------------------------------------------------
+# Server-Side Environment Variables
+# These variables are NOT exposed to the browser and validated by src/lib/backend/env.ts.
+# Use these for secrets and server-only configuration.
+# -----------------------------------------------------------------------------
+
+# Soroban RPC endpoint (server-only)
+# Use this for server-side routes. Takes precedence over NEXT_PUBLIC_SOROBAN_RPC_URL.
 # SOROBAN_RPC_URL=https://soroban-testnet.stellar.org:443
 
-# Stellar network passphrase (defaults to testnet value when not set)
-NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+# Stellar network passphrase (server-only)
+# Defaults to testnet value when not set.
 # SOROBAN_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 
 # -----------------------------------------------------------------------------
-# Contract addresses (required in non-test environments)
+# Contract addresses (server-only)
 # Provide either the private or the NEXT_PUBLIC_ variant.
 # Deployment note:
 # - contracts/scripts/deploy-testnet.sh upserts the deployed id into .env.local.
@@ -26,18 +69,9 @@ NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 # - If server-side routes submit writes, keep COMMITMENT_CORE_CONTRACT or
 #   SOROBAN_COMMITMENT_CORE_CONTRACT aligned with the public contract id.
 # -----------------------------------------------------------------------------
-NEXT_PUBLIC_COMMITMENT_NFT_CONTRACT=
-NEXT_PUBLIC_COMMITMENT_CORE_CONTRACT=
-NEXT_PUBLIC_ATTESTATION_ENGINE_CONTRACT=
 # COMMITMENT_NFT_CONTRACT=
 # COMMITMENT_CORE_CONTRACT=
 # ATTESTATION_ENGINE_CONTRACT=
-
-# Optional: select which configured version to use (defaults to "v1")
-NEXT_PUBLIC_ACTIVE_CONTRACT_VERSION=v1
-
-# Optional: JSON blob defining multiple contract versions.
-# NEXT_PUBLIC_CONTRACTS_JSON={"v1":{"commitmentNFT":{"address":"C..."},"commitmentCore":{"address":"C..."}}}
 
 # -----------------------------------------------------------------------------
 # Signing credentials (server-side only - NEVER expose to the browser)
@@ -103,5 +137,3 @@ COMMITLABS_FEATURE_MARKETPLACE=false
 # redis://localhost:6379
 # redis://:mypassword@redis.example.com:6379/0
 # rediss://:mypassword@redis.example.com:6380/0
-
-NEXT_PUBLIC_USE_MOCKS=true

--- a/docs/config.md
+++ b/docs/config.md
@@ -2,6 +2,49 @@
 
 This project supports multiple smart contract versions and addresses via a centralized configuration accessor.
 
+## Client-Side Environment Variable Validation
+
+Client-side environment variables (those prefixed with `NEXT_PUBLIC_*`) are validated at startup by `src/lib/clientEnv.ts` using Zod. This ensures that:
+
+- Misconfigured or missing public env vars fail fast with clear error messages
+- Invalid URLs are caught before runtime
+- Accidental exposure of non-public secrets as `NEXT_PUBLIC_*` is prevented
+- All client config is type-safe through TypeScript
+
+### Validated Client Environment Variables
+
+The following `NEXT_PUBLIC_*` variables are validated by the client env module:
+
+- `NEXT_PUBLIC_SOROBAN_RPC_URL` - Soroban RPC endpoint (URL format validated)
+- `NEXT_PUBLIC_NETWORK_PASSPHRASE` - Stellar network passphrase
+- `NEXT_PUBLIC_COMMITMENT_NFT_CONTRACT` - NFT contract address
+- `NEXT_PUBLIC_COMMITMENT_CORE_CONTRACT` - Core contract address
+- `NEXT_PUBLIC_ATTESTATION_ENGINE_CONTRACT` - Attestation contract address
+- `NEXT_PUBLIC_CONTRACTS_JSON` - JSON blob for contract configuration
+- `NEXT_PUBLIC_ACTIVE_CONTRACT_VERSION` - Active contract version
+- `NEXT_PUBLIC_USE_MOCKS` - Mock mode flag
+- `NEXT_PUBLIC_APP_URL` - Application URL (for CORS)
+- `NEXT_PUBLIC_SITE_URL` - Site URL (for CORS)
+
+### Usage in Client Code
+
+Import and use the validated client env in client-side code:
+
+```typescript
+import { getValidatedClientEnv } from '@/lib/clientEnv';
+
+const clientEnv = getValidatedClientEnv();
+const rpcUrl = clientEnv.NEXT_PUBLIC_SOROBAN_RPC_URL;
+```
+
+### Error Handling
+
+If validation fails, a `ClientEnvValidationError` is thrown with a clear message indicating which variables are invalid or missing. In development and production, validation happens eagerly at module load time to catch issues early.
+
+### Security Note
+
+Never include secrets in `NEXT_PUBLIC_*` variables. These are exposed to the browser and should only contain non-sensitive configuration data.
+
 ## Config sources
 
 - `NEXT_PUBLIC_CONTRACTS_JSON` (preferred): JSON string mapping versions to contract entries.

--- a/src/app/api/ready/route.ts
+++ b/src/app/api/ready/route.ts
@@ -4,22 +4,25 @@ import { createCorsOptionsHandler, type CorsRoutePolicy } from '@/lib/backend/co
 import { logger } from '@/lib/backend';
 import { withApiHandler } from '@/lib/backend/withApiHandler';
 import { getBackendConfig } from '@/lib/backend/config';
+import { getValidatedEnv } from '@/lib/backend/env';
 import { SorobanRpc } from '@stellar/stellar-sdk';
 
-const SOROBAN_RPC_URL = process.env.NEXT_PUBLIC_SOROBAN_RPC_URL;
 const READY_CORS_POLICY = {
   GET: { access: 'public' },
 } satisfies CorsRoutePolicy;
 
 async function checkSorobanRpc(): Promise<{ reachable: boolean; latencyMs?: number; error?: string }> {
-  if (!SOROBAN_RPC_URL) {
+  const env = getValidatedEnv();
+  const sorobanRpcUrl = env.SOROBAN_RPC_URL ?? env.NEXT_PUBLIC_SOROBAN_RPC_URL;
+  
+  if (!sorobanRpcUrl) {
     logger.warn('SOROBAN_RPC_URL not configured, skipping RPC connectivity check');
     return { reachable: false, error: 'SOROBAN_RPC_URL not configured' };
   }
 
   const start = Date.now();
   try {
-    const response = await fetch(SOROBAN_RPC_URL, {
+    const response = await fetch(sorobanRpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getHealth', params: [] }),
@@ -38,7 +41,7 @@ async function checkSorobanRpc(): Promise<{ reachable: boolean; latencyMs?: numb
     return { reachable: true, latencyMs };
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
-    logger.error('Soroban RPC connectivity check threw', { error, url: SOROBAN_RPC_URL });
+    logger.error('Soroban RPC connectivity check threw', { error, url: sorobanRpcUrl });
     return { reachable: false, error: error.message };
   }
 }
@@ -55,7 +58,10 @@ async function probeContractReachability(): Promise<{
   error?: string;
   details?: string;
 }> {
-  if (!SOROBAN_RPC_URL) {
+  const env = getValidatedEnv();
+  const sorobanRpcUrl = env.SOROBAN_RPC_URL ?? env.NEXT_PUBLIC_SOROBAN_RPC_URL;
+  
+  if (!sorobanRpcUrl) {
     return { reachable: false, error: 'RPC not configured' };
   }
 
@@ -69,8 +75,8 @@ async function probeContractReachability(): Promise<{
     }
 
     const start = Date.now();
-    const server = new SorobanRpc.Server(SOROBAN_RPC_URL, {
-      allowHttp: SOROBAN_RPC_URL.startsWith('http://'),
+    const server = new SorobanRpc.Server(sorobanRpcUrl, {
+      allowHttp: sorobanRpcUrl.startsWith('http://'),
     });
 
     // Perform a lightweight read: fetch the contract's metadata
@@ -91,16 +97,19 @@ export const OPTIONS = createCorsOptionsHandler(READY_CORS_POLICY);
 export const GET = withApiHandler(async () => {
   logger.info('Readiness check requested');
 
+  const env = getValidatedEnv();
+  const sorobanRpcUrl = env.SOROBAN_RPC_URL ?? env.NEXT_PUBLIC_SOROBAN_RPC_URL;
+
   const rpc = await checkSorobanRpc();
   const contract = await probeContractReachability();
 
-  const ready = (rpc.reachable || !SOROBAN_RPC_URL) && (contract.reachable || !SOROBAN_RPC_URL);
+  const ready = (rpc.reachable || !sorobanRpcUrl) && (contract.reachable || !sorobanRpcUrl);
   const body = {
     status: ready ? 'ready' : 'not_ready',
     timestamp: new Date().toISOString(),
     checks: {
-      sorobanRpc: SOROBAN_RPC_URL ? { ...rpc } : { reachable: null, note: 'not configured' },
-      contract: SOROBAN_RPC_URL ? { ...contract } : { reachable: null, note: 'not configured' },
+      sorobanRpc: sorobanRpcUrl ? { ...rpc } : { reachable: null, note: 'not configured' },
+      contract: sorobanRpcUrl ? { ...contract } : { reachable: null, note: 'not configured' },
     },
   };
 

--- a/src/app/commitments/page.tsx
+++ b/src/app/commitments/page.tsx
@@ -13,6 +13,7 @@ import { useWallet } from '@/hooks/useWallet'
 import { Commitment, CommitmentStats } from '@/types/commitment'
 import { listCommitments } from '@/lib/backend/mocks/contracts'
 import { fetchProtocolConstants, ProtocolConstants } from '@/utils/protocol'
+import { getValidatedClientEnv } from '@/lib/clientEnv'
 
 const mockCommitments: Commitment[] = [
   {
@@ -158,7 +159,8 @@ export default function MyCommitments() {
   }, [])
 
   useEffect(() => {
-    if (process.env.NEXT_PUBLIC_USE_MOCKS === 'true') {
+    const clientEnv = getValidatedClientEnv()
+    if (clientEnv.NEXT_PUBLIC_USE_MOCKS === 'true') {
       setIsLoading(true)
       listCommitments()
         .then(setCommitmentsList)

--- a/src/lib/__tests__/clientEnv.test.ts
+++ b/src/lib/__tests__/clientEnv.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  validateClientEnv,
+  getValidatedClientEnv,
+  _resetClientEnvCache,
+  ClientEnvValidationError,
+} from "../clientEnv";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const VALID_CLIENT_ENV = {
+  NEXT_PUBLIC_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org:443",
+  NEXT_PUBLIC_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+  NEXT_PUBLIC_COMMITMENT_NFT_CONTRACT: "CABC123...",
+  NEXT_PUBLIC_COMMITMENT_CORE_CONTRACT: "CDEF456...",
+  NEXT_PUBLIC_ATTESTATION_ENGINE_CONTRACT: "CGHI789...",
+  NEXT_PUBLIC_ACTIVE_CONTRACT_VERSION: "v1",
+  NEXT_PUBLIC_USE_MOCKS: "true",
+  NEXT_PUBLIC_APP_URL: "http://localhost:3000",
+  NEXT_PUBLIC_SITE_URL: "http://localhost:3000",
+} as const;
+
+const MINIMAL_CLIENT_ENV = {
+  NEXT_PUBLIC_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org:443",
+} as const;
+
+// ---------------------------------------------------------------------------
+// ClientEnvValidationError
+// ---------------------------------------------------------------------------
+
+describe("ClientEnvValidationError", () => {
+  it("extends Error", () => {
+    const err = new ClientEnvValidationError([{ path: "FOO", message: "missing" }]);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("has name ClientEnvValidationError", () => {
+    const err = new ClientEnvValidationError([{ path: "FOO", message: "missing" }]);
+    expect(err.name).toBe("ClientEnvValidationError");
+  });
+
+  it("includes path and message in the error string", () => {
+    const err = new ClientEnvValidationError([
+      { path: "SOME_VAR", message: "is required" },
+    ]);
+    expect(err.message).toContain("SOME_VAR");
+    expect(err.message).toContain("is required");
+  });
+
+  it("exposes a readonly issues array", () => {
+    const input = [
+      { path: "A", message: "msg A" },
+      { path: "B", message: "msg B" },
+    ];
+    const err = new ClientEnvValidationError(input);
+    expect(err.issues).toHaveLength(2);
+    expect(err.issues[0]).toEqual({ path: "A", message: "msg A" });
+    expect(err.issues[1]).toEqual({ path: "B", message: "msg B" });
+  });
+
+  it("formats a multi-issue message with bullet lines", () => {
+    const err = new ClientEnvValidationError([
+      { path: "A", message: "msg A" },
+      { path: "B", message: "msg B" },
+    ]);
+    expect(err.message).toContain("  - A: msg A");
+    expect(err.message).toContain("  - B: msg B");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClientEnv — basic validation
+// ---------------------------------------------------------------------------
+
+describe("validateClientEnv — basic validation", () => {
+  it("passes with no environment variables (all optional)", () => {
+    expect(() => validateClientEnv({})).not.toThrow();
+  });
+
+  it("returns undefined for unprovided optional fields", () => {
+    const env = validateClientEnv({});
+    expect(env.NEXT_PUBLIC_SOROBAN_RPC_URL).toBeUndefined();
+    expect(env.NEXT_PUBLIC_NETWORK_PASSPHRASE).toBeUndefined();
+    expect(env.NEXT_PUBLIC_COMMITMENT_NFT_CONTRACT).toBeUndefined();
+  });
+
+  it("accepts a valid NEXT_PUBLIC_SOROBAN_RPC_URL", () => {
+    const env = validateClientEnv(MINIMAL_CLIENT_ENV);
+    expect(env.NEXT_PUBLIC_SOROBAN_RPC_URL).toBe(
+      "https://soroban-testnet.stellar.org:443",
+    );
+  });
+
+  it("accepts localhost RPC URLs (development-friendly)", () => {
+    expect(() =>
+      validateClientEnv({
+        NEXT_PUBLIC_SOROBAN_RPC_URL: "http://localhost:8000",
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts all valid client environment variables", () => {
+    const env = validateClientEnv(VALID_CLIENT_ENV);
+    expect(env.NEXT_PUBLIC_SOROBAN_RPC_URL).toBe(
+      "https://soroban-testnet.stellar.org:443",
+    );
+    expect(env.NEXT_PUBLIC_NETWORK_PASSPHRASE).toBe(
+      "Test SDF Network ; September 2015",
+    );
+    expect(env.NEXT_PUBLIC_COMMITMENT_NFT_CONTRACT).toBe("CABC123...");
+    expect(env.NEXT_PUBLIC_COMMITMENT_CORE_CONTRACT).toBe("CDEF456...");
+    expect(env.NEXT_PUBLIC_ATTESTATION_ENGINE_CONTRACT).toBe("CGHI789...");
+    expect(env.NEXT_PUBLIC_ACTIVE_CONTRACT_VERSION).toBe("v1");
+    expect(env.NEXT_PUBLIC_USE_MOCKS).toBe("true");
+    expect(env.NEXT_PUBLIC_APP_URL).toBe("http://localhost:3000");
+    expect(env.NEXT_PUBLIC_SITE_URL).toBe("http://localhost:3000");
+  });
+
+  it("ignores non-NEXT_PUBLIC_ environment variables", () => {
+    expect(() =>
+      validateClientEnv({
+        ...MINIMAL_CLIENT_ENV,
+        SECRET_KEY: "should-be-ignored",
+        DATABASE_URL: "should-be-ignored",
+      }),
+    ).not.toThrow();
+  });
+
+  it("filters out non-NEXT_PUBLIC_ variables from the result", () => {
+    const env = validateClientEnv({
+      ...MINIMAL_CLIENT_ENV,
+      SECRET_KEY: "should-be-ignored",
+    });
+    expect(env).not.toHaveProperty("SECRET_KEY");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClientEnv — URL format validation
+// ---------------------------------------------------------------------------
+
+describe("validateClientEnv — URL validation", () => {
+  it("rejects an invalid NEXT_PUBLIC_SOROBAN_RPC_URL", () => {
+    expect(() =>
+      validateClientEnv({ NEXT_PUBLIC_SOROBAN_RPC_URL: "not-a-url" }),
+    ).toThrow(ClientEnvValidationError);
+  });
+
+  it("includes the field name in the error for an invalid NEXT_PUBLIC_SOROBAN_RPC_URL", () => {
+    try {
+      validateClientEnv({ NEXT_PUBLIC_SOROBAN_RPC_URL: "not-a-url" });
+    } catch (err) {
+      expect(err).toBeInstanceOf(ClientEnvValidationError);
+      const issue = (err as ClientEnvValidationError).issues.find(
+        (i) => i.path === "NEXT_PUBLIC_SOROBAN_RPC_URL",
+      );
+      expect(issue).toBeDefined();
+    }
+  });
+
+  it("rejects an invalid NEXT_PUBLIC_APP_URL", () => {
+    expect(() =>
+      validateClientEnv({ NEXT_PUBLIC_APP_URL: "no-protocol" }),
+    ).toThrow(ClientEnvValidationError);
+  });
+
+  it("rejects an invalid NEXT_PUBLIC_SITE_URL", () => {
+    expect(() =>
+      validateClientEnv({ NEXT_PUBLIC_SITE_URL: "not-a-url" }),
+    ).toThrow(ClientEnvValidationError);
+  });
+
+  it("accepts valid HTTPS URLs", () => {
+    expect(() =>
+      validateClientEnv({
+        NEXT_PUBLIC_SOROBAN_RPC_URL: "https://example.com",
+        NEXT_PUBLIC_APP_URL: "https://example.com",
+        NEXT_PUBLIC_SITE_URL: "https://example.com",
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts valid HTTP URLs (for local development)", () => {
+    expect(() =>
+      validateClientEnv({
+        NEXT_PUBLIC_SOROBAN_RPC_URL: "http://localhost:8000",
+        NEXT_PUBLIC_APP_URL: "http://localhost:3000",
+        NEXT_PUBLIC_SITE_URL: "http://localhost:3000",
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClientEnv — security: prevents secret exposure
+// ---------------------------------------------------------------------------
+
+describe("validateClientEnv — security: prevents secret exposure", () => {
+  it("does not include non-NEXT_PUBLIC_ variables in validation", () => {
+    // This test ensures that secrets without NEXT_PUBLIC_ prefix are not validated
+    // and therefore won't accidentally be exposed through the client env module
+    const env = validateClientEnv({
+      SECRET_KEY: "my-secret-value",
+      DATABASE_PASSWORD: "my-password",
+    });
+    expect(env).not.toHaveProperty("SECRET_KEY");
+    expect(env).not.toHaveProperty("DATABASE_PASSWORD");
+  });
+
+  it("only validates variables with NEXT_PUBLIC_ prefix", () => {
+    const env = validateClientEnv({
+      NEXT_PUBLIC_SOROBAN_RPC_URL: "https://example.com",
+      PRIVATE_VAR: "should-not-appear",
+    });
+    expect(env.NEXT_PUBLIC_SOROBAN_RPC_URL).toBe("https://example.com");
+    expect(env).not.toHaveProperty("PRIVATE_VAR");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClientEnv — malformed values
+// ---------------------------------------------------------------------------
+
+describe("validateClientEnv — malformed values", () => {
+  it("reports multiple validation errors together", () => {
+    try {
+      validateClientEnv({
+        NEXT_PUBLIC_SOROBAN_RPC_URL: "not-a-url",
+        NEXT_PUBLIC_APP_URL: "also-not-a-url",
+      });
+    } catch (err) {
+      const error = err as ClientEnvValidationError;
+      expect(error.issues.length).toBeGreaterThanOrEqual(2);
+      const paths = error.issues.map((i) => i.path);
+      expect(paths).toContain("NEXT_PUBLIC_SOROBAN_RPC_URL");
+      expect(paths).toContain("NEXT_PUBLIC_APP_URL");
+    }
+  });
+
+  it("accepts empty string values (optional fields)", () => {
+    expect(() =>
+      validateClientEnv({
+        NEXT_PUBLIC_SOROBAN_RPC_URL: "",
+        NEXT_PUBLIC_NETWORK_PASSPHRASE: "",
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getValidatedClientEnv — caching behaviour
+// ---------------------------------------------------------------------------
+
+describe("getValidatedClientEnv", () => {
+  beforeEach(() => {
+    _resetClientEnvCache();
+  });
+
+  it("returns a ValidatedClientEnv object on the first call", () => {
+    const env = getValidatedClientEnv(MINIMAL_CLIENT_ENV);
+    expect(env).toBeDefined();
+    expect(env.NEXT_PUBLIC_SOROBAN_RPC_URL).toBe(
+      "https://soroban-testnet.stellar.org:443",
+    );
+  });
+
+  it("caches the result — subsequent calls return the same object reference", () => {
+    const env1 = getValidatedClientEnv(MINIMAL_CLIENT_ENV);
+    const env2 = getValidatedClientEnv({ NEXT_PUBLIC_SOROBAN_RPC_URL: "https://different.com" });
+    expect(env1).toBe(env2);
+  });
+
+  it("ignores the source argument after the cache is populated", () => {
+    getValidatedClientEnv(MINIMAL_CLIENT_ENV);
+    const env2 = getValidatedClientEnv({ NEXT_PUBLIC_SOROBAN_RPC_URL: "https://different.com" });
+    // Cache still holds the first result
+    expect(env2.NEXT_PUBLIC_SOROBAN_RPC_URL).toBe("https://soroban-testnet.stellar.org:443");
+  });
+
+  it("throws ClientEnvValidationError when the source fails validation", () => {
+    expect(() =>
+      getValidatedClientEnv({ NEXT_PUBLIC_SOROBAN_RPC_URL: "not-a-url" }),
+    ).toThrow(ClientEnvValidationError);
+  });
+
+  it("does not populate the cache on a failed validation", () => {
+    try {
+      getValidatedClientEnv({ NEXT_PUBLIC_SOROBAN_RPC_URL: "not-a-url" });
+    } catch {
+      // swallow
+    }
+    // After a failure the cache is still empty; a fresh valid source should succeed
+    expect(() => getValidatedClientEnv(MINIMAL_CLIENT_ENV)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _resetClientEnvCache
+// ---------------------------------------------------------------------------
+
+describe("_resetClientEnvCache", () => {
+  it("clears the cache so the next call re-validates from the new source", () => {
+    const env1 = getValidatedClientEnv(MINIMAL_CLIENT_ENV);
+    _resetClientEnvCache();
+    const env2 = getValidatedClientEnv({ NEXT_PUBLIC_SOROBAN_RPC_URL: "https://different.com" });
+    expect(env1).not.toBe(env2);
+    expect(env2.NEXT_PUBLIC_SOROBAN_RPC_URL).toBe("https://different.com");
+  });
+
+  it("is idempotent — calling it twice does not throw", () => {
+    expect(() => {
+      _resetClientEnvCache();
+      _resetClientEnvCache();
+    }).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateClientEnv — root-level Zod issue path fallback
+// ---------------------------------------------------------------------------
+
+describe("validateClientEnv — root-level issue formatting", () => {
+  it("uses '(root)' as path when a Zod issue has no field path (e.g. non-object input)", () => {
+    // Passing null triggers z.object()'s root-level type error (path: [])
+    try {
+      validateClientEnv(null as unknown as Record<string, string | undefined>);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ClientEnvValidationError);
+      const error = err as ClientEnvValidationError;
+      const rootIssue = error.issues.find((i) => i.path === "(root)");
+      expect(rootIssue).toBeDefined();
+    }
+  });
+});

--- a/src/lib/clientEnv.ts
+++ b/src/lib/clientEnv.ts
@@ -1,0 +1,138 @@
+// Client-side environment variable validation.
+// All process.env.NEXT_PUBLIC_* reads for client config flow through getValidatedClientEnv().
+// This module validates at startup in development to fail fast on misconfiguration.
+// In production it validates eagerly to catch issues before runtime.
+
+import { z } from "zod";
+
+/**
+ * URL validation that works with Zod v4
+ */
+const urlSchema = z.string().refine(
+  (val) => {
+    try {
+      new URL(val);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  { message: "Must be a valid URL (e.g. https://example.com)" },
+);
+
+/**
+ * Schema for all recognised client-side (NEXT_PUBLIC_*) environment variables.
+ * These variables are exposed to the browser and must never contain secrets.
+ */
+const clientEnvSchema = z.object({
+  // Soroban RPC endpoint — format-validated when present
+  NEXT_PUBLIC_SOROBAN_RPC_URL: urlSchema.optional(),
+
+  // Stellar network passphrase
+  NEXT_PUBLIC_NETWORK_PASSPHRASE: z.string().optional(),
+
+  // Soroban contract addresses
+  NEXT_PUBLIC_COMMITMENT_NFT_CONTRACT: z.string().optional(),
+  NEXT_PUBLIC_COMMITMENT_CORE_CONTRACT: z.string().optional(),
+  NEXT_PUBLIC_ATTESTATION_ENGINE_CONTRACT: z.string().optional(),
+
+  // Contract version / JSON overrides
+  NEXT_PUBLIC_CONTRACTS_JSON: z.string().optional(),
+  NEXT_PUBLIC_ACTIVE_CONTRACT_VERSION: z.string().optional(),
+
+  // Mock-mode flag
+  NEXT_PUBLIC_USE_MOCKS: z.string().optional(),
+
+  // Application URLs (for CORS and links)
+  NEXT_PUBLIC_APP_URL: urlSchema.optional(),
+  NEXT_PUBLIC_SITE_URL: urlSchema.optional(),
+});
+
+/** Fully validated, type-safe client environment object */
+export type ValidatedClientEnv = z.infer<typeof clientEnvSchema>;
+
+/**
+ * Thrown whenever client environment validation fails.
+ */
+export class ClientEnvValidationError extends Error {
+  readonly issues: ReadonlyArray<{ path: string; message: string }>;
+
+  constructor(issues: Array<{ path: string; message: string }>) {
+    const lines = issues
+      .map(({ path, message }) => `  - ${path}: ${message}`)
+      .join("\n");
+    super(`Client environment validation failed:\n${lines}`);
+    this.name = "ClientEnvValidationError";
+    this.issues = issues;
+  }
+}
+
+function formatZodIssues(
+  zodError: z.ZodError,
+): Array<{ path: string; message: string }> {
+  return zodError.issues.map((issue) => {
+    const path = issue.path.join(".") || "(root)";
+    return {
+      path,
+      message: issue.message,
+    };
+  });
+}
+
+/**
+ * Parses and validates all client-side environment variables.
+ *
+ * - URL fields are format-checked whenever present.
+ * - All fields are optional to allow gradual migration.
+ * - In development, validation happens eagerly to catch issues early.
+ * - In production, validation also happens eagerly to prevent runtime failures.
+ *
+ * @param source - Map of env vars to validate (defaults to process.env)
+ * @throws {ClientEnvValidationError} when any validation rule fails
+ */
+export function validateClientEnv(
+  source: Record<string, string | undefined> = process.env,
+): ValidatedClientEnv {
+  // Filter to only NEXT_PUBLIC_* variables to prevent accidental secret exposure
+  const publicVars = Object.fromEntries(
+    Object.entries(source).filter(([key]) => key.startsWith("NEXT_PUBLIC_")),
+  );
+
+  const result = clientEnvSchema.safeParse(publicVars);
+
+  if (!result.success) {
+    throw new ClientEnvValidationError(formatZodIssues(result.error));
+  }
+
+  return result.data;
+}
+
+let _cachedClientEnv: ValidatedClientEnv | null = null;
+
+/**
+ * Returns the validated client env object, caching it after the first successful
+ * call. Pass a custom source only in tests (and call _resetClientEnvCache() in
+ * beforeEach so tests are isolated).
+ */
+export function getValidatedClientEnv(
+  source: Record<string, string | undefined> = process.env,
+): ValidatedClientEnv {
+  if (_cachedClientEnv) return _cachedClientEnv;
+  _cachedClientEnv = validateClientEnv(source);
+  return _cachedClientEnv;
+}
+
+/** Clears the module-level client env cache. For tests only. */
+export function _resetClientEnvCache(): void {
+  _cachedClientEnv = null;
+}
+
+// Fail fast in development and production: validate at module load time so a
+// misconfigured deployment crashes immediately rather than at runtime.
+if (
+  process.env.NODE_ENV === "development" ||
+  process.env.NODE_ENV === "production" ||
+  process.env.VERCEL_ENV === "production"
+) {
+  getValidatedClientEnv();
+}

--- a/src/utils/soroban.ts
+++ b/src/utils/soroban.ts
@@ -7,19 +7,23 @@
  * SINGLE SOURCE OF TRUTH:
  * - Contract addresses: This module (via contractAddresses getters)
  * - Chain interactions: src/lib/backend/services/contracts.ts
+ * - Client environment variables: src/lib/clientEnv.ts
  *
  * For wallet connection, contract calls, and contract reads, use:
  * @see src/lib/backend/services/contracts.ts
  */
 
+import { getContractAddress } from "../lib/backend/config";
+import { getValidatedClientEnv } from "../lib/clientEnv";
+
+const clientEnv = getValidatedClientEnv();
+
 export const rpcUrl =
-  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ||
+  clientEnv.NEXT_PUBLIC_SOROBAN_RPC_URL ||
   "https://soroban-testnet.stellar.org:443";
 export const networkPassphrase =
-  process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE ||
+  clientEnv.NEXT_PUBLIC_NETWORK_PASSPHRASE ||
   "Test SDF Network ; September 2015";
-
-import { getContractAddress } from "../lib/backend/config";
 
 /**
  * Lazily-loaded contract addresses to avoid build-time errors when env vars aren't set.


### PR DESCRIPTION
Add src/lib/clientEnv.ts validating NEXT_PUBLIC_* vars with Zod and exporting a typed object. Use it where public config is read (e.g. base URL / explorer host). Document each variable in .env.example and docs/config.md. Never read non-public secrets here.

Changes:
- Add src/lib/clientEnv.ts with Zod validation for all NEXT_PUBLIC_* variables
- Update src/utils/soroban.ts to use validated client env
- Update src/app/commitments/page.tsx to use validated client env
- Update src/app/api/ready/route.ts to use validated backend env
- Update .env.example with comprehensive NEXT_PUBLIC_* documentation
- Update docs/config.md with client env validation section
- Add src/lib/__tests__/clientEnv.test.ts with comprehensive test coverage

This ensures misconfigured or missing public env vars fail fast at startup with clear error messages, and prevents accidental exposure of non-public secrets as NEXT_PUBLIC_* variables.

closes  #812