### PR TITLE
feat: add per-route metadata for commitment detail and marketplace pages

### DIFF
--- a/docs/SEO_METADATA.md
+++ b/docs/SEO_METADATA.md
@@ -52,19 +52,55 @@ but inherits any fields not explicitly set (e.g. `robots`, `verification`).
 
 ### Dynamic routes
 
-For dynamic routes like `/commitments/[id]`, use `generateMetadata`:
+For dynamic routes like `/commitments/[id]`, use `generateMetadata`. Because the page itself
+is a client component (`'use client'`), place `generateMetadata` in the sibling
+`layout.tsx` server component:
 
 ```ts
-export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+// src/app/commitments/[id]/layout.tsx
+import type { Metadata } from 'next'
+
+type Props = { params: { id: string } }
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const id = params.id
+  const title = `Commitment #${id} — CommitLabs`
+  const description = `View performance metrics, compliance scores, and activity for commitment #${id} on CommitLabs.`
   return {
-    title: `Commitment #${params.id} — CommitLabs`,
-    description: `Details and performance data for commitment #${params.id}.`,
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `https://commitlabs.com/commitments/${id}`,
+      siteName: 'CommitLabs',
+      images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: title }],
+      locale: 'en_US',
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: ['/og-image.jpg'],
+    },
   }
+}
+
+export default function CommitmentDetailLayout({ children }: { children: React.ReactNode }) {
+  return children
 }
 ```
 
 The page **must** be a server component (or wrapped in a server-component layout) to use
 `generateMetadata`.
+
+### Implemented per-route metadata
+
+| Route | File | Metadata type | Notes |
+|-------|------|--------------|-------|
+| `/commitments/[id]` | `src/app/commitments/[id]/layout.tsx` | `generateMetadata` | Derives title/OG from `params.id`; safe fallback for unknown ids |
+| `/marketplace` | `src/app/marketplace/layout.tsx` | `export const metadata` | Static; full OG + Twitter card |
 
 ## Sitemap
 

--- a/src/app/commitments/[id]/layout.tsx
+++ b/src/app/commitments/[id]/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next'
+
+type Props = { params: { id: string } }
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const id = params.id
+  const title = `Commitment #${id} — CommitLabs`
+  const description = `View performance metrics, compliance scores, and activity for commitment #${id} on CommitLabs.`
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `https://commitlabs.com/commitments/${id}`,
+      siteName: 'CommitLabs',
+      images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: title }],
+      locale: 'en_US',
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: ['/og-image.jpg'],
+    },
+  }
+}
+
+export default function CommitmentDetailLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { generateMetadata as commitmentGenerateMetadata } from '@/app/commitments/[id]/layout'
+import { metadata as marketplaceMetadata } from '@/app/marketplace/layout'
+
+describe('commitment detail generateMetadata', () => {
+  it('returns correct title and description for a known id', async () => {
+    const result = await commitmentGenerateMetadata({ params: { id: '42' } })
+    expect(result.title).toBe('Commitment #42 — CommitLabs')
+    expect(result.description).toContain('#42')
+  })
+
+  it('returns correct openGraph fields', async () => {
+    const result = await commitmentGenerateMetadata({ params: { id: '7' } })
+    const og = result.openGraph as Record<string, unknown>
+    expect(og.title).toBe('Commitment #7 — CommitLabs')
+    expect(og.url).toBe('https://commitlabs.com/commitments/7')
+    expect(og.siteName).toBe('CommitLabs')
+    expect(og.locale).toBe('en_US')
+    expect(og.type).toBe('website')
+    const images = og.images as { url: string; width: number; height: number; alt: string }[]
+    expect(images[0].url).toBe('/og-image.jpg')
+    expect(images[0].width).toBe(1200)
+    expect(images[0].height).toBe(630)
+  })
+
+  it('returns correct twitter card fields', async () => {
+    const result = await commitmentGenerateMetadata({ params: { id: '7' } })
+    const tw = result.twitter as Record<string, unknown>
+    expect(tw.card).toBe('summary_large_image')
+    expect(tw.title).toBe('Commitment #7 — CommitLabs')
+    expect((tw.images as string[])[0]).toBe('/og-image.jpg')
+  })
+
+  it('does not leak sensitive data for an unknown id', async () => {
+    const result = await commitmentGenerateMetadata({ params: { id: 'unknown-xyz' } })
+    const title = result.title as string
+    const desc = result.description as string
+    // Title should only contain the id slug, no wallet addresses or private data
+    expect(title).toBe('Commitment #unknown-xyz — CommitLabs')
+    expect(desc).not.toMatch(/G[A-Z0-9]{55}/) // no Stellar address
+  })
+
+  it('uses id from params in the OG url for arbitrary ids', async () => {
+    const result = await commitmentGenerateMetadata({ params: { id: 'abc-123' } })
+    const og = result.openGraph as Record<string, unknown>
+    expect(og.url).toBe('https://commitlabs.com/commitments/abc-123')
+  })
+})
+
+describe('marketplace metadata', () => {
+  it('has title and description', () => {
+    expect(marketplaceMetadata.title).toBe('Marketplace — CommitLabs')
+    expect(typeof marketplaceMetadata.description).toBe('string')
+    expect((marketplaceMetadata.description as string).length).toBeGreaterThan(0)
+  })
+
+  it('has complete openGraph fields', () => {
+    const og = marketplaceMetadata.openGraph as Record<string, unknown>
+    expect(og.title).toBeTruthy()
+    expect(og.url).toBe('https://commitlabs.com/marketplace')
+    expect(og.siteName).toBe('CommitLabs')
+    expect(og.locale).toBe('en_US')
+    expect(og.type).toBe('website')
+    const images = og.images as { url: string }[]
+    expect(images[0].url).toBe('/og-image.jpg')
+  })
+
+  it('has twitter card fields', () => {
+    const tw = marketplaceMetadata.twitter as Record<string, unknown>
+    expect(tw.card).toBe('summary_large_image')
+    expect(tw.title).toBeTruthy()
+    expect((tw.images as string[])[0]).toBe('/og-image.jpg')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #801

Adds per-page titles, descriptions, and Open Graph tags for the commitment detail and marketplace routes.

## Changes

- **new** `src/app/commitments/[id]/layout.tsx` — server component exporting `generateMetadata`; derives title/OG from `params.id`; no sensitive data exposed
- **confirmed** `src/app/marketplace/layout.tsx` — already had complete static metadata (title, description, OG, Twitter)
- **new** `tests/metadata.test.ts` — 8 tests: commitment detail (title, OG fields, Twitter card, no sensitive data, arbitrary id URL) + marketplace static metadata
- **updated** `docs/SEO_METADATA.md` — full `generateMetadata` example and implemented-routes table

## Tested

```
Test Files  1 passed (1)
      Tests  8 passed (8)
```

All 8 new tests pass. Pre-existing test failures are unrelated to this change.