### PR TITLE
feat: dispute status tracker on commitment detail page

### DIFF
--- a/docs/DISPUTE_TRACKER.md
+++ b/docs/DISPUTE_TRACKER.md
@@ -1,0 +1,62 @@
+# Dispute Status Tracker
+
+A read-only stepper rendered on the commitment detail page that makes the dispute lifecycle visible to the affected user.
+
+## Where it lives
+
+| File | Purpose |
+|------|---------|
+| `src/components/dispute/DisputeStatusTracker.tsx` | Component + exported types |
+| `src/components/dispute/DisputeStatusTracker.test.tsx` | RTL unit tests |
+| `src/app/commitments/[id]/page.tsx` | Mount point |
+
+## Data sources
+
+In production the component is fed from two existing routes:
+
+- `GET /api/commitments/[id]` — commitment `status` field (`DISPUTED` triggers the tracker)
+- `GET /api/commitments/[id]/history` — lifecycle events supply timestamps and reason context
+
+The detail page currently uses mock data (`MOCK_DISPUTES`). Replace those entries with real API responses when the backend dispute indexer is wired up.
+
+## Props
+
+```ts
+interface DisputeStatusTrackerProps {
+  dispute: DisputeInfo | null; // null → component renders nothing
+}
+
+interface DisputeInfo {
+  stage: 'filed' | 'under_review' | 'resolved';
+  filedAt?: string;          // ISO-8601
+  reasonCategory?: string;   // free-text label shown under Filed step
+  reviewStartedAt?: string;  // ISO-8601
+  resolvedAt?: string;       // ISO-8601
+  resolution?:
+    | 'resolved_in_favor_of_owner'
+    | 'resolved_in_favor_of_counterparty'
+    | 'dismissed';
+}
+```
+
+## Stepper stages
+
+| Stage | Step highlighted | Notes |
+|-------|-----------------|-------|
+| `filed` | Filed | Dispute submitted, awaiting triage |
+| `under_review` | Under Review | Under active investigation |
+| `resolved` | Resolved | Shows outcome label |
+
+## Accessibility
+
+- The outer `<section>` is labelled via `aria-labelledby` pointing at the heading.
+- The step list is an `<ol>` with `aria-label="Dispute lifecycle steps"`.
+- Each `<li>` receives `aria-current="step"` only on the active step.
+- Decorative SVG indicators carry `aria-hidden="true"`.
+
+## Rendering rules
+
+- The component returns `null` when `dispute` is `null` — safe to place unconditionally.
+- All date fields are optional; the step simply omits the timestamp when absent.
+- `reasonCategory` is shown beneath the Filed step label.
+- The resolution outcome label is shown beneath the Resolved step label only when `resolution` is provided.

--- a/src/app/commitments/[id]/page.tsx
+++ b/src/app/commitments/[id]/page.tsx
@@ -12,6 +12,7 @@ import RecentAttestationsPanel from '@/components/RecentAttestationsPanel/Recent
 import ExportCommitmentsModal from '@/components/export/ExportCommitmentsModal';
 import CommitmentEarlyExitModal from '@/components/CommitmentEarlyExitModal/CommitmentEarlyExitModal';
 import CommitmentDisputeModal from '@/components/modals/CommitmentDisputeModal';
+import DisputeStatusTracker, { type DisputeInfo } from '@/components/dispute/DisputeStatusTracker';
 import { openExplorerUrl } from '@/utils/explorerLinks';
 
 // Mock Commitments
