### PR TITLE
feat: post-creation funding step wired to fund route

### DIFF
--- a/docs/CREATE_THEN_FUND.md
+++ b/docs/CREATE_THEN_FUND.md
@@ -1,0 +1,213 @@
+# CREATE_THEN_FUND — Two-Step Commitment Lifecycle
+
+This document describes the two-step lifecycle for creating and funding a
+Commitlabs escrow commitment, and the UX flow that guides users through it.
+
+---
+
+## Overview
+
+The backend enforces a two-phase lifecycle for every commitment:
+
+| Phase | Status | Description |
+|-------|--------|-------------|
+| **1 — Created** | `CREATED` | Commitment record exists on-chain; escrow is empty. Yield does not accrue yet. |
+| **2 — Funded** | `ACTIVE` | Escrow has been funded; yield accrual and compliance monitoring begin. |
+
+Without completing Phase 2, a commitment is permanently in the `CREATED` state
+and never earns yield or becomes tradeable on the marketplace.
+
+---
+
+## API Contract
+
+### Fund endpoint
+
+```
+POST /api/commitments/:id/fund
+Content-Type: application/json
+
+{
+  "callerAddress": "<optional stellar address of connected wallet>"
+}
+```
+
+**Success (200)**
+
+```json
+{
+  "data": {
+    "commitmentId": "CMT-ABC1234",
+    "txHash": "0x...",
+    "reference": "...",
+    "fundedAt": "2026-06-27T08:00:00.000Z"
+  }
+}
+```
+
+**Error codes handled by the UI**
+
+| Status | Meaning | UI behaviour |
+|--------|---------|--------------|
+| 200 | Funded | Transition to `success` state, show `txHash` |
+| 409 | Already funded | Treated as success (idempotent) |
+| 403 | Caller is not the owner | Error panel with ownership message |
+| 429 | Rate-limited | Error panel with retry guidance |
+| 4xx / 5xx | Validation / server error | Error panel with server message |
+| network | Fetch threw | Error panel with JS error message |
+
+**Idempotency:** The route supports an optional `Idempotency-Key` header. The
+frontend does not currently set this header, but it can be added in the
+`handleFund` function inside `CommitmentCreatedModal.tsx` if needed.
+
+---
+
+## UX Flow
+
+```
+┌─────────────────────────────┐
+│      Create Wizard          │
+│  Step 1 → Step 2 → Step 3  │
+│         (Review)            │
+└─────────────┬───────────────┘
+              │  handleSubmit → POST /api/commitments
+              ▼
+┌─────────────────────────────┐
+│  CommitmentCreatedModal     │
+│  fundStep = "idle"          │◄──── modal opens automatically
+│                             │
+│  [Fund Now]  [Fund Later]   │
+└──────┬──────────┬───────────┘
+       │          │
+  Fund Now    Fund Later
+       │          │
+       ▼          ▼
+  "funding"   "skipped" ──────────────► /commitments/:id
+       │                                (detail page allows
+       │                                 retry any time)
+  ┌────┴────┐
+  │  fetch  │  POST /api/commitments/:id/fund
+  └────┬────┘
+       │
+   ┌───┴────────────┐
+ ok/409           error
+   │                │
+   ▼                ▼
+"success"        "error"
+   │                │
+[View]        [Retry] [Fund Later]
+   │
+   ▼
+/commitments/:id
+```
+
+### State machine
+
+```
+idle ──► funding ──► success
+  ▲          │
+  │        error
+  └──────────┘  (retry resets to idle)
+
+idle ──► skipped  (Fund Later clicked)
+error ──► skipped (Fund Later clicked from error panel)
+```
+
+---
+
+## Component API
+
+### `CommitmentCreatedModal` — new props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `callerAddress` | `string \| undefined` | `undefined` | Connected wallet address forwarded to the fund API for ownership validation. |
+| `onFundLater` | `() => void \| undefined` | `undefined` | If provided, shows the "Fund Later" button. Called when the user skips. |
+
+All pre-existing props (`isOpen`, `commitmentId`, `onViewCommitment`,
+`onCreateAnother`, `onClose`, `onViewOnExplorer`) are unchanged.
+
+### `create/page.tsx` — additions
+
+- `callerAddress` constant — currently `undefined`; replace with the value
+  from your wallet hook (e.g. `useWallet().address`) once wallet integration
+  is complete.
+- `handleFundLater` — closes the modal and navigates to
+  `/commitments/:numericId` so the user can fund from the detail page.
+
+---
+
+## Skip and Resume
+
+Skipping funding is always reversible. When the user skips:
+
+1. The modal transitions to the `skipped` state showing a reminder banner.
+2. `onFundLater()` is called — in `create/page.tsx` this navigates to the
+   commitment detail page (`/commitments/:id`).
+3. On the detail page the user can initiate funding separately (that
+   integration is outside the scope of this feature but follows the same
+   `POST /api/commitments/:id/fund` call).
+
+---
+
+## Error Handling
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Network unreachable | Error panel with `err.message`; retry available |
+| 403 Forbidden | Specific ownership message; user may still skip |
+| 409 Conflict (already funded) | Silently treated as success; no user interruption |
+| 429 Too Many Requests | Message asks user to wait; retry available |
+| JSON parse failure on response | Gracefully ignored; falls back to status-code message |
+
+---
+
+## Accessibility
+
+- The modal is mounted via `createPortal` to `document.body`, ensuring it sits
+  at the top of the stacking context.
+- Focus is set to the primary action button 100 ms after open.
+- A focus trap cycles focus within the modal using `Tab` / `Shift+Tab`.
+- `Escape` closes the modal in all states.
+- `aria-live="polite"` on the loading and success panels announces transitions
+  to screen readers without interrupting current speech.
+- `aria-live="assertive"` on the error panel announces failures immediately.
+- All interactive elements have descriptive `aria-label` attributes.
+- Buttons are `disabled` during the `funding` state to prevent duplicate submissions.
+
+---
+
+## Testing
+
+Tests live in `src/components/modals/CommitmentCreatedModal.test.tsx` and cover:
+
+- Initial idle state rendering
+- Loading / spinner state
+- Successful fund (200)
+- Already-funded (409) treated as success
+- Network error → error panel
+- 403 ownership error message
+- Skip / Fund Later → skipped state + `onFundLater` callback
+- `onFundLater` button hidden when prop absent
+- Retry flow (error → retry → success)
+- `onViewCommitment` triggered after success
+- `onCreateAnother` trigger
+- Keyboard: Escape closes modal
+- Backdrop click closes modal
+- `aria-live` region present after fund action
+- Body scroll locked while modal is open
+- Not rendered when `isOpen` is false
+- Stellar Explorer link conditional
+- Fund state resets when `commitmentId` changes
+
+Run with:
+
+```bash
+npx vitest run src/components/modals/CommitmentCreatedModal.test.tsx
+```
+
+Or as part of the full suite:
+
+```bash
+npx vitest run
+```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 0.563.0(react@18.3.1)
       next:
         specifier: ^14.0.0
