### PR TITLE
feat: purchase-success modal with ownership summary and next steps

### DIFF
--- a/docs/PURCHASE_SUCCESS.md
+++ b/docs/PURCHASE_SUCCESS.md
@@ -1,0 +1,59 @@
+# Purchase Success Modal
+
+Closes the purchase loop after a successful marketplace transaction by showing a confirmation with ownership-transfer details and next-step actions.
+
+## User Flow
+
+1. User clicks **Trade** on a `MarketplaceCard` that has an `onPurchase` handler.
+2. The card calls `onPurchase(id)` and disables the button while the transaction is in flight.
+3. On success, `PurchaseSuccessModal` opens with the ownership summary.
+4. User can copy the tx hash, open Stellar Explorer, or navigate to **My Commitments**.
+
+If no `onPurchase` prop is provided, the Trade button falls back to `router.push(tradeHref)` (the previous behaviour).
+
+## Component
+
+`src/components/modals/PurchaseSuccessModal.tsx`
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `isOpen` | `boolean` | ✓ | Controls modal visibility |
+| `onClose` | `() => void` | ✓ | Called when the user dismisses the modal |
+| `commitmentId` | `string` | ✓ | Raw commitment id, zero-padded to 3 digits in the UI |
+| `commitmentType` | `string` | ✓ | Human-readable type label (e.g. `"Safe Commitment"`) |
+| `pricePaid` | `string` | ✓ | Formatted price string (e.g. `"1,000 USDC"`) |
+| `txHash` | `string` | — | Transaction hash; missing hash is handled gracefully |
+| `onViewCommitments` | `() => void` | ✓ | Called when user clicks "View in My Commitments" |
+
+### Usage
+
+```tsx
+// In a page or parent component
+async function handlePurchase(id: string): Promise<string | undefined> {
+  const result = await buyCommitment(id); // your purchase logic
+  return result.txHash;
+}
+
+<MarketplaceCard
+  {...cardProps}
+  onPurchase={handlePurchase}
+/>
+```
+
+`MarketplaceCard` manages all modal state internally; no additional wiring is required.
+
+## Accessibility
+
+- Built on the shared `Dialog` primitive — focus is trapped inside the modal while open, and restored to the trigger on close.
+- Initial focus lands on the primary "View in My Commitments" CTA.
+- `aria-modal`, `aria-labelledby`, and `aria-describedby` are set.
+- Copy-hash confirmation uses a `role="status"` live region.
+- Escape key closes the modal.
+
+## Tests
+
+`src/components/modals/PurchaseSuccessModal.test.tsx`
+
+Covers: rendering (open/closed), ownership summary display, tx hash truncation, missing hash fallback, copy-hash affordance, CTA callbacks, close callbacks, and ARIA attributes.

--- a/src/components/MarketplaceCard.tsx
+++ b/src/components/MarketplaceCard.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useState } from "react";
 import { CommitmentDetailsModal } from "./modals/CommitmentDetailsModal";
-import Link from "next/link";
+import PurchaseSuccessModal from "./modals/PurchaseSuccessModal";
 import { TrustBadge, TrustLevel } from "./TrustBadge";
 
 export type CommitmentType = "Safe" | "Balanced" | "Aggressive";
