### PR TITLE
feat: sort menu for My Commitments by maturity, amount, score, yield

### DIFF
--- a/docs/MY_COMMITMENTS_SORT.md
+++ b/docs/MY_COMMITMENTS_SORT.md
@@ -1,0 +1,28 @@
+# My Commitments Sorting Feature
+
+## Overview
+This feature adds sorting capabilities to the My Commitments grid, allowing users to order their commitments by various criteria.
+
+## Sort Options
+- **Newest**: Sort by creation date (newest first)
+- **Oldest**: Sort by creation date (oldest first)
+- **Value High → Low**: Sort by commitment amount (highest first)
+- **Value Low → High**: Sort by commitment amount (lowest first)
+- **Maturity Soonest**: Sort by days remaining (soonest first)
+- **Maturity Latest**: Sort by days remaining (latest first)
+- **Compliance High → Low**: Sort by compliance score (highest first)
+- **Compliance Low → High**: Sort by compliance score (lowest first)
+- **Yield High → Low**: Sort by change percentage (highest first)
+- **Yield Low → High**: Sort by change percentage (lowest first)
+
+## Files Modified/Added
+- `src/utils/sortCommitments.ts`: Contains sorting logic
+- `src/utils/__tests__/sortCommitments.test.ts`: Tests for sorting function
+- `src/components/MyCommitmentsFilters/SortMenu.tsx`: Sort menu component
+- `src/components/MyCommitmentsFilters/MyCommitmentsFilters.tsx`: Updated to use SortMenu
+- `src/components/MyCommitmentsOverview/MyCommitmentsOverview.tsx`: Updated types
+- `src/app/commitments/page.tsx`: Integrated sorting
+- `docs/MY_COMMITMENTS_SORT.md`: This documentation
+
+## Usage
+The sorting is applied after filtering and is persistent for the session. The active sort is reflected in the UI and accessible via aria attributes.

--- a/src/app/commitments/page.tsx
+++ b/src/app/commitments/page.tsx
@@ -13,6 +13,7 @@ import { useWallet } from '@/hooks/useWallet'
 import { Commitment, CommitmentStats } from '@/types/commitment'
 import { listCommitments } from '@/lib/backend/mocks/contracts'
 import { fetchProtocolConstants, ProtocolConstants } from '@/utils/protocol'
+import { sortCommitments, SortOption } from '@/utils/sortCommitments'
 
 const mockCommitments: Commitment[] = [
   {
@@ -139,7 +140,7 @@ export default function MyCommitments() {
   const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState('All')
   const [typeFilter, setTypeFilter] = useState('All')
-  const [sortBy, setSortBy] = useState('Newest')
+  const [sortBy, setSortBy] = useState<SortOption>('Newest')
 
   const [earlyExitCommitmentId, setEarlyExitCommitmentId] = useState<string | null>(null)
   const [isExportOpen, setIsExportOpen] = useState(false)
@@ -181,18 +182,7 @@ export default function MyCommitments() {
       return matchesSearch && matchesStatus && matchesType
     })
 
-    // Basic Sorting Logic
-    if (sortBy === 'ValueHighLow') {
-      filtered.sort((a, b) => Number(b.amount.replace(/,/g, '')) - Number(a.amount.replace(/,/g, '')))
-    } else if (sortBy === 'ValueLowHigh') {
-      filtered.sort((a, b) => Number(a.amount.replace(/,/g, '')) - Number(b.amount.replace(/,/g, '')))
-    } else if (sortBy === 'Newest') {
-      filtered.sort((a, b) => new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime())
-    } else if (sortBy === 'Oldest') {
-      filtered.sort((a, b) => new Date(a.createdDate).getTime() - new Date(b.createdDate).getTime())
-    }
-
-    return filtered
+    return sortCommitments(filtered, sortBy)
   }, [commitmentsList, searchQuery, statusFilter, typeFilter, sortBy])
 
   const commitmentForEarlyExit = commitmentsList.find((c) => c.id === earlyExitCommitmentId)

--- a/src/components/MyCommitmentsFilters/MyCommitmentsFilters.tsx
+++ b/src/components/MyCommitmentsFilters/MyCommitmentsFilters.tsx
@@ -4,89 +4,79 @@ import React from 'react';
 import { Search, ChevronDown } from 'lucide-react';
 import styles from './MyCommitmentsFilters.module.css';
 import { clsx } from 'clsx';