-        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       postcss:
         specifier: ^8.5.6
         version: 8.5.14
@@ -69,6 +69,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.0
         version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@8.0.12(@types/node@20.19.41)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.6(vitest@4.1.6)
@@ -113,12 +116,66 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.3':
@@ -126,12 +183,41 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -389,28 +475,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -502,42 +584,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0':
     resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0':
     resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0':
     resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0':
     resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0':
     resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0':
     resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
@@ -564,6 +640,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.0':
     resolution: {integrity: sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -633,28 +712,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -715,6 +790,18 @@ packages:
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -879,49 +966,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -942,6 +1021,12 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/coverage-v8@4.1.6':
     resolution: {integrity: sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==}
@@ -1130,6 +1215,11 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  baseline-browser-mapping@2.10.40:
+    resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
@@ -1142,6 +1232,11 @@ packages:
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
+
+  browserslist@4.28.4:
+    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -1168,6 +1263,9 @@ packages:
 
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1346,6 +1444,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  electron-to-chromium@1.5.380:
+    resolution: {integrity: sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1402,6 +1503,10 @@ packages:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1636,6 +1741,10 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1917,6 +2026,11 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -1928,6 +2042,11 @@ packages:
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
     hasBin: true
 
   jsx-ast-utils@3.3.5:
@@ -1983,28 +2102,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2035,6 +2150,9 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lucide-react@0.563.0:
     resolution: {integrity: sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==}
@@ -2145,6 +2263,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-releases@2.0.50:
+    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
+    engines: {node: '>=18'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2297,6 +2419,10 @@ packages:
         optional: true
       redux:
         optional: true
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -2653,6 +2779,12 @@ packages:
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -2812,6 +2944,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2831,20 +2966,132 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -3138,6 +3385,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0': {}
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.16.1': {}
@@ -3289,6 +3538,27 @@ snapshots:
     optional: true
 
   '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -3499,6 +3769,18 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@vitejs/plugin-react@4.7.0(vite@8.0.12(@types/node@20.19.41)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 8.0.12(@types/node@20.19.41)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':
     dependencies:
@@ -3726,6 +4008,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  baseline-browser-mapping@2.10.40: {}
+
   bignumber.js@9.3.1: {}
 
   brace-expansion@1.1.14:
@@ -3740,6 +4024,14 @@ snapshots:
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
+
+  browserslist@4.28.4:
+    dependencies:
+      baseline-browser-mapping: 2.10.40
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.380
+      node-releases: 2.0.50
+      update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
   buffer@6.0.3:
     dependencies:
@@ -3770,6 +4062,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001792: {}
+
+  caniuse-lite@1.0.30001799: {}
 
   chai@6.2.2: {}
 
@@ -3920,6 +4214,8 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  electron-to-chromium@1.5.380: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -4065,6 +4361,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  escalade@3.2.0: {}
+
   escape-string-regexp@4.0.0: {}
 
   eslint-config-next@14.2.35(eslint@8.57.1)(typescript@5.9.3):
@@ -4075,8 +4373,8 @@ snapshots:
       '@typescript-eslint/parser': 8.59.3(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -4095,7 +4393,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4106,22 +4404,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.3(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4132,7 +4430,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -4364,6 +4662,8 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   generator-function@2.0.1: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4674,6 +4974,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsesc@3.1.0: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -4683,6 +4985,8 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
+
+  json5@2.2.3: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -4767,6 +5071,10 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lucide-react@0.563.0(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -4829,7 +5137,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@babel/core@7.29.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -4839,7 +5147,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(react@18.3.1)
+      styled-jsx: 5.1.1(@babel/core@7.29.7)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.33
       '@next/swc-darwin-x64': 14.2.33
@@ -4868,6 +5176,8 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-releases@2.0.50: {}
 
   object-assign@4.1.1: {}
 
@@ -5023,6 +5333,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       redux: 5.0.1
+
+  react-refresh@0.17.0: {}
 
   react@18.3.1:
     dependencies:
@@ -5341,10 +5653,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.1(react@18.3.1):
+  styled-jsx@5.1.1(@babel/core@7.29.7)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
+    optionalDependencies:
+      '@babel/core': 7.29.7
 
   supports-color@7.2.0:
     dependencies:
@@ -5478,6 +5792,12 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
+  update-browserslist-db@1.2.3(browserslist@4.28.4):
+    dependencies:
+      browserslist: 4.28.4
+      escalade: 3.2.0
+      picocolors: 1.1.1
 
   uri-js@4.4.1:
     dependencies:
@@ -5621,6 +5941,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.20.1: {}
+
+  yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import CreateCommitmentStepSelectType from "@/components/CreateCommitmentStepSelectType";
 import CreateCommitmentStepConfigure from "@/components/CreateCommitmentStepConfigure";
 import CreateCommitmentStepReview from "@/components/CreateCommitmentStepReview";
-import CommitmentCreatedModal from "@/components/modals/Commitmentcreatedmodal";
+import CommitmentCreatedModal from "@/components/modals/CommitmentCreatedModal";
 import { buildExplorerUrl, openExplorerUrl } from "@/utils/explorerLinks";
 
 type CommitmentType = "safe" | "balanced" | "aggressive";
@@ -33,6 +33,11 @@ export default function CreateCommitment() {
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [commitmentId, setCommitmentId] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // In production this would come from the connected wallet hook.
+  // Passed as undefined while wallet integration is pending; the fund
+  // API accepts an optional callerAddress and validates it on-chain.
+  const callerAddress: string | undefined = undefined;
 
   // Build review data from actual configured values
   const getReviewData = () => {
@@ -154,6 +159,14 @@ export default function CreateCommitment() {
     router.push("/commitments");
   };
 
+  // Fund-later: close the success modal and go to the detail page so the
+  // user can fund the escrow from there at any time.
+  const handleFundLater = () => {
+    setShowSuccessModal(false);
+    const numericId = commitmentId.split("-")[1] || "1";
+    router.push(`/commitments/${numericId}`);
+  };
+
   const handleViewOnExplorer = () => {
     openExplorerUrl("tx", commitmentId, "testnet");
   };
@@ -209,9 +222,11 @@ export default function CreateCommitment() {
           <CommitmentCreatedModal
             isOpen={showSuccessModal}
             commitmentId={commitmentId}
+            callerAddress={callerAddress}
             onViewCommitment={handleViewCommitment}
             onCreateAnother={handleCreateAnother}
             onClose={handleCloseModal}
+            onFundLater={handleFundLater}
             onViewOnExplorer={commitmentExplorerUrl ? handleViewOnExplorer : undefined}
           />
         </>

--- a/src/components/modals/CommitmentCreatedModal.test.tsx
+++ b/src/components/modals/CommitmentCreatedModal.test.tsx
@@ -1,0 +1,366 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import CommitmentCreatedModal from '@/components/modals/CommitmentCreatedModal';
+
+// ── Shared default props ─────────────────────────────────────────────────────
+
+const defaultProps = {
+  isOpen: true,
+  commitmentId: 'CMT-ABC1234',
+  onViewCommitment: vi.fn(),
+  onCreateAnother: vi.fn(),
+  onClose: vi.fn(),
+  onFundLater: vi.fn(),
+  onViewOnExplorer: vi.fn(),
+} as const;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderModal(props: Partial<typeof defaultProps> = {}) {
+  return render(<CommitmentCreatedModal {...defaultProps} {...props} />);
+}
+
+// ── Setup / teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.style.overflow = '';
+});
+
+// ── Suite ────────────────────────────────────────────────────────────────────
+
+describe('CommitmentCreatedModal', () => {
+  // ── 1. Initial render (idle state) ─────────────────────────────────────────
+
+  it('renders the fund prompt on open (idle state)', () => {
+    renderModal();
+
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Commitment Created' })).toBeTruthy();
+    expect(screen.getByText('CMT-ABC1234')).toBeTruthy();
+
+    // Fund-prompt elements
+    expect(screen.getByRole('button', { name: 'Fund escrow now' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /skip funding/i })).toBeTruthy();
+
+    // Success-only elements must NOT be visible yet
+    expect(screen.queryByText('Your commitment is now active and available in your dashboard.')).toBeNull();
+    expect(screen.queryByText('Escrow Funded')).toBeNull();
+  });
+
+  // ── 2. Commitment ID always shown ──────────────────────────────────────────
+
+  it('always shows the commitment ID', () => {
+    renderModal({ commitmentId: 'CMT-XYZ9999' });
+    expect(screen.getByText('CMT-XYZ9999')).toBeTruthy();
+  });
+
+  // ── 3. Loading state while funding ────────────────────────────────────────
+
+  it('shows spinner and disables buttons while funding is in-flight', async () => {
+    // Never resolves — keeps the component in funding state
+    vi.stubGlobal('fetch', () => new Promise(() => {}));
+
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Fund escrow now' }));
+
+    expect(await screen.findByRole('status', { name: /funding in progress/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Fund escrow now' })).toBeNull();
+
+    // Navigation buttons should be disabled
+    expect(screen.getByRole('button', { name: /create another/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeDisabled();
+  });
+
+  // ── 4. Successful fund ────────────────────────────────────────────────────
+
+  it('transitions to success state after a 200 response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: { txHash: '0xdeadbeef', fundedAt: '2026-01-01T00:00:00Z' } }),
+      })
+    );
+
+    renderModal({ callerAddress: 'GABC123' });
+    fireEvent.click(screen.getByRole('button', { name: 'Fund escrow now' }));
+
+    // Wait for success banner
+    expect(await screen.findByRole('status', { name: /escrow funded successfully/i })).toBeTruthy();
+    expect(screen.getByText(/0xdeadbeef/i)).toBeTruthy();
+
+    // Description switches to "active"
+    expect(
+      screen.getByText('Your commitment is now active and available in your dashboard.')
+    ).toBeTruthy();
+
+    // "Next Steps" list is shown
+    expect(screen.getByText('Your commitment is now active and earning yield')).toBeTruthy();
+
+    // Primary CTA is "View Commitment"
+    expect(screen.getByRole('button', { name: 'View commitment detail' })).toBeTruthy();
+
+    // Verify correct fetch call
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/commitments/CMT-ABC1234/fund',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ callerAddress: 'GABC123' }),
+      })
+    );
+  });
+
+  // ── 5. 409 treated as success ─────────────────────────────────────────────
+
+  it('treats a 409 Already-Funded response as success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        json: async () => ({ error: { message: 'Only created commitments can be funded' } }),
+      })
+    );
+
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Fund escrow now' }));
+
+    expect(await screen.findByRole('status', { name: /escrow funded successfully/i })).toBeTruthy();
+  });
+
+  // ── 6. Network / generic error ────────────────────────────────────────────
+
+  it('shows an error panel and retry button on network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network unreachable')));
+
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Fund escrow now' }));
+
+    expect(await screen.findByRole('alert', { name: /funding failed/i })).toBeTruthy();
+    expect(screen.getByText('Network unreachable')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Retry funding' })).toBeTruthy();
+  });
+
+  // ── 7. 403 error shows ownership message ─────────────────────────────────
+
+  it('shows an ownership error message for 403 responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({}),
+      })
+    );
+
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Fund escrow now' }));
+
+    expect(await screen.findByRole('alert', { name: /funding failed/i })).toBeTruthy();
+    expect(
+      screen.getByText('Only the commitment owner may fund this escrow.')
+    ).toBeTruthy();
+  });
+
+  // ── 8. Skip / Fund Later ──────────────────────────────────────────────────
+
+  it('transitions to skipped state and fires onFundLater when user skips', () => {
+    const onFundLater = vi.fn();
+    renderModal({ onFundLater });
+
+    fireEvent.click(screen.getByRole('button', { name: /skip funding/i }));
+
+    expect(onFundLater).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('status', { name: /funding skipped/i })).toBeTruthy();
+    expect(
+      screen.getByText(/fund the escrow anytime from the commitment detail page/i)
+    ).toBeTruthy();
+
+    // "View Commitment" CTA appears after skipping
+    expect(screen.getByRole('button', { name: 'View commitment detail' })).toBeTruthy();
+  });
+
+  // ── 9. Fund Later hidden when prop not provided ───────────────────────────
+
+  it('hides the "Fund Later" button when onFundLater is not provided', () => {
+    renderModal({ onFundLater: undefined });
+
+    expect(screen.queryByRole('button', { name: /skip funding/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /fund later/i })).toBeNull();
+  });
+
+  // ── 10. Retry flow: error → retry → funding ───────────────────────────────
+
+  it('allows the user to retry after an error', async () => {
+    let callCount = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return Promise.reject(new Error('Timeout'));
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ data: { txHash: '0xretried' } }),
+        });
+      })
+    );
+
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Fund escrow now' }));
+
+    // First call fails → error panel
+    await screen.findByRole('alert', { name: /funding failed/i });
+
+    // Click retry
+    fireEvent.click(screen.getByRole('button', { name: 'Retry funding' }));
+
+    // Retry should go back via idle then fund again → success
+    expect(await screen.findByRole('status', { name: /escrow funded successfully/i })).toBeTruthy();
+    expect(screen.getByText(/0xretried/i)).toBeTruthy();
+    expect(callCount).toBe(2);
+  });
+
+  // ── 11. View Commitment button fires onViewCommitment ─────────────────────
+
+  it('fires onViewCommitment when the View Commitment button is clicked after success', async () => {
+    const onViewCommitment = vi.fn();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: {} }),
+      })
+    );
+
+    renderModal({ onViewCommitment });
+    fireEvent.click(screen.getByRole('button', { name: 'Fund escrow now' }));
+    await screen.findByRole('status', { name: /escrow funded successfully/i });
+
+    fireEvent.click(screen.getByRole('button', { name: 'View commitment detail' }));
+    expect(onViewCommitment).toHaveBeenCalledTimes(1);
+  });
+
+  // ── 12. Create Another button fires onCreateAnother ──────────────────────
+
+  it('fires onCreateAnother', () => {
+    const onCreateAnother = vi.fn();
+    renderModal({ onCreateAnother });
+
+    fireEvent.click(screen.getByRole('button', { name: /create another/i }));
+    expect(onCreateAnother).toHaveBeenCalledTimes(1);
+  });
+
+  // ── 13. Escape closes modal ───────────────────────────────────────────────
+
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // ── 14. backdrop click closes modal ──────────────────────────────────────
+
+  it('calls onClose when the backdrop is clicked', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+
+    // The backdrop is the role="presentation" wrapper
+    fireEvent.click(screen.getByRole('presentation'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // ── 15. Accessibility: aria-live region present ───────────────────────────
+
+  it('contains an aria-live region for status announcements after fund click', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: {} }),
+    }));
+
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Fund escrow now' }));
+
+    // The success banner uses role="status" which implies aria-live
+    const liveRegion = await screen.findByRole('status', { name: /escrow funded successfully/i });
+    expect(liveRegion).toBeTruthy();
+  });
+
+  // ── 16. body scroll locked while open ────────────────────────────────────
+
+  it('locks body scroll while the modal is open', () => {
+    renderModal();
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  // ── 17. not rendered when isOpen is false ─────────────────────────────────
+
+  it('renders nothing when isOpen is false', () => {
+    renderModal({ isOpen: false });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  // ── 18. Explorer link shown only when prop provided ───────────────────────
+
+  it('shows the Stellar Explorer button only when onViewOnExplorer is provided', () => {
+    const { rerender } = renderModal({ onViewOnExplorer: vi.fn() });
+    expect(screen.getByRole('button', { name: 'View on Stellar Explorer' })).toBeTruthy();
+
+    rerender(
+      <CommitmentCreatedModal {...defaultProps} onViewOnExplorer={undefined} />
+    );
+    expect(screen.queryByRole('button', { name: 'View on Stellar Explorer' })).toBeNull();
+  });
+
+  // ── 19. Fund state resets for a new commitmentId ──────────────────────────
+
+  it('resets fund state when commitmentId changes', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: {} }),
+      })
+    );
+
+    const { rerender } = renderModal({ commitmentId: 'CMT-FIRST' });
+
+    // Fund the first commitment
+    fireEvent.click(screen.getByRole('button', { name: 'Fund escrow now' }));
+    await screen.findByRole('status', { name: /escrow funded successfully/i });
+
+    // Simulate a new commitment being created (modal re-opens with new id)
+    rerender(
+      <CommitmentCreatedModal
+        {...defaultProps}
+        isOpen={true}
+        commitmentId="CMT-SECOND"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole('status', { name: /escrow funded successfully/i })).toBeNull();
+      expect(screen.getByRole('button', { name: 'Fund escrow now' })).toBeTruthy();
+    });
+  });
+});

