### PR TITLE
feat: inline relist and edit-price action on My Commitments cards

### DIFF
--- a/docs/RELIST_EDIT_PRICE.md
+++ b/docs/RELIST_EDIT_PRICE.md
@@ -1,0 +1,116 @@
+# Relist & Edit Price — Inline Listing Management
+
+## Overview
+
+Sellers can manage their active marketplace listings directly from the
+My Commitments card without navigating to a separate page. Two actions are
+available depending on the listing status:
+
+| Listing Status | Action Shown | Behaviour |
+|----------------|-------------|-----------|
+| `Active`       | **Edit price** | Cancels the current listing and creates a new one with the updated price. |
+| `Cancelled`    | **Relist**     | Creates a fresh listing for the commitment. |
+
+## Components
+
+### `RelistPriceEditor`
+
+**File:** `src/components/marketplace/RelistPriceEditor.tsx`
+
+An inline editor that conditionally renders based on `listing.status`:
+
+- **Display state** — Shows the current price and an action button
+  (`"Edit price"` for active, `"Relist"` for cancelled).
+- **Editing state** — After clicking the action button, the component
+  expands to show a labelled price input, the asset currency, Save and
+  Cancel buttons.
+- **Validation** — Client-side checks run before the API call:
+  - Price is required (non-empty).
+  - Price must be a positive number.
+  - Price cannot exceed 1,000,000,000.
+- **API flow (edit price):**
+  1. `DELETE /api/marketplace/listings/{listingId}` — cancels the
+     existing active listing.
+  2. `POST /api/marketplace/listings` — creates a new listing with the
+     new price.
+- **API flow (relist):**
+  1. `POST /api/marketplace/listings` — creates a fresh listing.
+- **Success:** The `onPriceUpdated` callback fires with the new price
+  string; a success toast is shown.
+- **Failure:** The price is rolled back to the previous value; an error
+  toast is shown with the server message.
+- **Accessibility:** The input has `aria-label`, `aria-invalid`, and
+  `aria-describedby` wired to the validation error element. Buttons are
+  disabled during submission.
+
+### Props
+
+```typescript
+interface RelistPriceEditorProps {
+  listing: MarketplaceListing;   // Current listing (Active or Cancelled)
+  sellerAddress: string;         // Wallet address of the seller
+  commitmentAsset: string;       // e.g. "XLM", "USDC"
+  onPriceUpdated?: (newPrice: string) => void;
+}
+```
+
+## Integration
+
+### `MyCommitmentCard`
+
+Two optional props were added:
+
+```typescript
+interface MyCommitmentCardProps {
+  // ... existing props ...
+  listing?: MarketplaceListing;
+  sellerAddress?: string;
+  onListingPriceUpdated?: (commitmentId: string, newPrice: string) => void;
+}
+```
+
+When `listing` and `sellerAddress` are provided, a Listing Price section
+appears between the commitment metrics and the action buttons. The
+`RelistPriceEditor` is rendered inside a subtle card panel.
+
+## Testing
+
+**File:** `src/components/marketplace/RelistPriceEditor.test.tsx`
+
+The test suite covers:
+
+- **Display states** — renders nothing for `Sold`, shows Edit price for
+  `Active`, shows Relist for `Cancelled`.
+- **Inline editor** — opens on click, pre-fills current price, cancels
+  and resets, shows correct labels per status.
+- **Price validation** — empty, negative, zero, non-numeric, exceeds max,
+  error clears on input change.
+- **API submission** — edit price flow (cancel + create), relist flow
+  (create only), rollback on API failure, error handling for non-ok
+  status codes.
+- **Accessibility** — `aria-invalid` + `aria-describedby` for errors,
+  buttons disabled during submit.
+
+Run with:
+
+```bash
+pnpm test -- src/components/marketplace/RelistPriceEditor.test.tsx
+```
+
+## Error Handling
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Cancel API returns 4xx/5xx | Error toast with server message; price rolled back. |
+| Create API returns 4xx/5xx | Error toast with server message; price rolled back. |
+| Network failure | Error toast with generic message; price rolled back. |
+| Invalid input (client-side) | Inline validation error, no API call made. |
+
+## Future Considerations
+
+- When the backend supports a dedicated `PATCH /api/marketplace/listings/{id}`
+  endpoint for price updates, the cancel-then-create flow can be simplified
+  to a single request.
+- The editor currently resets to display state after success. For the user
+  to see the new price immediately, the parent component should update the
+  `listing.price` via `onPriceUpdated`.