+import SortMenu from './SortMenu';
+import { SortOption } from '@/utils/sortCommitments';
 
 interface MyCommitmentsFiltersProps {
-    searchQuery: string;
-    onSearchChange: (value: string) => void;
-    status: string;
-    type: string;
-    sortBy?: string;
-    onStatusChange: (value: string) => void;
-    onTypeChange: (value: string) => void;
-    onSortByChange?: (value: string) => void;
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+  status: string;
+  type: string;
+  sortBy?: SortOption;
+  onStatusChange: (value: string) => void;
+  onTypeChange: (value: string) => void;
+  onSortByChange?: (value: SortOption) => void;
 }
 
 const MyCommitmentsFilters: React.FC<MyCommitmentsFiltersProps> = ({
-    searchQuery,
-    onSearchChange,
-    status,
-    type,
-    sortBy,
-    onStatusChange,
-    onTypeChange,
-    onSortByChange,
+  searchQuery,
+  onSearchChange,
+  status,
+  type,
+  sortBy = 'Newest',
+  onStatusChange,
+  onTypeChange,
+  onSortByChange,
 }) => {
-    return (
-        <div className={styles.filtersWrapper}>
-            <div className={styles.searchContainer}>
-                <Search className={styles.searchIcon} size={18} />
-                <input
-                    type="text"
-                    className={styles.searchInput}
-                    placeholder="Search by commitment ID..."
-                    value={searchQuery}
-                    onChange={(e) => onSearchChange(e.target.value)}
-                />
-            </div>
+  return (
+    <div className={styles.filtersWrapper}>
+      <div className={styles.searchContainer}>
+        <Search className={styles.searchIcon} size={18} />
+        <input
+          type="text"
+          className={styles.searchInput}
+          placeholder="Search by commitment ID..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+        />
+      </div>
 
-            <div className={styles.filtersRow}>
-                <div className={styles.selectWrapper}>
-                    <select
-                        className={clsx(styles.select, status !== 'All' && styles.selectActive)}
-                        value={status}
-                        onChange={(e) => onStatusChange(e.target.value)}
-                    >
-                        <option value="All">Status: All</option>
-                        <option value="Active">Active</option>
-                        <option value="Settled">Settled</option>
-                        <option value="Violated">Violated</option>
-                        <option value="Early Exit">Early Exit</option>
-                    </select>
-                    <ChevronDown className={styles.chevronIcon} size={16} />
-                </div>
-
-                <div className={styles.selectWrapper}>
-                    <select
-                        className={clsx(styles.select, type !== 'All' && styles.selectActive)}
-                        value={type}
-                        onChange={(e) => onTypeChange(e.target.value)}
-                    >
-                        <option value="All">Type: All</option>
-                        <option value="Safe">Safe</option>
-                        <option value="Balanced">Balanced</option>
-                        <option value="Aggressive">Aggressive</option>
-                    </select>
-                    <ChevronDown className={styles.chevronIcon} size={16} />
-                </div>
-
-                {onSortByChange && (
-                    <div className={styles.selectWrapper}>
-                        <select
-                            className={clsx(styles.select, sortBy && styles.selectActive)}
-                            value={sortBy}
-                            onChange={(e) => onSortByChange(e.target.value)}
-                        >
-                            <option value="Newest">Sort: Newest</option>
-                            <option value="Oldest">Oldest</option>
-                            <option value="ValueHighLow">Value: High to Low</option>
-                            <option value="ValueLowHigh">Value: Low to High</option>
-                        </select>
-                        <ChevronDown className={styles.chevronIcon} size={16} />
-                    </div>
-                )}
-            </div>
+      <div className={styles.filtersRow}>
+        <div className={styles.selectWrapper}>
+          <select
+            className={clsx(styles.select, status !== 'All' && styles.selectActive)}
+            value={status}
+            onChange={(e) => onStatusChange(e.target.value)}
+          >
+            <option value="All">Status: All</option>
+            <option value="Active">Active</option>
+            <option value="Settled">Settled</option>
+            <option value="Violated">Violated</option>
+            <option value="Early Exit">Early Exit</option>
+          </select>
+          <ChevronDown className={styles.chevronIcon} size={16} />
         </div>
-    );
+
+        <div className={styles.selectWrapper}>
+          <select
+            className={clsx(styles.select, type !== 'All' && styles.selectActive)}
+            value={type}
+            onChange={(e) => onTypeChange(e.target.value)}
+          >
+            <option value="All">Type: All</option>
+            <option value="Safe">Safe</option>
+            <option value="Balanced">Balanced</option>
+            <option value="Aggressive">Aggressive</option>
+          </select>
+          <ChevronDown className={styles.chevronIcon} size={16} />
+        </div>
+
+        {onSortByChange && (
+          <SortMenu sortBy={sortBy} onSortByChange={onSortByChange} />
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default MyCommitmentsFilters;

--- a/src/components/MyCommitmentsFilters/SortMenu.tsx
+++ b/src/components/MyCommitmentsFilters/SortMenu.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React from 'react';
+import { ChevronDown } from 'lucide-react';
+import styles from './MyCommitmentsFilters.module.css';
+import { clsx } from 'clsx';
+import { SortOption } from '@/utils/sortCommitments';
+
+interface SortMenuProps {
+  sortBy: SortOption;
+  onSortByChange: (value: SortOption) => void;
+}
+
+const SortMenu: React.FC<SortMenuProps> = ({ sortBy, onSortByChange }) => {
+  const options: { value: SortOption; label: string }[] = [
+    { value: 'Newest', label: 'Sort: Newest' },
+    { value: 'Oldest', label: 'Oldest' },
+    { value: 'ValueHighLow', label: 'Value: High to Low' },
+    { value: 'ValueLowHigh', label: 'Value: Low to High' },
+    { value: 'MaturitySoonest', label: 'Maturity: Soonest' },
+    { value: 'MaturityLatest', label: 'Maturity: Latest' },
+    { value: 'ComplianceHighLow', label: 'Compliance: High to Low' },
+    { value: 'ComplianceLowHigh', label: 'Compliance: Low to High' },
+    { value: 'YieldHighLow', label: 'Yield: High to Low' },
+    { value: 'YieldLowHigh', label: 'Yield: Low to High' },
+  ];
+
+  return (
+    <div className={styles.selectWrapper}>
+      <select
+        className={clsx(styles.select, sortBy && styles.selectActive)}
+        value={sortBy}
+        onChange={(e) => onSortByChange(e.target.value as SortOption)}
+        aria-label="Sort commitments"
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <ChevronDown className={styles.chevronIcon} size={16} />
+    </div>
+  );
+};
+
+export default SortMenu;

--- a/src/components/MyCommitmentsOverview/MyCommitmentsOverview.tsx
+++ b/src/components/MyCommitmentsOverview/MyCommitmentsOverview.tsx
@@ -3,53 +3,54 @@
 import React from 'react';
 import MyCommitmentsStats from '../MyCommitmentsStats/MyCommitmentsStats';
 import MyCommitmentsFilters from '../MyCommitmentsFilters/MyCommitmentsFilters';
+import { SortOption } from '@/utils/sortCommitments';
 
 interface MyCommitmentsOverviewProps {
-    stats: {
-        totalActive: number;
-        totalCommittedValue: string;
-        averageComplianceScore: string;
-        totalFeesGenerated: string;
-    };
-    search: {
-        searchQuery: string;
-        onSearchChange: (value: string) => void;
-    };
-    filters: {
-        status: string;
-        type: string;
-        sortBy?: string;
-        onStatusChange: (value: string) => void;
-        onTypeChange: (value: string) => void;
-        onSortByChange?: (value: string) => void;
-    };
+  stats: {
+    totalActive: number;
+    totalCommittedValue: string;
+    averageComplianceScore: string;
+    totalFeesGenerated: string;
+  };
+  search: {
+    searchQuery: string;
+    onSearchChange: (value: string) => void;
+  };
+  filters: {
+    status: string;
+    type: string;
+    sortBy?: SortOption;
+    onStatusChange: (value: string) => void;
+    onTypeChange: (value: string) => void;
+    onSortByChange?: (value: SortOption) => void;
+  };
 }
 
 const MyCommitmentsOverview: React.FC<MyCommitmentsOverviewProps> = ({
-    stats,
-    search,
-    filters,
+  stats,
+  search,
+  filters,
 }) => {
-    return (
-        <div style={{ width: '100%' }}>
-            <MyCommitmentsStats
-                totalActive={stats.totalActive}
-                totalCommittedValue={stats.totalCommittedValue}
-                averageComplianceScore={stats.averageComplianceScore}
-                totalFeesGenerated={stats.totalFeesGenerated}
-            />
-            <MyCommitmentsFilters
-                searchQuery={search.searchQuery}
-                onSearchChange={search.onSearchChange}
-                status={filters.status}
-                type={filters.type}
-                sortBy={filters.sortBy}
-                onStatusChange={filters.onStatusChange}
-                onTypeChange={filters.onTypeChange}
-                onSortByChange={filters.onSortByChange}
-            />
-        </div>
-    );
+  return (
+    <div style={{ width: '100%' }}>
+      <MyCommitmentsStats
+        totalActive={stats.totalActive}
+        totalCommittedValue={stats.totalCommittedValue}
+        averageComplianceScore={stats.averageComplianceScore}
+        totalFeesGenerated={stats.totalFeesGenerated}
+      />
+      <MyCommitmentsFilters
+        searchQuery={search.searchQuery}
+        onSearchChange={search.onSearchChange}
+        status={filters.status}
+        type={filters.type}
+        sortBy={filters.sortBy}
+        onStatusChange={filters.onStatusChange}
+        onTypeChange={filters.onTypeChange}
+        onSortByChange={filters.onSortByChange}
+      />
+    </div>
+  );
 };
 
 export default MyCommitmentsOverview;

--- a/src/utils/__tests__/sortCommitments.test.ts
+++ b/src/utils/__tests__/sortCommitments.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { sortCommitments, SortOption } from '../sortCommitments';
+import { Commitment } from '@/types/commitment';
+
+const mockCommitments: Commitment[] = [
+  {
+    id: 'CMT-1',
+    type: 'Safe',
+    status: 'Active',
+    asset: 'XLM',
+    amount: '50,000',
+    currentValue: '52,600',
+    changePercent: 5.2,
+    durationProgress: 75,
+    daysRemaining: 15,
+    complianceScore: 95,
+    maxLoss: '2%',
+    currentDrawdown: '0.8%',
+    createdDate: 'Jan 10, 2026',
+    expiryDate: 'Feb 9, 2026',
+  },
+  {
+    id: 'CMT-2',
+    type: 'Balanced',
+    status: 'Active',
+    asset: 'USDC',
+    amount: '100,000',
+    currentValue: '112,500',
+    changePercent: 12.5,
+    durationProgress: 30,
+    daysRemaining: 42,
+    complianceScore: 88,
+    maxLoss: '8%',
+    currentDrawdown: '3.2%',
+    createdDate: 'Dec 15, 2025',
+    expiryDate: 'Feb 13, 2026',
+  },
+  {
+    id: 'CMT-3',
+    type: 'Aggressive',
+    status: 'Active',
+    asset: 'XLM',
+    amount: '250,000',
+    currentValue: '296,750',
+    changePercent: 18.7,
+    durationProgress: 17,
+    daysRemaining: 75,
+    complianceScore: 76,
+    maxLoss: 'No limit',
+    currentDrawdown: '12.5%',
+    createdDate: 'Nov 20, 2025',
+    expiryDate: 'Feb 10, 2026',
+  },
+];
+
+describe('sortCommitments', () => {
+  it('sorts by newest created date', () => {
+    const sorted = sortCommitments(mockCommitments, 'Newest');
+    expect(sorted[0].id).toBe('CMT-1');
+    expect(sorted[1].id).toBe('CMT-2');
+    expect(sorted[2].id).toBe('CMT-3');
+  });
+
+  it('sorts by oldest created date', () => {
+    const sorted = sortCommitments(mockCommitments, 'Oldest');
+    expect(sorted[0].id).toBe('CMT-3');
+    expect(sorted[1].id).toBe('CMT-2');
+    expect(sorted[2].id).toBe('CMT-1');
+  });
+
+  it('sorts by value high to low', () => {
+    const sorted = sortCommitments(mockCommitments, 'ValueHighLow');
+    expect(sorted[0].id).toBe('CMT-3');
+    expect(sorted[1].id).toBe('CMT-2');
+    expect(sorted[2].id).toBe('CMT-1');
+  });
+
+  it('sorts by value low to high', () => {
+    const sorted = sortCommitments(mockCommitments, 'ValueLowHigh');
+    expect(sorted[0].id).toBe('CMT-1');
+    expect(sorted[1].id).toBe('CMT-2');
+    expect(sorted[2].id).toBe('CMT-3');
+  });
+
+  it('sorts by maturity soonest', () => {
+    const sorted = sortCommitments(mockCommitments, 'MaturitySoonest');
+    expect(sorted[0].id).toBe('CMT-1');
+    expect(sorted[1].id).toBe('CMT-2');
+    expect(sorted[2].id).toBe('CMT-3');
+  });
+
+  it('sorts by maturity latest', () => {
+    const sorted = sortCommitments(mockCommitments, 'MaturityLatest');
+    expect(sorted[0].id).toBe('CMT-3');
+    expect(sorted[1].id).toBe('CMT-2');
+    expect(sorted[2].id).toBe('CMT-1');
+  });
+
+  it('sorts by compliance high to low', () => {
+    const sorted = sortCommitments(mockCommitments, 'ComplianceHighLow');
+    expect(sorted[0].id).toBe('CMT-1');
+    expect(sorted[1].id).toBe('CMT-2');
+    expect(sorted[2].id).toBe('CMT-3');
+  });
+
+  it('sorts by compliance low to high', () => {
+    const sorted = sortCommitments(mockCommitments, 'ComplianceLowHigh');
+    expect(sorted[0].id).toBe('CMT-3');
+    expect(sorted[1].id).toBe('CMT-2');
+    expect(sorted[2].id).toBe('CMT-1');
+  });
+
+  it('sorts by yield high to low', () => {
+    const sorted = sortCommitments(mockCommitments, 'YieldHighLow');
+    expect(sorted[0].id).toBe('CMT-3');
+    expect(sorted[1].id).toBe('CMT-2');
+    expect(sorted[2].id).toBe('CMT-1');
+  });
+
+  it('sorts by yield low to high', () => {
+    const sorted = sortCommitments(mockCommitments, 'YieldLowHigh');
+    expect(sorted[0].id).toBe('CMT-1');
+    expect(sorted[1].id).toBe('CMT-2');
+    expect(sorted[2].id).toBe('CMT-3');
+  });
+});

--- a/src/utils/sortCommitments.ts
+++ b/src/utils/sortCommitments.ts
@@ -1,0 +1,54 @@
+import { Commitment } from '@/types/commitment';
+
+export type SortOption = 
+  | 'Newest' 
+  | 'Oldest' 
+  | 'ValueHighLow' 
+  | 'ValueLowHigh'
+  | 'MaturitySoonest'
+  | 'MaturityLatest'
+  | 'ComplianceHighLow'
+  | 'ComplianceLowHigh'
+  | 'YieldHighLow'
+  | 'YieldLowHigh';
+
+export function sortCommitments(commitments: Commitment[], sortBy: SortOption): Commitment[] {
+  const sorted = [...commitments];
+
+  switch (sortBy) {
+    case 'Newest':
+      sorted.sort((a, b) => new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime());
+      break;
+    case 'Oldest':
+      sorted.sort((a, b) => new Date(a.createdDate).getTime() - new Date(b.createdDate).getTime());
+      break;
+    case 'ValueHighLow':
+      sorted.sort((a, b) => Number(b.amount.replace(/,/g, '')) - Number(a.amount.replace(/,/g, '')));
+      break;
+    case 'ValueLowHigh':
+      sorted.sort((a, b) => Number(a.amount.replace(/,/g, '')) - Number(b.amount.replace(/,/g, '')));
+      break;
+    case 'MaturitySoonest':
+      sorted.sort((a, b) => a.daysRemaining - b.daysRemaining);
+      break;
+    case 'MaturityLatest':
+      sorted.sort((a, b) => b.daysRemaining - a.daysRemaining);
+      break;
+    case 'ComplianceHighLow':
+      sorted.sort((a, b) => b.complianceScore - a.complianceScore);
+      break;
+    case 'ComplianceLowHigh':
+      sorted.sort((a, b) => a.complianceScore - b.complianceScore);
+      break;
+    case 'YieldHighLow':
+      sorted.sort((a, b) => b.changePercent - a.changePercent);
+      break;
+    case 'YieldLowHigh':
+      sorted.sort((a, b) => a.changePercent - b.changePercent);
+      break;
+    default:
+      break;
+  }
+
+  return sorted;
+}


### PR DESCRIPTION
Close: #693
## Summary
I've successfully implemented the sorting feature for the My Commitments grid. Here's what was done:

### 1. Added Sorting Logic (src/utils/sortCommitments.ts)
- Created a sortCommitments function that handles sorting commitments by various criteria
- Defined SortOption type to represent all possible sort options
- Supports sorting by: Newest, Oldest, Value (High→Low, Low→High), Maturity (Soonest, Latest), Compliance (High→Low, Low→High), Yield (High→Low, Low→High)
### 2. Added Tests (src/utils/__tests__/sortCommitments.test.ts)
- Comprehensive test coverage for all sort options
- Tests verify the correct order of commitments for each sort criteria
### 3. Created Sort Menu Component (src/components/MyCommitmentsFilters/SortMenu.tsx)
- Reusable sort menu component
- Follows existing design patterns
- Accessible with aria attributes
### 4. Updated Components
- MyCommitmentsFilters.tsx : Integrated the new SortMenu component
- MyCommitmentsOverview.tsx : Updated type definitions
- src/app/commitments/page.tsx : Updated to use sortCommitments function for sorting
- Added proper TypeScript types for all components
### 5. Documentation (docs/MY_COMMITMENTS_SORT.md)
- Created documentation outlining the feature
- Lists all sort options
- Documents modified/added files
- Explains usage
The implementation is complete and follows the project's existing code conventions. The sorting is applied after filtering, and the sort selection is persistent for the session.