--- a/src/components/modals/CommitmentCreatedModal.tsx
+++ b/src/components/modals/CommitmentCreatedModal.tsx
@@ -1,41 +1,92 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { ArrowRight, CheckCircle, ExternalLink, Eye, X } from 'lucide-react';
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle,
+  ExternalLink,
+  Eye,
+  Loader2,
+  X,
+  Zap,
+} from 'lucide-react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type FundStep = 'idle' | 'funding' | 'success' | 'error' | 'skipped';
+
+interface FundResult {
+  txHash?: string;
+  reference?: string;
+  fundedAt?: string;
+}
 
 export interface CommitmentCreatedModalProps {
   isOpen: boolean;
   commitmentId: string;
+  /** Optional connected-wallet address forwarded to the fund API. */
+  callerAddress?: string;
   onViewCommitment: () => void;
   onCreateAnother: () => void;
   onClose: () => void;
+  /** Called when the user chooses "Fund Later". If omitted, the button is hidden. */
+  onFundLater?: () => void;
   onViewOnExplorer?: () => void;
 }
 
-const nextSteps = [
+// ─── Static content ───────────────────────────────────────────────────────────
+
+const nextStepsAfterFund = [
   'Your commitment is now active and earning yield',
   'Monitor compliance and performance in your dashboard',
   'You can trade this commitment NFT in the marketplace',
 ];
 
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return 'An unexpected error occurred. Please try again.';
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
 export default function CommitmentCreatedModal({
   isOpen,
   commitmentId,
+  callerAddress,
   onViewCommitment,
   onCreateAnother,
   onClose,
+  onFundLater,
   onViewOnExplorer,
 }: CommitmentCreatedModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const primaryButtonRef = useRef<HTMLButtonElement>(null);
   const [mounted, setMounted] = useState(false);
 
+  // Fund state machine
+  const [fundStep, setFundStep] = useState<FundStep>('idle');
+  const [fundResult, setFundResult] = useState<FundResult | null>(null);
+  const [fundError, setFundError] = useState<string | null>(null);
+
+  // Reset fund state whenever the modal is opened fresh (new commitmentId)
+  useEffect(() => {
+    if (isOpen) {
+      setFundStep('idle');
+      setFundResult(null);
+      setFundError(null);
+    }
+  }, [isOpen, commitmentId]);
+
   useEffect(() => {
     setMounted(true);
     return () => setMounted(false);
   }, []);
 
+  // Focus trap + keyboard handling
   useEffect(() => {
     if (!isOpen) return;
 
@@ -79,6 +130,61 @@ export default function CommitmentCreatedModal({
     };
   }, [isOpen, onClose]);
 
+  // ── Fund handler ─────────────────────────────────────────────────────────────
+
+  const handleFund = useCallback(async () => {
+    setFundStep('funding');
+    setFundError(null);
+
+    try {
+      const res = await fetch(`/api/commitments/${encodeURIComponent(commitmentId)}/fund`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ callerAddress }),
+      });
+
+      // 409 means it was already funded — treat as success
+      if (res.status === 409 || res.ok) {
+        const json = res.ok ? await res.json().catch(() => ({})) : {};
+        const data: FundResult = json?.data ?? json ?? {};
+        setFundResult(data);
+        setFundStep('success');
+        return;
+      }
+
+      // Surface a readable error from the response body
+      let message = `Request failed with status ${res.status}.`;
+      try {
+        const errJson = await res.json();
+        if (errJson?.error?.message) message = errJson.error.message;
+        else if (errJson?.message) message = errJson.message;
+      } catch {
+        // ignore parse failures
+      }
+
+      if (res.status === 403) message = 'Only the commitment owner may fund this escrow.';
+      if (res.status === 429) message = 'Too many requests. Please wait a moment then try again.';
+
+      setFundError(message);
+      setFundStep('error');
+    } catch (err) {
+      setFundError(errorMessage(err));
+      setFundStep('error');
+    }
+  }, [commitmentId, callerAddress]);
+
+  const handleSkip = useCallback(() => {
+    setFundStep('skipped');
+    onFundLater?.();
+  }, [onFundLater]);
+
+  const handleRetry = useCallback(() => {
+    setFundStep('idle');
+    setFundError(null);
+  }, []);
+
+  // ── Render guard ──────────────────────────────────────────────────────────────
+
   if (!isOpen || !mounted) return null;
 
   const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -86,6 +192,151 @@ export default function CommitmentCreatedModal({
       onClose();
     }
   };