--- a/src/components/MyCommitmentCard.tsx
+++ b/src/components/MyCommitmentCard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Commitment } from "@/types/commitment";
+import type { MarketplaceListing } from "@/types/marketplace";
 import Link from "next/link";
 import {
   SafeIcon,
@@ -10,19 +11,26 @@ import {
   AlertIcon,
 } from "./icons/CommitmentIcons";
 import { TrendingUp as Increase, TrendingDown as Decrease } from "lucide-react";
+import RelistPriceEditor from "./marketplace/RelistPriceEditor";
 
 interface MyCommitmentCardProps {
   commitment: Commitment;
+  listing?: MarketplaceListing;
+  sellerAddress?: string;
   onDetails?: (id: string) => void;
   onAttestations?: (id: string) => void;
   onEarlyExit?: (id: string) => void;
+  onListingPriceUpdated?: (commitmentId: string, newPrice: string) => void;
 }
 
 const MyCommitmentCard: React.FC<MyCommitmentCardProps> = ({
   commitment,
+  listing,
+  sellerAddress,
   onDetails,
   onAttestations,
   onEarlyExit,
+  onListingPriceUpdated,
 }) => {
   const {
     id,
@@ -232,6 +240,17 @@ const MyCommitmentCard: React.FC<MyCommitmentCardProps> = ({
           <span className="text-white font-roboto">{expiryDate}</span>
         </div>
       </div>
+
+      {listing && sellerAddress && (
+        <div className="rounded-[10px] border border-white/5 bg-[#FFFFFF05] px-3 py-2.5">
+          <RelistPriceEditor
+            listing={listing}
+            sellerAddress={sellerAddress}
+            commitmentAsset={asset}
+            onPriceUpdated={(newPrice) => onListingPriceUpdated?.(id, newPrice)}
+          />
+        </div>
+      )}
 
       <div className="mt-2 flex flex-col gap-2">
         <div className="grid grid-cols-2 gap-3">

--- a/src/components/marketplace/RelistPriceEditor.test.tsx
+++ b/src/components/marketplace/RelistPriceEditor.test.tsx
@@ -1,0 +1,341 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import RelistPriceEditor from './RelistPriceEditor';
+import type { MarketplaceListing } from '@/types/marketplace';
+
+vi.mock('@/components/toast/ToastProvider', () => ({
+  useToast: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    dismiss: vi.fn(),
+    dismissAll: vi.fn(),
+  }),
+}));
+
+const activeListing: MarketplaceListing = {
+  id: 'lst-001',
+  commitmentId: 'CMT-ABC123',
+  price: '52000',
+  currencyAsset: 'XLM',
+  sellerAddress: 'GABCDEF1234567890',
+  status: 'Active',
+  createdAt: '2026-01-15T00:00:00Z',
+  updatedAt: '2026-01-15T00:00:00Z',
+};
+
+const cancelledListing: MarketplaceListing = {
+  ...activeListing,
+  status: 'Cancelled',
+};
+
+const sellerAddress = 'GABCDEF1234567890';
+const commitmentAsset = 'XLM';
+
+function renderEditor(listing: MarketplaceListing = activeListing) {
+  const onPriceUpdated = vi.fn();
+  const view = render(
+    <RelistPriceEditor
+      listing={listing}
+      sellerAddress={sellerAddress}
+      commitmentAsset={commitmentAsset}
+      onPriceUpdated={onPriceUpdated}
+    />,
+  );
+  return { onPriceUpdated, ...view };
+}
+
+function setInputValue(input: HTMLElement, value: string) {
+  fireEvent.change(input, { target: { value } });
+}
+
+function clickButton(name: string | RegExp) {
+  fireEvent.click(screen.getByRole('button', { name }));
+}
+
+describe('RelistPriceEditor', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe('display state', () => {
+    it('renders nothing for Sold listings', () => {
+      const sold: MarketplaceListing = { ...activeListing, status: 'Sold' };
+      const { container } = renderEditor(sold);
+      expect(container.textContent).toBe('');
+    });
+
+    it('renders current price and Edit price button for active listings', () => {
+      renderEditor(activeListing);
+      expect(screen.getByText('52000 XLM')).toBeInTheDocument();
+      expect(screen.getByText('Edit price')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Edit listing price' })).toBeInTheDocument();
+    });
+
+    it('renders Listing Price label and Relist button for cancelled listings', () => {
+      renderEditor(cancelledListing);
+      expect(screen.getByText('Listing Price')).toBeInTheDocument();
+      expect(screen.getByText('52000 XLM')).toBeInTheDocument();
+      expect(screen.getByText('Relist')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Relist commitment' })).toBeInTheDocument();
+    });
+  });
+
+  describe('inline editor', () => {
+    it('opens inline editor when Edit price is clicked', () => {
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      expect(screen.getByLabelText('Listing price')).toBeInTheDocument();
+      expect(screen.getByText('Save')).toBeInTheDocument();
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+    });
+
+    it('pre-fills the input with current price', () => {
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      const input = screen.getByLabelText('Listing price') as HTMLInputElement;
+      expect(input.value).toBe('52000');
+    });
+
+    it('closes editor and resets price on Cancel', () => {
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      const input = screen.getByLabelText('Listing price');
+      setInputValue(input, '99999');
+      clickButton('Cancel editing');
+      expect(screen.getByText('52000 XLM')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Listing price')).not.toBeInTheDocument();
+    });
+
+    it('opens inline editor when Relist is clicked', () => {
+      renderEditor(cancelledListing);
+      clickButton('Relist commitment');
+      expect(screen.getByLabelText('Listing price')).toBeInTheDocument();
+      expect(screen.getByText('Save')).toBeInTheDocument();
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+    });
+
+    it('shows Set Price label for cancelled listings in editor', () => {
+      renderEditor(cancelledListing);
+      clickButton('Relist commitment');
+      expect(screen.getByText('Set Price')).toBeInTheDocument();
+    });
+
+    it('shows Edit Price label for active listings in editor', () => {
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      expect(screen.getByText('Edit Price')).toBeInTheDocument();
+    });
+  });
+
+  describe('price validation', () => {
+    it('shows error for empty price', () => {
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      const input = screen.getByLabelText('Listing price');
+      setInputValue(input, '');
+      clickButton('Save price');
+      expect(screen.getByText('Price is required')).toBeInTheDocument();
+    });
+
+    it('shows error for negative price', () => {
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      const input = screen.getByLabelText('Listing price');
+      setInputValue(input, '-100');
+      clickButton('Save price');
+      expect(screen.getByText('Price must be positive')).toBeInTheDocument();
+    });
+
+    it('shows error for zero price', () => {
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      const input = screen.getByLabelText('Listing price');
+      setInputValue(input, '0');
+      clickButton('Save price');
+      expect(screen.getByText('Price must be positive')).toBeInTheDocument();
+    });
+
+    it('shows error for non-numeric price', () => {
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      const input = screen.getByLabelText('Listing price');
+      setInputValue(input, 'abc');
+      clickButton('Save price');
+      expect(screen.getByText('Price must be a valid number')).toBeInTheDocument();
+    });
+
+    it('shows error for price exceeding max', () => {
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      const input = screen.getByLabelText('Listing price');
+      setInputValue(input, '999999999999');
+      clickButton('Save price');
+      expect(screen.getByText(/Price cannot exceed/)).toBeInTheDocument();
+    });
+
+    it('clears validation error when user types', () => {
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      const input = screen.getByLabelText('Listing price');
+      setInputValue(input, '');
+      clickButton('Save price');
+      expect(screen.getByText('Price is required')).toBeInTheDocument();
+      setInputValue(input, '100');
+      expect(screen.queryByText('Price is required')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('API submission', () => {
+    it('cancels existing listing and creates new one on edit price submit', async () => {
+      const fetchMock = vi.spyOn(globalThis, 'fetch');
+      fetchMock
+        .mockResolvedValueOnce(new Response(JSON.stringify({ cancelled: true }), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ listing: { id: 'lst-002' } }), { status: 201 }));
+
+      const { onPriceUpdated } = renderEditor(activeListing);
+      clickButton('Edit listing price');
+      const input = screen.getByLabelText('Listing price');
+      setInputValue(input, '55000');
+      clickButton('Save price');
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
+
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        '/api/marketplace/listings/lst-001',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        '/api/marketplace/listings',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"price":"55000"'),
+        }),
+      );
+      expect(onPriceUpdated).toHaveBeenCalledWith('55000');
+    });
+
+    it('creates new listing on relist submit (no cancel call)', async () => {
+      const fetchMock = vi.spyOn(globalThis, 'fetch');
+      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ listing: { id: 'lst-003' } }), { status: 201 }));
+
+      const { onPriceUpdated } = renderEditor(cancelledListing);
+      clickButton('Relist commitment');
+      const input = screen.getByLabelText('Listing price');
+      setInputValue(input, '50000');
+      clickButton('Save price');
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/marketplace/listings',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"price":"50000"'),
+        }),
+      );
+      expect(onPriceUpdated).toHaveBeenCalledWith('50000');
+    });
+
+    it('shows error toast and rolls back price on API failure', async () => {
+      const fetchMock = vi.spyOn(globalThis, 'fetch');
+      fetchMock.mockRejectedValueOnce(new Error('Network error'));
+
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      const input = screen.getByLabelText('Listing price') as HTMLInputElement;
+      setInputValue(input, '99999');
+      clickButton('Save price');
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      clickButton('Cancel editing');
+      expect(screen.getByText('52000 XLM')).toBeInTheDocument();
+    });
+
+    it('throws error when cancel API returns non-ok status', async () => {
+      const fetchMock = vi.spyOn(globalThis, 'fetch');
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'Unauthorized' }), { status: 403 }),
+      );
+
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      const input = screen.getByLabelText('Listing price');
+      setInputValue(input, '55000');
+      clickButton('Save price');
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      clickButton('Cancel editing');
+      expect(screen.getByText('52000 XLM')).toBeInTheDocument();
+    });
+
+    it('throws error when create API returns non-ok status', async () => {
+      const fetchMock = vi.spyOn(globalThis, 'fetch');
+      fetchMock
+        .mockResolvedValueOnce(new Response(JSON.stringify({ cancelled: true }), { status: 200 }))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ message: 'Invalid price' }), { status: 400 }),
+        );
+
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      const input = screen.getByLabelText('Listing price');
+      setInputValue(input, '55000');
+      clickButton('Save price');
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
+
+      clickButton('Cancel editing');
+      expect(screen.getByText('52000 XLM')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('associates error message with input via aria-describedby', () => {
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      const input = screen.getByLabelText('Listing price');
+      setInputValue(input, '');
+      clickButton('Save price');
+
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+      const errorId = input.getAttribute('aria-describedby');
+      expect(errorId).toBeTruthy();
+      expect(screen.getByRole('alert')).toHaveAttribute('id', errorId);
+    });
+
+    it('disables Save and Cancel buttons while submitting', () => {
+      const fetchMock = vi.spyOn(globalThis, 'fetch');
+      fetchMock.mockImplementationOnce(
+        () => new Promise(() => {}),
+      );
+
+      renderEditor(activeListing);
+      clickButton('Edit listing price');
+      clickButton('Save price');
+
+      expect(screen.getByRole('button', { name: 'Saving...' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Cancel editing' })).toBeDisabled();
+    });
+  });
+});