@@ -20,6 +20,9 @@ export interface MarketplaceCardProps {
   forSale: boolean;
   tradeHref?: string;
   trustLevel?: TrustLevel;
+  /** Called when user confirms a purchase. Receives the commitment id and
+   *  must return (or resolve to) a tx hash string, or undefined on failure. */
+  onPurchase?: (id: string) => Promise<string | undefined> | string | undefined;
 }
 
 function clampScore(score: number) {
@@ -176,8 +179,12 @@ function MarketplaceCardComponent({
   forSale,
   tradeHref,
   trustLevel,
+  onPurchase,
 }: MarketplaceCardProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isPurchaseSuccessOpen, setIsPurchaseSuccessOpen] = useState(false);
+  const [purchaseTxHash, setPurchaseTxHash] = useState<string | undefined>();
+  const [isPurchasing, setIsPurchasing] = useState(false);
 
   const clampedScore = clampScore(score);
   const cardBorderClass =
@@ -203,6 +210,21 @@ function MarketplaceCardComponent({
 
   const resolvedTradeHref =
     tradeHref ?? `/marketplace/trade?id=${encodeURIComponent(id)}`;
+
+  async function handleTrade() {
+    if (onPurchase) {
+      setIsPurchasing(true);
+      try {
+        const hash = await onPurchase(id);
+        setPurchaseTxHash(hash);
+        setIsPurchaseSuccessOpen(true);
+      } finally {
+        setIsPurchasing(false);
+      }
+    } else {
+      window.location.href = resolvedTradeHref;
+    }
+  }
 
   return (
     <article
@@ -296,13 +318,15 @@ function MarketplaceCardComponent({
                 View
               </button>
 
-              <Link
-                className="focus-ring h-12 text-sm xl:text-base rounded-[14px] inline-flex items-center justify-center gap-1 xl:gap-2.5 font-[650] tracking-[0.01em] select-none text-[#0FF0FC] bg-[#0FF0FC1A] border-[0.56px] border-[#0FF0FC66] transition-[transform,filter] duration-[160ms] ease-[ease] hover:brightness-105 hover:-translate-y-px"
-                href={resolvedTradeHref}
+              <button
+                type="button"
+                onClick={handleTrade}
+                disabled={isPurchasing}
+                className="focus-ring h-12 text-sm xl:text-base rounded-[14px] inline-flex items-center justify-center gap-1 xl:gap-2.5 font-[650] tracking-[0.01em] select-none text-[#0FF0FC] bg-[#0FF0FC1A] border-[0.56px] border-[#0FF0FC66] transition-[transform,filter] duration-[160ms] ease-[ease] hover:brightness-105 hover:-translate-y-px disabled:opacity-50 disabled:pointer-events-none"
                 aria-label={`Trade ${id}`}
               >
-                <DollarSignIcon /> Trade
-              </Link>
+                <DollarSignIcon /> {isPurchasing ? 'Processing…' : 'Trade'}
+              </button>
             </div>
           </>
         ) : (
@@ -358,6 +382,19 @@ function MarketplaceCardComponent({
           },
         ]}
         TypeIcon={TypeIcon}
+      />
+
+      <PurchaseSuccessModal
+        isOpen={isPurchaseSuccessOpen}
+        onClose={() => setIsPurchaseSuccessOpen(false)}
+        commitmentId={id}
+        commitmentType={`${type} Commitment`}
+        pricePaid={price}
+        txHash={purchaseTxHash}
+        onViewCommitments={() => {
+          setIsPurchaseSuccessOpen(false);
+          window.location.href = '/commitments';
+        }}
       />
     </article>
   );

--- a/src/components/__tests__/MarketplaceKeyboardA11y.test.tsx
+++ b/src/components/__tests__/MarketplaceKeyboardA11y.test.tsx
@@ -186,9 +186,9 @@ describe("Marketplace keyboard accessibility", () => {
     render(<MarketplaceGrid items={[listing]} />);
 
     const viewButton = screen.getByRole("button", { name: /view 12/i });
-    const tradeLink = screen.getByRole("link", { name: /trade 12/i });
+    const tradeButton = screen.getByRole("button", { name: /trade 12/i });
 
     expect(viewButton.className).toContain("focus-ring");
-    expect(tradeLink.className).toContain("focus-ring");
+    expect(tradeButton.className).toContain("focus-ring");
   });
 });

--- a/src/components/modals/PurchaseSuccessModal.test.tsx
+++ b/src/components/modals/PurchaseSuccessModal.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import PurchaseSuccessModal from '@/components/modals/PurchaseSuccessModal';
+
+const DEFAULT_PROPS = {
+  isOpen: true,
+  onClose: vi.fn(),
+  commitmentId: '42',
+  commitmentType: 'Safe Commitment',
+  pricePaid: '1,000 USDC',
+  onViewCommitments: vi.fn(),
+};
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof PurchaseSuccessModal>> = {},
+) {
+  const props = { ...DEFAULT_PROPS, ...overrides };
+  const view = render(<PurchaseSuccessModal {...props} />);
+  return { props, ...view };
+}
+
+describe('PurchaseSuccessModal', () => {
+  beforeEach(() => {
+    // Mock clipboard API — navigator.clipboard is a non-writable getter so we
+    // must use defineProperty rather than Object.assign.
+    const clipboardMock = { writeText: vi.fn().mockResolvedValue(undefined) };
+    Object.defineProperty(navigator, 'clipboard', {
+      value: clipboardMock,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  it('renders nothing when isOpen is false', () => {
+    renderModal({ isOpen: false });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders the dialog when isOpen is true', () => {
+    renderModal();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+  });
+
+  it('shows the success heading', () => {
+    renderModal();
+    expect(screen.getByRole('heading', { name: 'Purchase Successful' })).toBeTruthy();
+  });
+
+  it('displays formatted commitment id', () => {
+    renderModal({ commitmentId: '7' });
+    expect(screen.getByText('#CMT-007')).toBeTruthy();
+  });
+
+  it('displays commitment type', () => {
+    renderModal({ commitmentType: 'Balanced Commitment' });
+    expect(screen.getByText('Balanced Commitment')).toBeTruthy();
+  });
+
+  it('displays price paid', () => {
+    renderModal({ pricePaid: '500 XLM' });
+    expect(screen.getByText('500 XLM')).toBeTruthy();
+  });
+
+  // ── Transaction hash ───────────────────────────────────────────────────────
+
+  it('shows truncated tx hash when provided', () => {
+    renderModal({ txHash: 'abcdefgh12345678ijklmnop87654321' });
+    // truncated: first 8 + '...' + last 8
+    expect(screen.getByText('abcdefgh...87654321')).toBeTruthy();
+  });
+
+  it('shows hash unavailable message when txHash is undefined', () => {
+    renderModal({ txHash: undefined });
+    expect(screen.getByText('Transaction hash unavailable.')).toBeTruthy();
+  });
+
+  it('shows explorer link when txHash is provided', () => {
+    renderModal({ txHash: 'deadbeef00000000cafebabe11111111' });
+    const link = screen.getByRole('link', { name: /View on Stellar Explorer/i });
+    expect(link).toBeTruthy();
+    expect((link as HTMLAnchorElement).href).toContain('deadbeef00000000cafebabe11111111');
+  });
+
+  it('does not show explorer link when txHash is absent', () => {
+    renderModal({ txHash: undefined });
+    expect(screen.queryByRole('link', { name: /View on Stellar Explorer/i })).toBeNull();
+  });
+
+  // ── Copy hash ──────────────────────────────────────────────────────────────
+
+  it('copy button calls clipboard.writeText with full hash', async () => {
+    const hash = 'fullhashvalue1234567890abcdef00';
+    renderModal({ txHash: hash });
+    fireEvent.click(screen.getByRole('button', { name: 'Copy transaction hash' }));
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(hash);
+    });
+  });
+
+  it('shows "Copied!" status after copy', async () => {
+    renderModal({ txHash: 'abc123def456abc7' });
+    fireEvent.click(screen.getByRole('button', { name: 'Copy transaction hash' }));
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeTruthy();
+      expect(screen.getByRole('status').textContent).toBe('Copied!');
+    });
+  });
+
+  // ── Actions ────────────────────────────────────────────────────────────────
+
+  it('calls onViewCommitments when CTA button is clicked', () => {
+    const onViewCommitments = vi.fn();
+    renderModal({ onViewCommitments });
+    fireEvent.click(screen.getByRole('button', { name: /View in My Commitments/i }));
+    expect(onViewCommitments).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when Close button is clicked', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when X button is clicked', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Focus management ───────────────────────────────────────────────────────
+
+  it('dialog has aria-modal="true"', () => {
+    renderModal();
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('dialog is labelled by heading id', () => {
+    renderModal();
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'aria-labelledby',
+      'purchase-success-title',
+    );
+  });
+
+  it('dialog is described by description id', () => {
+    renderModal();
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'aria-describedby',
+      'purchase-success-description',
+    );
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────────────────
+
+  it('handles short txHash without truncation', () => {
+    renderModal({ txHash: 'short' });
+    expect(screen.getByText('short')).toBeTruthy();
+  });
+
+  it('pads commitment id with leading zeros to 3 digits', () => {
+    renderModal({ commitmentId: '1' });
+    expect(screen.getByText('#CMT-001')).toBeTruthy();
+  });
+
+  it('does not show copy button when txHash is missing', () => {
+    renderModal({ txHash: undefined });
+    expect(screen.queryByRole('button', { name: 'Copy transaction hash' })).toBeNull();
+  });
+});

--- a/src/components/modals/PurchaseSuccessModal.tsx
+++ b/src/components/modals/PurchaseSuccessModal.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import { ArrowRight, CheckCircle, Copy, ExternalLink, X } from 'lucide-react';
+import { Dialog } from '@/components/ui/Dialog';
+
+export interface PurchaseSuccessModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  commitmentId: string;
+  commitmentType: string;
+  pricePaid: string;
+  txHash?: string;
+  onViewCommitments: () => void;
+}
+
+function truncateHash(hash: string) {
+  if (hash.length <= 16) return hash;
+  return `${hash.slice(0, 8)}...${hash.slice(-8)}`;
+}
+
+export default function PurchaseSuccessModal({
+  isOpen,
+  onClose,
+  commitmentId,
+  commitmentType,
+  pricePaid,
+  txHash,
+  onViewCommitments,
+}: PurchaseSuccessModalProps) {
+  const primaryButtonRef = useRef<HTMLButtonElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  function handleCopyHash() {
+    if (!txHash) return;
+    navigator.clipboard.writeText(txHash).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  const explorerUrl = txHash
+    ? `https://stellar.expert/explorer/testnet/tx/${txHash}`
+    : null;
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      initialFocusRef={primaryButtonRef}
+      labelledById="purchase-success-title"
+      describedById="purchase-success-description"
+      className="relative flex max-h-[100dvh] w-full max-w-[540px] flex-col overflow-y-auto rounded-[32px] border border-white/10 bg-[#0A0A0A] shadow-2xl sm:max-h-[90vh]"
+    >
+      <div className="absolute right-6 top-6 z-10">
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 transition-all hover:scale-105 hover:bg-white/10 active:scale-95"
+          aria-label="Close modal"
+        >
+          <X className="h-5 w-5 text-white/50" />
+        </button>
+      </div>
+
+      <div className="flex-1 px-6 pb-10 pt-12 sm:px-10">
+        {/* Header */}
+        <div className="mb-8 flex flex-col items-center">
+          <div className="relative mb-6 h-20 w-20 sm:h-24 sm:w-24">
+            <div className="absolute inset-0 rounded-full bg-[#0FF0FC] opacity-20 blur-2xl animate-pulse" />
+            <div className="relative z-10 flex h-full w-full items-center justify-center rounded-full border-2 border-[#0FF0FC] bg-[#0FF0FC]/10 shadow-[inset_0_0_20px_rgba(15,240,252,0.2)]">
+              <CheckCircle className="h-10 w-10 text-[#0FF0FC] sm:h-12 sm:w-12" strokeWidth={2.5} />
+            </div>
+          </div>
+          <div className="text-center">
+            <h2
+              id="purchase-success-title"
+              className="mb-2 text-[28px] font-bold leading-tight tracking-tight text-white sm:text-[32px]"
+            >
+              Purchase Successful
+            </h2>
+            <p
+              id="purchase-success-description"
+              className="mx-auto max-w-[340px] text-[15px] font-medium leading-relaxed text-white/50 sm:text-[16px]"
+            >
+              You now own this commitment. It has been transferred to your wallet.
+            </p>
+          </div>
+        </div>
+
+        {/* Ownership summary */}
+        <div className="group relative mb-6 overflow-hidden rounded-[24px] border border-white/[0.08] bg-white/[0.03] p-6 transition-colors hover:bg-white/[0.05]">
+          <div className="absolute -mr-12 -mt-12 right-0 top-0 h-24 w-24 rounded-full bg-[#0FF0FC] opacity-[0.02] blur-2xl transition-opacity group-hover:opacity-[0.04]" />
+          <dl className="space-y-3">
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-[13px] font-bold uppercase tracking-[0.15em] text-white/40">
+                Commitment
+              </dt>
+              <dd className="m-0 font-mono text-[14px] font-bold tracking-wider text-[#0FF0FC]">
+                #CMT-{commitmentId.padStart(3, '0')}
+              </dd>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-[13px] font-bold uppercase tracking-[0.15em] text-white/40">
+                Type
+              </dt>
+              <dd className="m-0 text-[14px] font-semibold text-white/90">
+                {commitmentType}
+              </dd>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-[13px] font-bold uppercase tracking-[0.15em] text-white/40">
+                Price Paid
+              </dt>
+              <dd className="m-0 text-[20px] font-bold text-white">
+                {pricePaid}
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        {/* Transaction hash */}
+        {txHash ? (
+          <div className="mb-8 rounded-[16px] border border-white/[0.08] bg-white/[0.03] p-4">
+            <div className="mb-2 text-[12px] font-bold uppercase tracking-[0.15em] text-white/40">
+              Transaction Hash
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="flex-1 truncate font-mono text-[13px] text-white/70">
+                {truncateHash(txHash)}
+              </span>
+              <button
+                type="button"
+                onClick={handleCopyHash}
+                aria-label="Copy transaction hash"
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/5 transition-all hover:bg-white/10 active:scale-95"
+              >
+                <Copy className="h-3.5 w-3.5 text-white/50" />
+              </button>
+            </div>
+            {copied && (
+              <p role="status" className="mt-1.5 text-[12px] text-[#0FF0FC]">
+                Copied!
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="mb-8 rounded-[16px] border border-white/[0.06] bg-white/[0.02] p-4 text-[13px] text-white/30">
+            Transaction hash unavailable.
+          </div>
+        )}
+
+        {/* CTAs */}
+        <div className="space-y-3">
+          <button
+            ref={primaryButtonRef}
+            type="button"
+            onClick={onViewCommitments}
+            className="flex w-full items-center justify-center gap-3 rounded-2xl bg-[#0FF0FC] py-4 text-[16px] font-bold text-black transition-all shadow-[0_0_30px_rgba(15,240,252,0.3)] hover:scale-[1.01] hover:bg-[#0FF0FC]/90 active:scale-[0.98]"
+          >
+            View in My Commitments
+            <ArrowRight className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-full rounded-2xl border border-white/10 bg-white/5 py-3.5 text-[14px] font-bold text-white transition-all hover:bg-white/10 active:scale-[0.98]"
+          >
+            Close
+          </button>
+        </div>
+
+        {/* Explorer link */}
+        {explorerUrl && (
+          <div className="mt-8 border-t border-white/5 pt-6">
+            <a
+              href={explorerUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex w-full items-center justify-center gap-2 py-1 text-[13px] text-white/30 transition-colors hover:text-[#0FF0FC]"
+            >
+              View on Stellar Explorer
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </div>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/tests/components/MarketplaceGrid.test.tsx
+++ b/tests/components/MarketplaceGrid.test.tsx
@@ -47,10 +47,7 @@ describe('MarketplaceGrid', () => {
     expect(within(grid).getByRole('article', { name: /commitment 8/i })).toBeInTheDocument();
     expect(screen.getByText('#CMT-007')).toBeInTheDocument();
     expect(screen.getByText('$10,000')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /trade 7/i })).toHaveAttribute(
-      'href',
-      '/marketplace/trade?id=7',
-    );
+    expect(screen.getByRole('button', { name: /trade 7/i })).toBeInTheDocument();
     expect(screen.getByText('Not for sale')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

Closes #714

Adds a purchase-success modal that closes the purchase loop after a marketplace transaction, showing the buyer a clear confirmation with ownership details and next-step actions.

## Changes

### New
- `src/components/modals/PurchaseSuccessModal.tsx` — Dialog-based modal matching the visual language of `CommitmentCreatedModal`
  - Displays: commitment id, type, price paid, tx hash (truncated + clipboard copy), Stellar Explorer link
  - Handles missing tx hash gracefully
  - Accessible: focus trap, `aria-modal`, `aria-labelledby`/`aria-describedby`, `role="status"` live region for copy feedback
- `src/components/modals/PurchaseSuccessModal.test.tsx` — 21 RTL tests
- `docs/PURCHASE_SUCCESS.md`

### Modified
- `src/components/MarketplaceCard.tsx` — adds optional `onPurchase` prop; Trade button calls `onPurchase` and opens success modal, falls back to `window.location.href` navigation when no handler provided
- `tests/components/MarketplaceGrid.test.tsx` + `MarketplaceKeyboardA11y.test.tsx` — updated Trade assertions from `link` to `button` role

## Testing

- 21/21 new `PurchaseSuccessModal` tests pass
- 9/9 `MarketplaceGrid` + `MarketplaceKeyboardA11y` tests pass (no regressions)
- All pre-existing failures are unrelated to this feature