+
+  // ── Sub-views ─────────────────────────────────────────────────────────────────
+
+  const renderFundPrompt = () => (
+    <div
+      className="rounded-[20px] border border-[#0FF0FC]/20 bg-[#0FF0FC]/5 p-5"
+      role="region"
+      aria-label="Fund your commitment"
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <Zap className="h-4 w-4 text-[#0FF0FC]" />
+        <span className="text-[13px] font-bold uppercase tracking-widest text-[#0FF0FC]">
+          Fund Escrow to Activate
+        </span>
+      </div>
+      <p className="mb-4 text-[13px] leading-relaxed text-white/60">
+        Your commitment has been created but is not yet active. Fund the escrow
+        now to start earning yield. You can also fund later from the detail page.
+      </p>
+      <div className="flex gap-3">
+        <button
+          ref={primaryButtonRef}
+          type="button"
+          onClick={handleFund}
+          className="flex flex-1 items-center justify-center gap-2 rounded-2xl bg-[#0FF0FC] py-3 text-[14px] font-bold text-black transition-all shadow-[0_0_20px_rgba(15,240,252,0.3)] hover:scale-[1.01] hover:bg-[#0FF0FC]/90 active:scale-[0.98]"
+          aria-label="Fund escrow now"
+        >
+          <Zap className="h-4 w-4" />
+          Fund Now
+        </button>
+        {onFundLater && (
+          <button
+            type="button"
+            onClick={handleSkip}
+            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-[14px] font-bold text-white/70 transition-all hover:bg-white/10 active:scale-[0.98]"
+            aria-label="Skip funding and fund later"
+          >
+            Fund Later
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  const renderFunding = () => (
+    <div
+      className="rounded-[20px] border border-white/10 bg-white/5 p-6 text-center"
+      role="status"
+      aria-live="polite"
+      aria-label="Funding in progress"
+    >
+      <Loader2
+        className="mx-auto mb-3 h-8 w-8 animate-spin text-[#0FF0FC]"
+        aria-hidden="true"
+      />
+      <p className="text-[14px] font-medium text-white/70">
+        Funding escrow on-chain…
+      </p>
+      <p className="mt-1 text-[12px] text-white/30">This may take a few seconds</p>
+    </div>
+  );
+
+  const renderFundSuccess = () => (
+    <div
+      className="rounded-[20px] border border-emerald-500/30 bg-emerald-500/10 p-5"
+      role="status"
+      aria-live="polite"
+      aria-label="Escrow funded successfully"
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <CheckCircle className="h-4 w-4 text-emerald-400" />
+        <span className="text-[13px] font-bold uppercase tracking-widest text-emerald-400">
+          Escrow Funded
+        </span>
+      </div>
+      <p className="text-[13px] text-white/60">
+        Your commitment is now active and earning yield.
+      </p>
+      {fundResult?.txHash && (
+        <p className="mt-2 break-all font-mono text-[11px] text-white/30">
+          Tx: {fundResult.txHash}
+        </p>
+      )}
+    </div>
+  );
+
+  const renderFundError = () => (
+    <div
+      className="rounded-[20px] border border-rose-500/30 bg-rose-500/10 p-5"
+      role="alert"
+      aria-live="assertive"
+      aria-label="Funding failed"
+    >
+      <div className="mb-2 flex items-center gap-2">
+        <AlertTriangle className="h-4 w-4 text-rose-400" />
+        <span className="text-[13px] font-bold uppercase tracking-widest text-rose-400">
+          Funding Failed
+        </span>
+      </div>
+      <p className="mb-4 text-[13px] leading-relaxed text-white/60">{fundError}</p>
+      <div className="flex gap-3">
+        <button
+          ref={primaryButtonRef}
+          type="button"
+          onClick={handleRetry}
+          className="flex flex-1 items-center justify-center gap-2 rounded-2xl bg-rose-500/20 py-2.5 text-[13px] font-bold text-rose-300 transition-all hover:bg-rose-500/30 active:scale-[0.98]"
+          aria-label="Retry funding"
+        >
+          Retry
+        </button>
+        {onFundLater && (
+          <button
+            type="button"
+            onClick={handleSkip}
+            className="flex-1 rounded-2xl border border-white/10 bg-white/5 py-2.5 text-[13px] font-bold text-white/70 transition-all hover:bg-white/10 active:scale-[0.98]"
+            aria-label="Skip and fund later from the detail page"
+          >
+            Fund Later
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  const renderSkipped = () => (
+    <div
+      className="rounded-[20px] border border-amber-500/20 bg-amber-500/5 p-4"
+      role="status"
+      aria-live="polite"
+      aria-label="Funding skipped"
+    >
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+        <p className="text-[13px] leading-relaxed text-white/60">
+          Commitment is not yet active. You can fund the escrow anytime from the
+          commitment detail page.
+        </p>
+      </div>
+    </div>
+  );
+
+  const isFundSuccess = fundStep === 'success';
+  const showNextSteps = isFundSuccess;
+
+  // ── Full render ───────────────────────────────────────────────────────────────
 
   return createPortal(
     <div
@@ -101,6 +352,7 @@ export default function CommitmentCreatedModal({
         aria-labelledby="commitment-created-title"
         aria-describedby="commitment-created-description"
       >
+        {/* Close button */}
         <div className="absolute right-6 top-6 z-10">
           <button
             type="button"
@@ -113,11 +365,15 @@ export default function CommitmentCreatedModal({
         </div>
 
         <div className="flex-1 px-6 pb-10 pt-12 sm:px-10">
+          {/* Header */}
           <div className="mb-8 flex flex-col items-center">
             <div className="relative mb-6 h-20 w-20 sm:h-24 sm:w-24">
               <div className="absolute inset-0 rounded-full bg-[#0FF0FC] opacity-20 blur-2xl animate-pulse" />
               <div className="relative z-10 flex h-full w-full items-center justify-center rounded-full border-2 border-[#0FF0FC] bg-[#0FF0FC]/10 shadow-[inset_0_0_20px_rgba(15,240,252,0.2)]">
-                <CheckCircle className="h-10 w-10 text-[#0FF0FC] sm:h-12 sm:w-12" strokeWidth={2.5} />
+                <CheckCircle
+                  className="h-10 w-10 text-[#0FF0FC] sm:h-12 sm:w-12"
+                  strokeWidth={2.5}
+                />
               </div>
             </div>
 
@@ -132,12 +388,15 @@ export default function CommitmentCreatedModal({
                 id="commitment-created-description"
                 className="mx-auto max-w-[340px] text-[15px] font-medium leading-relaxed text-white/50 sm:text-[16px]"
               >
-                Your liquidity commitment is active and available in your dashboard.
+                {isFundSuccess
+                  ? 'Your commitment is now active and available in your dashboard.'
+                  : 'Complete the funding step to activate your commitment.'}
               </p>
             </div>
           </div>
 
-          <div className="group relative mb-8 overflow-hidden rounded-[24px] border border-white/[0.08] bg-white/[0.03] p-6 text-center transition-colors hover:bg-white/[0.05]">
+          {/* Commitment ID */}
+          <div className="group relative mb-6 overflow-hidden rounded-[24px] border border-white/[0.08] bg-white/[0.03] p-6 text-center transition-colors hover:bg-white/[0.05]">
             <div className="absolute -mr-12 -mt-12 right-0 top-0 h-24 w-24 rounded-full bg-[#0FF0FC] opacity-[0.02] blur-2xl transition-opacity group-hover:opacity-[0.04]" />
             <div className="mb-3 ml-1 text-[13px] font-bold uppercase tracking-[0.2em] text-white/40">
               Commitment ID
@@ -147,40 +406,59 @@ export default function CommitmentCreatedModal({
             </div>
           </div>
 
-          <div className="mb-10 lg:px-2">
-            <h3 className="mb-5 ml-1 text-[14px] font-bold uppercase tracking-widest text-white/90">
-              Next Steps
-            </h3>
-            <div className="space-y-4">
-              {nextSteps.map((step) => (
-                <div key={step} className="flex items-start gap-4 p-1">
-                  <div className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-[#0FF0FC]/30 bg-[#0FF0FC]/10">
-                    <CheckCircle className="h-3 w-3 text-[#0FF0FC]" strokeWidth={3} />
-                  </div>
-                  <span className="text-[14px] font-medium leading-relaxed text-white/70 sm:text-[15px]">
-                    {step}
-                  </span>
-                </div>
-              ))}
-            </div>
+          {/* Fund step region */}
+          <div className="mb-8">
+            {fundStep === 'idle' && renderFundPrompt()}
+            {fundStep === 'funding' && renderFunding()}
+            {fundStep === 'success' && renderFundSuccess()}
+            {fundStep === 'error' && renderFundError()}
+            {fundStep === 'skipped' && renderSkipped()}
           </div>
 
+          {/* Next steps — only after successful funding */}
+          {showNextSteps && (
+            <div className="mb-8 lg:px-2">
+              <h3 className="mb-5 ml-1 text-[14px] font-bold uppercase tracking-widest text-white/90">
+                Next Steps
+              </h3>
+              <div className="space-y-4">
+                {nextStepsAfterFund.map((s) => (
+                  <div key={s} className="flex items-start gap-4 p-1">
+                    <div className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-[#0FF0FC]/30 bg-[#0FF0FC]/10">
+                      <CheckCircle className="h-3 w-3 text-[#0FF0FC]" strokeWidth={3} />
+                    </div>
+                    <span className="text-[14px] font-medium leading-relaxed text-white/70 sm:text-[15px]">
+                      {s}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Action buttons */}
           <div className="space-y-3">
-            <button
-              ref={primaryButtonRef}
-              type="button"
-              onClick={onViewCommitment}
-              className="flex w-full items-center justify-center gap-3 rounded-2xl bg-[#0FF0FC] py-4 text-[16px] font-bold text-black transition-all shadow-[0_0_30px_rgba(15,240,252,0.3)] hover:scale-[1.01] hover:bg-[#0FF0FC]/90 active:scale-[0.98]"
-            >
-              <Eye className="h-5 w-5" />
-              View Commitment
-            </button>
+            {/* "View Commitment" is primary after success or skipped; hidden while funding */}
+            {(isFundSuccess || fundStep === 'skipped') && (
+              <button
+                ref={fundStep !== 'error' && fundStep !== 'idle' ? primaryButtonRef : undefined}
+                type="button"
+                onClick={onViewCommitment}
+                className="flex w-full items-center justify-center gap-3 rounded-2xl bg-[#0FF0FC] py-4 text-[16px] font-bold text-black transition-all shadow-[0_0_30px_rgba(15,240,252,0.3)] hover:scale-[1.01] hover:bg-[#0FF0FC]/90 active:scale-[0.98]"
+                aria-label="View commitment detail"
+              >
+                <Eye className="h-5 w-5" />
+                View Commitment
+              </button>
+            )}
 
             <div className="grid grid-cols-2 gap-3">
               <button
                 type="button"
                 onClick={onCreateAnother}
-                className="flex items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 py-3.5 text-[14px] font-bold text-white transition-all hover:bg-white/10 active:scale-[0.98]"
+                disabled={fundStep === 'funding'}
+                className="flex items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 py-3.5 text-[14px] font-bold text-white transition-all hover:bg-white/10 active:scale-[0.98] disabled:pointer-events-none disabled:opacity-40"
+                aria-label="Create another commitment"
               >
                 <span className="opacity-70">Create Another</span>
                 <ArrowRight className="h-4 w-4" />
@@ -188,7 +466,9 @@ export default function CommitmentCreatedModal({
               <button
                 type="button"
                 onClick={onClose}
-                className="rounded-2xl border border-white/10 bg-white/5 py-3.5 text-[14px] font-bold text-white transition-all hover:bg-white/10 active:scale-[0.98]"
+                disabled={fundStep === 'funding'}
+                className="rounded-2xl border border-white/10 bg-white/5 py-3.5 text-[14px] font-bold text-white transition-all hover:bg-white/10 active:scale-[0.98] disabled:pointer-events-none disabled:opacity-40"
+                aria-label="Close"
               >
                 Close
               </button>
@@ -201,6 +481,7 @@ export default function CommitmentCreatedModal({
                 type="button"
                 onClick={onViewOnExplorer}
                 className="flex w-full items-center justify-center gap-2 py-1 text-[13px] text-white/30 transition-colors hover:text-[#0FF0FC]"
+                aria-label="View on Stellar Explorer"
               >
                 View on Stellar Explorer
                 <ExternalLink className="h-3.5 w-3.5" />


### PR DESCRIPTION
Close: #634
Summary 
1. Create Page ( src/app/create/page.tsx ) : Has the handleFundLater function and passes all necessary props to CommitmentCreatedModal
2. CommitmentCreatedModal ( src/components/modals/CommitmentCreatedModal.tsx ) :
   - Has a fundStep state machine: idle → funding → success/error, with skipped option
   - Implements handleFund that calls POST /api/commitments/:id/fund
   - Handles all errors (403, 409, 429, network errors)
   - Accessible with focus trap, aria-live, etc.
3. Test File ( src/components/modals/CommitmentCreatedModal.test.tsx ) : Covers all the required scenarios:
   - Initial state
   - Successful funding
   - 409 treated as success
   - Network errors
   - Skipping funding
   - Retry flow
   - Accessibility
4. Documentation ( docs/CREATE_THEN_FUND.md ) : Full documentation of the flow
So the two-step create-then-fund flow is already complete! The user can now create a commitment, then either fund it immediately or skip and fund later from the detail page!