--- a/src/components/marketplace/RelistPriceEditor.tsx
+++ b/src/components/marketplace/RelistPriceEditor.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import React, { useState, useCallback, useId } from 'react';
+import { Pencil, RotateCcw, Loader2, X, Check } from 'lucide-react';
+import type { MarketplaceListing } from '@/types/marketplace';
+import { useToast } from '@/components/toast/ToastProvider';
+
+interface RelistPriceEditorProps {
+  listing: MarketplaceListing;
+  sellerAddress: string;
+  commitmentAsset: string;
+  onPriceUpdated?: (newPrice: string) => void;
+}
+
+const MIN_PRICE = 0.01;
+const MAX_PRICE = 1_000_000_000;
+
+function isValidPrice(value: string): { valid: true } | { valid: false; error: string } {
+  const trimmed = value.trim();
+  if (!trimmed) return { valid: false, error: 'Price is required' };
+  const num = Number(trimmed);
+  if (!Number.isFinite(num)) return { valid: false, error: 'Price must be a valid number' };
+  if (num <= 0) return { valid: false, error: 'Price must be positive' };
+  if (num > MAX_PRICE) return { valid: false, error: `Price cannot exceed ${MAX_PRICE.toLocaleString()}` };
+  return { valid: true };
+}
+
+export default function RelistPriceEditor({
+  listing,
+  sellerAddress,
+  commitmentAsset,
+  onPriceUpdated,
+}: RelistPriceEditorProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [price, setPrice] = useState(listing.price);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const toast = useToast();
+  const inputId = useId();
+
+  const isActive = listing.status === 'Active';
+  const isCancelled = listing.status === 'Cancelled';
+
+  const handleOpen = useCallback(() => {
+    setPrice(listing.price);
+    setValidationError(null);
+    setIsEditing(true);
+  }, [listing.price]);
+
+  const handleCancel = useCallback(() => {
+    setIsEditing(false);
+    setValidationError(null);
+    setPrice(listing.price);
+  }, [listing.price]);
+
+  const handleSubmit = useCallback(async () => {
+    const validation = isValidPrice(price);
+    if (!validation.valid) {
+      setValidationError(validation.error);
+      return;
+    }
+    setValidationError(null);
+    setIsSubmitting(true);
+
+    const previousPrice = listing.price;
+    const numericPrice = Number(price.trim());
+
+    try {
+      if (isActive) {
+        const cancelRes = await fetch(
+          `/api/marketplace/listings/${encodeURIComponent(listing.id)}`,
+          {
+            method: 'DELETE',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${sellerAddress}`,
+            },
+          },
+        );
+
+        if (!cancelRes.ok) {
+          const data = await cancelRes.json().catch(() => ({}));
+          throw new Error(data.message || data.error || 'Failed to cancel existing listing');
+        }
+      }
+
+      const createRes = await fetch('/api/marketplace/listings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          commitmentId: listing.commitmentId,
+          price: numericPrice.toString(),
+          currencyAsset: commitmentAsset,
+          sellerAddress,
+        }),
+      });
+
+      if (!createRes.ok) {
+        const data = await createRes.json().catch(() => ({}));
+        throw new Error(data.message || data.error || 'Failed to create listing');
+      }
+
+      const formatted = numericPrice.toString();
+      onPriceUpdated?.(formatted);
+      toast.success({
+        title: isActive ? 'Price updated' : 'Listing created',
+        description: isActive
+          ? `Price changed to ${formatted} ${commitmentAsset}`
+          : `Commitment relisted at ${formatted} ${commitmentAsset}`,
+      });
+      setIsEditing(false);
+    } catch (err) {
+      setPrice(previousPrice);
+      const message = err instanceof Error ? err.message : 'An unexpected error occurred';
+      toast.error({
+        title: 'Failed to update listing',
+        description: message,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [price, isActive, listing.id, listing.commitmentId, commitmentAsset, sellerAddress, onPriceUpdated, toast, listing.price]);
+
+  if (!isActive && !isCancelled) return null;
+
+  if (!isEditing) {
+    return (
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[11px] tracking-[0.05em] text-[#94A3B8]">
+            Listing Price
+          </span>
+          <span className="text-[14px] font-semibold text-white">
+            {listing.price} {listing.currencyAsset}
+          </span>
+        </div>
+        {isActive && (
+          <button
+            type="button"
+            onClick={handleOpen}
+            className="flex items-center gap-1.5 rounded-[8px] border border-[rgba(15,240,252,0.2)] bg-[rgba(15,240,252,0.05)] px-2.5 py-1.5 text-[12px] font-semibold text-[#0FF0FC] transition-all duration-200 hover:bg-[rgba(15,240,252,0.1)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC]"
+            aria-label="Edit listing price"
+          >
+            <Pencil size={14} /> Edit price
+          </button>
+        )}
+        {isCancelled && (
+          <button
+            type="button"
+            onClick={handleOpen}
+            className="flex items-center gap-1.5 rounded-[8px] border border-[rgba(5,223,114,0.3)] bg-[rgba(5,223,114,0.08)] px-2.5 py-1.5 text-[12px] font-semibold text-[#05DF72] transition-all duration-200 hover:bg-[rgba(5,223,114,0.12)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#05DF72]"
+            aria-label="Relist commitment"
+          >
+            <RotateCcw size={14} /> Relist
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label
+        htmlFor={inputId}
+        className="text-[11px] tracking-[0.05em] text-[#94A3B8]"
+      >
+        {isActive ? 'Edit Price' : 'Set Price'}
+      </label>
+      <div className="flex items-center gap-2">
+        <input
+          id={inputId}
+          type="text"
+          inputMode="decimal"
+          value={price}
+          onChange={(e) => {
+            setPrice(e.target.value);
+            setValidationError(null);
+          }}
+          disabled={isSubmitting}
+          className="flex-1 rounded-[8px] border border-white/10 bg-[#050505] px-3 py-2 text-[14px] text-white placeholder:text-white/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC] disabled:cursor-not-allowed disabled:opacity-50"
+          placeholder="0.00"
+          autoComplete="off"
+          aria-label="Listing price"
+          aria-invalid={!!validationError}
+          aria-describedby={validationError ? `${inputId}-error` : undefined}
+        />
+        <span className="text-[12px] text-[#94A3B8] font-medium">
+          {commitmentAsset}
+        </span>
+      </div>
+      {validationError && (
+        <p
+          id={`${inputId}-error`}
+          role="alert"
+          className="text-[11px] text-[#EF4444]"
+        >
+          {validationError}
+        </p>
+      )}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={isSubmitting}
+          className="flex items-center gap-1.5 rounded-[8px] border border-[rgba(5,223,114,0.3)] bg-[rgba(5,223,114,0.08)] px-2.5 py-1.5 text-[12px] font-semibold text-[#05DF72] transition-all duration-200 hover:bg-[rgba(5,223,114,0.12)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#05DF72] disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label={isSubmitting ? 'Saving...' : 'Save price'}
+        >
+          {isSubmitting ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : (
+            <Check size={14} />
+          )}
+          {isSubmitting ? 'Saving...' : 'Save'}
+        </button>
+        <button
+          type="button"
+          onClick={handleCancel}
+          disabled={isSubmitting}
+          className="flex items-center gap-1.5 rounded-[8px] border border-white/10 px-2.5 py-1.5 text-[12px] font-semibold text-white/80 transition-all duration-200 hover:border-white/30 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC] disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="Cancel editing"
+        >
+          <X size={14} /> Cancel
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #716

## Summary

Adds an inline relist/edit-price editor on My Commitment cards for commitments with active or cancelled marketplace listings.

## Changes

### New: `src/components/marketplace/RelistPriceEditor.tsx`
- Shows "Edit price" button for active listings, "Relist" for cancelled listings
- Opens an accessible inline form with a labelled price input
- Validates price (positive number, within bounds) before API call
- Edit flow: cancels existing listing (`DELETE /api/marketplace/listings/{id}`) then creates a new one (`POST /api/marketplace/listings`)
- Relist flow: creates a fresh listing
- Shows success/error toast on result
- Optimistic price rollback on API failure

### Modified: `src/components/MyCommitmentCard.tsx`
- Added optional `listing`, `sellerAddress`, `onListingPriceUpdated` props
- Renders `RelistPriceEditor` when a listing is provided

### New: `src/components/marketplace/RelistPriceEditor.test.tsx`
22 tests covering:
- Display states (Active/Cancelled/Sold)
- Inline editor open/close/reset
- Price validation (empty, negative, zero, non-numeric, exceeds max, clears on input)
- API submission (edit price, relist, failure rollback, non-ok status codes)
- Accessibility (aria-invalid, aria-describedby, disabled during submit)

### New: `docs/RELIST_EDIT_PRICE.md`
Documentation covering component API, integration, testing, error handling.

## Testing

```
✓ 22 tests pass (RelistPriceEditor)
✓ 15 tests pass (GridMemoization — MyCommitmentCard memo unchanged)
```