@@ -21,6 +22,17 @@ const MOCK_COMMITMENTS: Record<
 > = {
   '1': { id: '1', type: 'Balanced', duration: 60, maxLoss: 8, earlyExitPenaltyPercent: 3, canEarlyExit: true },
   '2': { id: '2', type: 'Safe', duration: 30, maxLoss: 2, earlyExitPenaltyPercent: 3, canEarlyExit: false },
+};
+
+// Mock dispute state — populated from /api/commitments/[id] status + history in production
+const MOCK_DISPUTES: Record<string, DisputeInfo | null> = {
+  '1': {
+    stage: 'under_review',
+    filedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+    reasonCategory: 'Compliance violation',
+    reviewStartedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  '2': null,
 };
 
 // Mock data for health metrics
@@ -129,6 +141,8 @@ export default function CommitmentDetailPage({
     const commitment = getCommitmentById(params.id)
     if (!commitment) notFound()
 
+    const dispute = MOCK_DISPUTES[params.id] ?? null;
+
     const durationLabel = `${commitment.duration} days`
     const maxLossLabel = `${commitment.maxLoss}%`
     const commitmentTypeLabel = commitment.type
@@ -209,6 +223,8 @@ export default function CommitmentDetailPage({
                         earlyExitPenaltyLabel={earlyExitPenaltyLabel}
                     />
                 </div>
+
+                <DisputeStatusTracker dispute={dispute} />
 
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-start">
                     <div className="lg:col-span-2 space-y-8">

--- a/src/components/dispute/DisputeStatusTracker.test.tsx
+++ b/src/components/dispute/DisputeStatusTracker.test.tsx
@@ -1,0 +1,230 @@
+// @vitest-environment happy-dom
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DisputeStatusTracker, {
+  type DisputeInfo,
+  type DisputeStage,
+  type DisputeResolution,
+} from './DisputeStatusTracker';
+
+const BASE_DISPUTE: DisputeInfo = {
+  stage: 'filed',
+  filedAt: '2026-01-10T12:00:00.000Z',
+  reasonCategory: 'Compliance issue',
+};
+
+function renderTracker(dispute: DisputeInfo | null) {
+  return render(<DisputeStatusTracker dispute={dispute} />);
+}
+
+describe('DisputeStatusTracker', () => {
+  describe('hidden when no dispute', () => {
+    it('renders nothing when dispute is null', () => {
+      const { container } = renderTracker(null);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('section and heading', () => {
+    it('renders the "Dispute Status" heading', () => {
+      renderTracker(BASE_DISPUTE);
+      expect(screen.getByRole('heading', { name: /dispute status/i })).toBeInTheDocument();
+    });
+
+    it('renders as a section with an accessible label', () => {
+      renderTracker(BASE_DISPUTE);
+      expect(
+        screen.getByRole('region', { name: /dispute status/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('stepper step labels', () => {
+    it('renders all three step labels', () => {
+      renderTracker(BASE_DISPUTE);
+      const list = screen.getByRole('list', { name: /dispute lifecycle steps/i });
+      expect(within(list).getByText('Filed')).toBeInTheDocument();
+      expect(within(list).getByText('Under Review')).toBeInTheDocument();
+      expect(within(list).getByText('Resolved')).toBeInTheDocument();
+    });
+  });
+
+  describe('aria-current reflects the active step', () => {
+    const cases: Array<{ stage: DisputeStage; currentLabel: string; pendingLabels: string[] }> = [
+      {
+        stage: 'filed',
+        currentLabel: 'Filed',
+        pendingLabels: ['Under Review', 'Resolved'],
+      },
+      {
+        stage: 'under_review',
+        currentLabel: 'Under Review',
+        pendingLabels: ['Resolved'],
+      },
+      {
+        stage: 'resolved',
+        currentLabel: 'Resolved',
+        pendingLabels: [],
+      },
+    ];
+
+    cases.forEach(({ stage, currentLabel, pendingLabels }) => {
+      it(`marks "${currentLabel}" as aria-current="step" when stage is "${stage}"`, () => {
+        renderTracker({ ...BASE_DISPUTE, stage });
+        const list = screen.getByRole('list', { name: /dispute lifecycle steps/i });
+        const items = within(list).getAllByRole('listitem');
+
+        const currentItem = items.find((li) =>
+          li.textContent?.includes(currentLabel),
+        );
+        expect(currentItem).toHaveAttribute('aria-current', 'step');
+      });
+
+      it(`only one listitem has aria-current="step" when stage is "${stage}"`, () => {
+        renderTracker({ ...BASE_DISPUTE, stage });
+        const list = screen.getByRole('list', { name: /dispute lifecycle steps/i });
+        const items = within(list).getAllByRole('listitem');
+        const currentItems = items.filter(
+          (li) => li.getAttribute('aria-current') === 'step',
+        );
+        expect(currentItems).toHaveLength(1);
+      });
+
+      if (pendingLabels.length > 0) {
+        it(`pending steps after "${currentLabel}" have no aria-current when stage is "${stage}"`, () => {
+          renderTracker({ ...BASE_DISPUTE, stage });
+          const list = screen.getByRole('list', { name: /dispute lifecycle steps/i });
+          const items = within(list).getAllByRole('listitem');
+          pendingLabels.forEach((label) => {
+            const item = items.find((li) => li.textContent?.includes(label));
+            expect(item).not.toHaveAttribute('aria-current');
+          });
+        });
+      }
+    });
+
+    it('completed steps (before current) have no aria-current', () => {
+      renderTracker({ ...BASE_DISPUTE, stage: 'resolved' });
+      const list = screen.getByRole('list', { name: /dispute lifecycle steps/i });
+      const items = within(list).getAllByRole('listitem');
+
+      const filedItem = items.find((li) => li.textContent?.includes('Filed'));
+      const reviewItem = items.find((li) => li.textContent?.includes('Under Review'));
+      expect(filedItem).not.toHaveAttribute('aria-current');
+      expect(reviewItem).not.toHaveAttribute('aria-current');
+    });
+  });
+
+  describe('timestamps displayed per step', () => {
+    it('shows filedAt timestamp on the Filed step', () => {
+      renderTracker(BASE_DISPUTE);
+      // Jan 10, 2026 formatted
+      expect(screen.getByText(/jan 10, 2026/i)).toBeInTheDocument();
+    });
+
+    it('shows reviewStartedAt on the Under Review step', () => {
+      renderTracker({
+        ...BASE_DISPUTE,
+        stage: 'under_review',
+        reviewStartedAt: '2026-01-11T08:00:00.000Z',
+      });
+      expect(screen.getByText(/jan 11, 2026/i)).toBeInTheDocument();
+    });
+
+    it('shows resolvedAt on the Resolved step', () => {
+      renderTracker({
+        ...BASE_DISPUTE,
+        stage: 'resolved',
+        reviewStartedAt: '2026-01-11T08:00:00.000Z',
+        resolvedAt: '2026-01-13T15:00:00.000Z',
+        resolution: 'dismissed',
+      });
+      expect(screen.getByText(/jan 13, 2026/i)).toBeInTheDocument();
+    });
+
+    it('omits timestamp elements when dates are absent', () => {
+      renderTracker({ stage: 'filed' });
+      // No ISO dates provided, so no formatted dates should appear
+      expect(screen.queryByText(/jan/i)).toBeNull();
+    });
+  });
+
+  describe('reasonCategory shown on Filed step', () => {
+    it('renders the reasonCategory text when provided', () => {
+      renderTracker({ ...BASE_DISPUTE, reasonCategory: 'Protocol violation' });
+      expect(screen.getByText('Protocol violation')).toBeInTheDocument();
+    });
+
+    it('does not render a reason element when reasonCategory is absent', () => {
+      renderTracker({ stage: 'filed', filedAt: '2026-01-10T12:00:00.000Z' });
+      expect(screen.queryByText(/violation/i)).toBeNull();
+    });
+  });
+
+  describe('resolution outcome on Resolved step', () => {
+    const resolutionCases: Array<{ resolution: DisputeResolution; expectedText: string }> = [
+      {
+        resolution: 'resolved_in_favor_of_owner',
+        expectedText: 'Resolved in your favor',
+      },
+      {
+        resolution: 'resolved_in_favor_of_counterparty',
+        expectedText: 'Resolved against you',
+      },
+      {
+        resolution: 'dismissed',
+        expectedText: 'Dismissed',
+      },
+    ];
+
+    resolutionCases.forEach(({ resolution, expectedText }) => {
+      it(`shows "${expectedText}" for resolution "${resolution}"`, () => {
+        renderTracker({
+          stage: 'resolved',
+          filedAt: '2026-01-10T12:00:00.000Z',
+          reviewStartedAt: '2026-01-11T08:00:00.000Z',
+          resolvedAt: '2026-01-13T15:00:00.000Z',
+          resolution,
+        });
+        expect(screen.getByText(expectedText)).toBeInTheDocument();
+      });
+    });
+
+    it('shows no resolution detail when stage is "filed"', () => {
+      renderTracker(BASE_DISPUTE);
+      expect(screen.queryByText(/resolved in your favor/i)).toBeNull();
+      expect(screen.queryByText(/resolved against you/i)).toBeNull();
+      expect(screen.queryByText(/dismissed/i)).toBeNull();
+    });
+
+    it('shows no resolution detail when stage is "under_review"', () => {
+      renderTracker({
+        ...BASE_DISPUTE,
+        stage: 'under_review',
+        reviewStartedAt: '2026-01-11T08:00:00.000Z',
+      });
+      expect(screen.queryByText(/resolved in your favor/i)).toBeNull();
+    });
+
+    it('shows no resolution outcome when resolution is undefined on resolved step', () => {
+      renderTracker({
+        stage: 'resolved',
+        filedAt: '2026-01-10T12:00:00.000Z',
+        resolvedAt: '2026-01-13T15:00:00.000Z',
+      });
+      expect(screen.queryByText(/resolved in your favor/i)).toBeNull();
+      expect(screen.queryByText(/resolved against you/i)).toBeNull();
+      expect(screen.queryByText(/dismissed/i)).toBeNull();
+    });
+  });
+
+  describe('step counts', () => {
+    it('renders exactly 3 list items', () => {
+      renderTracker(BASE_DISPUTE);
+      const list = screen.getByRole('list', { name: /dispute lifecycle steps/i });
+      expect(within(list).getAllByRole('listitem')).toHaveLength(3);
+    });
+  });
+});

--- a/src/components/dispute/DisputeStatusTracker.tsx
+++ b/src/components/dispute/DisputeStatusTracker.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import React from 'react';
+
+export type DisputeStage = 'filed' | 'under_review' | 'resolved';
+export type DisputeResolution =
+  | 'resolved_in_favor_of_owner'
+  | 'resolved_in_favor_of_counterparty'
+  | 'dismissed';
+
+export interface DisputeInfo {
+  stage: DisputeStage;
+  filedAt?: string;
+  reasonCategory?: string;
+  reviewStartedAt?: string;
+  resolvedAt?: string;
+  resolution?: DisputeResolution;
+}
+
+interface DisputeStatusTrackerProps {
+  dispute: DisputeInfo | null;
+}
+
+const STAGE_INDEX: Record<DisputeStage, number> = {
+  filed: 0,
+  under_review: 1,
+  resolved: 2,
+};
+
+const RESOLUTION_LABELS: Record<DisputeResolution, string> = {
+  resolved_in_favor_of_owner: 'Resolved in your favor',
+  resolved_in_favor_of_counterparty: 'Resolved against you',
+  dismissed: 'Dismissed',
+};
+
+function formatTimestamp(iso: string | undefined): string {
+  if (!iso) return '';
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+type StepState = 'completed' | 'current' | 'pending';
+
+function getStepState(stepIndex: number, currentIndex: number): StepState {
+  if (stepIndex < currentIndex) return 'completed';
+  if (stepIndex === currentIndex) return 'current';
+  return 'pending';
+}
+
+interface StepIndicatorProps {
+  state: StepState;
+}
+
+function StepIndicator({ state }: StepIndicatorProps) {
+  if (state === 'completed') {
+    return (
+      <span
+        className="flex h-8 w-8 items-center justify-center rounded-full bg-[#0ff0fc]/20 border border-[#0ff0fc]"
+        aria-hidden="true"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <path
+            d="M2 7l4 4 6-7"
+            stroke="#0ff0fc"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
+    );
+  }
+
+  if (state === 'current') {
+    return (
+      <span
+        className="flex h-8 w-8 items-center justify-center rounded-full bg-[#FF8A04]/20 border-2 border-[#FF8A04]"
+        aria-hidden="true"
+      >
+        <span className="h-3 w-3 rounded-full bg-[#FF8A04]" />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="flex h-8 w-8 items-center justify-center rounded-full border border-[#333] bg-[#111]"
+      aria-hidden="true"
+    >
+      <span className="h-2 w-2 rounded-full bg-[#444]" />
+    </span>
+  );
+}
+
+export default function DisputeStatusTracker({ dispute }: DisputeStatusTrackerProps) {
+  if (!dispute) return null;
+
+  const currentIndex = STAGE_INDEX[dispute.stage];
+
+  const steps = [
+    {
+      key: 'filed' as const,
+      label: 'Filed',
+      timestamp: formatTimestamp(dispute.filedAt),
+      detail: dispute.reasonCategory,
+    },
+    {
+      key: 'under_review' as const,
+      label: 'Under Review',
+      timestamp: formatTimestamp(dispute.reviewStartedAt),
+      detail: undefined,
+    },
+    {
+      key: 'resolved' as const,
+      label: 'Resolved',
+      timestamp: formatTimestamp(dispute.resolvedAt),
+      detail: dispute.resolution ? RESOLUTION_LABELS[dispute.resolution] : undefined,
+    },
+  ];
+
+  return (
+    <section
+      aria-labelledby="dispute-tracker-heading"
+      className="bg-[#0a0a0a] rounded-2xl p-6 border border-[#FF8A04]/20"
+    >
+      <h2
+        id="dispute-tracker-heading"
+        className="text-sm font-semibold uppercase tracking-[0.18em] text-[#FF8A04] mb-6"
+      >
+        Dispute Status
+      </h2>
+
+      <ol className="flex items-start" aria-label="Dispute lifecycle steps">
+        {steps.map((step, index) => {
+          const state = getStepState(index, currentIndex);
+          const isCurrent = state === 'current';
+          const isLast = index === steps.length - 1;
+
+          return (
+            <React.Fragment key={step.key}>
+              <li
+                className="flex flex-col items-center"
+                aria-current={isCurrent ? 'step' : undefined}
+              >
+                <StepIndicator state={state} />
+                <div className="mt-2 flex flex-col items-center text-center w-24">
+                  <span
+                    className={`text-xs font-semibold ${
+                      state === 'pending'
+                        ? 'text-[#555]'
+                        : state === 'current'
+                          ? 'text-[#FF8A04]'
+                          : 'text-[#0ff0fc]'
+                    }`}
+                  >
+                    {step.label}
+                  </span>
+                  {step.timestamp && (
+                    <span className="mt-1 text-[10px] leading-tight text-[#666]">
+                      {step.timestamp}
+                    </span>
+                  )}
+                  {step.detail && (
+                    <span className="mt-1 text-[10px] leading-tight text-[#888] italic">
+                      {step.detail}
+                    </span>
+                  )}
+                </div>
+              </li>
+              {!isLast && (
+                <div
+                  className={`mt-4 flex-1 h-px min-w-[32px] ${
+                    index < currentIndex ? 'bg-[#0ff0fc]/40' : 'bg-[#2a2a2a]'
+                  }`}
+                  aria-hidden="true"
+                />
+              )}
+            </React.Fragment>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #700

Adds a read-only 3-step stepper (Filed -> Under Review -> Resolved) to the commitment detail page so users can track their dispute after filing.

- New component src/components/dispute/DisputeStatusTracker.tsx
- Wired into src/app/commitments/[id]/page.tsx with mock dispute state
- 26 RTL tests covering every stage, all resolution outcomes, aria-current
- docs/DISPUTE_TRACKER.md with props reference and a11y notes