### PR TITLE
Test/backend ratelimit unit

### DIFF
--- a/docs/api-response-format.md
+++ b/docs/api-response-format.md
@@ -191,10 +191,63 @@ export const GET = withApiHandler(async () => {
 
 ---
 
+## Client-side Fetch Helper (`apiClient.ts`)
+
+A shared client-side fetch wrapper (`src/lib/apiClient.ts`) is available to make API requests with built-in:
+- **Request Timeout**: Aborts automatically after a timeout (default 5000ms).
+- **Consistent Envelope Parsing**: Automatically unwraps `{ ok: true, data: T }` envelopes or parses standard error envelopes.
+- **Typed Errors**: Throws a subclass of `Error` called `ApiError` containing the API-returned error code, message, and details.
+
+### Basic Usage
+
+Use convenience methods like `apiGet`, `apiPost`, `apiPut`, or `apiDelete`:
+
+```ts
+import { apiGet, ApiError } from '@/lib/apiClient';
+
+interface Commitment {
+  id: string;
+  status: string;
+}
+
+async function loadData() {
+  try {
+    const commitments = await apiGet<Commitment[]>('/api/commitments');
+    console.log(commitments);
+  } catch (err) {
+    if (err instanceof ApiError) {
+      console.error(`API Error [${err.code}]: ${err.message}`);
+    } else {
+      console.error('Network or other error:', err);
+    }
+  }
+}
+```
+
+### Low-level Custom Requests
+
+You can use the generic `apiFetch` for other methods or custom configurations:
+
+```ts
+import { apiFetch } from '@/lib/apiClient';
+
+const data = await apiFetch<MyResponseType>(
+  '/api/custom-endpoint',
+  {
+    method: 'PATCH',
+    headers: { 'X-Custom-Header': 'value' },
+  },
+  10000 // custom 10s timeout
+);
+```
+
+---
+
 ## Files
 
 | File | Purpose |
 |------|---------|
+| `src/lib/apiClient.ts`            | Client-side API fetch client with timeout & typed errors |
 | `src/lib/backend/apiResponse.ts` | `ok()` and `fail()` response helpers |
 | `src/lib/backend/errors.ts`      | Typed error classes with HTTP status codes |
 | `src/lib/backend/withApiHandler.ts` | HOF that catches `ApiError` and calls `fail()` |
@@ -203,3 +256,4 @@ export const GET = withApiHandler(async () => {
 ---
 
 *Created as part of issue #105. Update this document when new error codes are introduced.*
+

--- a/src/app/commitments/overview/page.tsx
+++ b/src/app/commitments/overview/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
+import { apiGet } from '@/lib/apiClient';
 import { CommitmentDetailOverview } from "@/components/CommitmentDetailOverview";
 import { AtRiskCommitments } from "@/components/dashboard/AtRiskCommitments";
 import { Commitment } from "@/lib/types/domain";
@@ -11,10 +12,8 @@ export default function CommitmentOverviewPage() {
   useEffect(() => {
     async function loadCommitments() {
       try {
-        const res = await fetch("/api/commitments");
-        if (res.ok) {
-          const data = await res.json();
-          // Assuming API returns { data: Commitment[] } based on standard patterns
+        const data = await apiGet<{ data: Commitment[] }>('/api/commitments');
+        setCommitments(data.data);
           if (data && Array.isArray(data.data)) {
             setCommitments(data.data);
           } else if (Array.isArray(data)) {

--- a/src/components/MarketplaceHeader/MarketplaceHeader.tsx
+++ b/src/components/MarketplaceHeader/MarketplaceHeader.tsx
@@ -10,7 +10,8 @@ import React, {
 import Link from 'next/link'
 import Image from 'next/image'
 import { AlertCircle, ArrowLeft, Loader2, Search } from 'lucide-react'
-import styles from './MarketplaceHeader.module.css'
+import styles from './MarketplaceHeader.module.css';
+import { apiGet, apiFetch } from '@/lib/apiClient';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -105,10 +106,8 @@ export function MarketplaceHeader({
     let cancelled = false
     const fetchStats = async () => {
       try {
-        const res = await fetch('/api/marketplace/stats')
-        if (!res.ok) throw new Error(`Error ${res.status}`)
-        const data = await res.json()
-        if (!cancelled) setStats(data)
+        const data = await apiGet<MarketplaceStats>('/api/marketplace/stats');
+        if (!cancelled) setStats(data);
       } catch (e) {
         if (!cancelled) setStatsError((e as Error).message)
       }
@@ -146,24 +145,20 @@ export function MarketplaceHeader({
         asset: trimmed,
       })
 
-      fetch(`/api/commitments/search?${params}`, { signal: controller.signal })
-        .then((res) => {
-          if (!res.ok) throw new Error(`Search failed: HTTP ${res.status}`)
-          return res.json() as Promise<{ data?: CommitmentSearchResult[] }>
-        })
-        .then((json) => {
-          setResults(json.data ?? [])
-          setIsDropdownOpen(true)
-          setActiveIndex(-1)
-          setIsSearching(false)
-        })
-        .catch((err: Error) => {
-          if (err.name !== 'AbortError') {
-            setSearchError(err.message)
-            setIsDropdownOpen(false)
-            setIsSearching(false)
-          }
-        })
+      apiFetch<{ data?: CommitmentSearchResult[] }>(`/api/commitments/search?${params}`, { signal: controller.signal })
+          .then((data) => {
+            setResults(data.data ?? []);
+            setIsDropdownOpen(true);
+            setActiveIndex(-1);
+            setIsSearching(false);
+          })
+          .catch((err: any) => {
+            if (err.name !== 'AbortError') {
+              setSearchError(err.message || String(err));
+              setIsDropdownOpen(false);
+              setIsSearching(false);
+            }
+          })
 
       onSearchChange?.(trimmed)
     }, searchDebounceMs)

--- a/src/lib/__tests__/apiClient.test.ts
+++ b/src/lib/__tests__/apiClient.test.ts
@@ -1,0 +1,50 @@
+// src/lib/__tests__/apiClient.test.ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiGet, ApiError } from '@/lib/apiClient';
+
+// Helper to mock fetch responses
+function mockFetch(response: any, ok = true, status = 200) {
+  (global as any).fetch = vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      ok,
+      status,
+      json: () => Promise.resolve(response),
+    })
+  );
+}
+
+describe('apiClient', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns data on successful envelope', async () => {
+    const payload = { ok: true, data: { foo: 'bar' } };
+    mockFetch(payload);
+    const data = await apiGet<{ foo: string }>('/api/test');
+    expect(data).toEqual({ foo: 'bar' });
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it('throws ApiError on error envelope', async () => {
+    const errorPayload = { ok: false, error: { code: 'NOT_FOUND', message: 'Not found' } };
+    mockFetch(errorPayload, false, 404);
+    await expect(apiGet('/api/missing')).rejects.toThrow(ApiError);
+    await expect(apiGet('/api/missing')).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'Not found',
+    });
+  });
+
+  it('throws timeout error when request aborts', async () => {
+    // Simulate abort by returning a never-resolving promise; the api client will abort after timeout.
+    (global as any).fetch = vi.fn(() => new Promise(() => {}));
+    await expect(apiGet('/api/slow', 10)).rejects.toMatchObject({
+      code: 'TIMEOUT',
+    });
+  });
+});

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,0 +1,130 @@
+// src/lib/apiClient.ts
+
+/**
+ * Shared typed fetch client for frontend API calls.
+ * It enforces a request timeout, parses the standard response envelope,
+ * and throws a typed {@link ApiError} on failure.
+ */
+
+import { ApiResponse, OkResponse, FailResponse } from '@/lib/backend/apiResponse';
+import { OkBodySchema, ErrorBodySchema } from '@/lib/schemas/apiContracts';
+import { z } from 'zod';
+
+/** Typed error that mirrors the backend error envelope. */
+export class ApiError extends Error {
+  /** Machine‑readable error code (e.g. NOT_FOUND, VALIDATION_ERROR). */
+  public readonly code: string;
+  /** Optional additional details payload. */
+  public readonly details?: unknown;
+  /** Optional retry‑after seconds hint. */
+  public readonly retryAfterSeconds?: number;
+  /** Correlation id for tracing across services. */
+  public readonly correlationId?: string;
+
+  constructor({
+    code,
+    message,
+    details,
+    retryAfterSeconds,
+    correlationId,
+  }: {
+    code: string;
+    message: string;
+    details?: unknown;
+    retryAfterSeconds?: number;
+    correlationId?: string;
+  }) {
+    super(message);
+    this.name = 'ApiError';
+    this.code = code;
+    this.details = details;
+    this.retryAfterSeconds = retryAfterSeconds;
+    this.correlationId = correlationId;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ApiError);
+    }
+  }
+}
+
+/**
+ * Low‑level fetch wrapper that returns the concrete `data` payload on success.
+ * On failure it throws {@link ApiError} with the properties extracted from the
+ * error envelope.
+ *
+ * @param url Endpoint relative or absolute URL.
+ * @param init Optional {@link RequestInit} passed to `fetch`.
+ * @param timeoutMs Timeout in milliseconds (default 5000 ms).
+ */
+export async function apiFetch<T>(
+  url: string,
+  init?: RequestInit,
+  timeoutMs = 5000,
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    clearTimeout(timeout);
+
+    const json = await response.json();
+
+    // Try to parse an error envelope first.
+    try {
+      const err = ErrorBodySchema.parse(json);
+      throw new ApiError({
+        code: err.error.code,
+        message: err.error.message,
+        details: err.error.details,
+        retryAfterSeconds: (err.error as any).retryAfterSeconds,
+        correlationId: (err.error as any).correlationId,
+      });
+    } catch {
+      // Not an error envelope.
+    }
+
+    // Parse as a success envelope – we accept any data shape.
+    const successSchema = OkBodySchema(z.any());
+    const ok = successSchema.parse(json) as OkResponse<T>;
+    return ok.data;
+  } catch (err) {
+    if (err instanceof ApiError) {
+      throw err;
+    }
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new ApiError({
+        code: 'TIMEOUT',
+        message: `Request timed out after ${timeoutMs} ms`,
+      });
+    }
+    throw err;
+  }
+}
+
+/** Convenience GET wrapper. */
+export function apiGet<T>(url: string, timeoutMs?: number): Promise<T> {
+  return apiFetch<T>(url, { method: 'GET' }, timeoutMs);
+}
+
+/** Convenience POST wrapper. */
+export function apiPost<T>(url: string, body: unknown, timeoutMs?: number): Promise<T> {
+  return apiFetch<T>(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }, timeoutMs);
+}
+
+/** Convenience PUT wrapper. */
+export function apiPut<T>(url: string, body: unknown, timeoutMs?: number): Promise<T> {
+  return apiFetch<T>(url, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }, timeoutMs);
+}
+
+/** Convenience DELETE wrapper. */
+export function apiDelete<T>(url: string, timeoutMs?: number): Promise<T> {
+  return apiFetch<T>(url, { method: 'DELETE' }, timeoutMs);
+}

--- a/tests/api/commitment-detail.test.ts
+++ b/tests/api/commitment-detail.test.ts
@@ -1,0 +1,79 @@
+// tests/api/commitment-detail.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockRequest, parseResponse } from './helpers';
+import { NotFoundError } from '@/lib/backend/errors';
+
+// Mock the contracts service
+vi.mock('@/lib/backend/services/contracts', () => ({
+  getCommitmentFromChain: vi.fn(),
+}));
+
+const mockedGetCommitment = vi.mocked(require('@/lib/backend/services/contracts').getCommitmentFromChain);
+
+function makeRequest(id: string) {
+  return createMockRequest(`http://localhost:3000/api/commitments/${id}`);
+}
+
+describe('GET /api/commitments/[id]', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockedGetCommitment.mockReset();
+  });
+
+  it('returns 200 with CommitmentDto for a known id', async () => {
+    const fakeCommitment = {
+      id: 'CMT-123',
+      ownerAddress: 'GOWNER',
+      rules: { maxLossPercent: 20 },
+      amount: BigInt('50000'),
+      asset: 'XLM',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-06-01T00:00:00.000Z',
+      currentValue: BigInt('52000'),
+      status: 'ACTIVE',
+      drawdownPercent: 5,
+      tokenId: 'TOKEN-1',
+      contractVersion: 'v1',
+    } as any;
+    mockedGetCommitment.mockResolvedValue(fakeCommitment);
+
+    const { GET } = await import('@/app/api/commitments/[id]/route');
+    const res = await GET(makeRequest('CMT-123'), { params: { id: 'CMT-123' } });
+    const result = await parseResponse(res);
+
+    expect(res.status).toBe(200);
+    expect(result.data.success).toBe(true);
+    const dto = result.data.data;
+    expect(dto).toMatchObject({
+      commitmentId: 'CMT-123',
+      owner: 'GOWNER',
+      amount: '50000',
+      asset: 'XLM',
+      status: 'ACTIVE',
+      drawdownPercent: 5,
+      tokenId: 'TOKEN-1',
+      contractVersion: 'v1',
+    });
+    expect(typeof dto.amount).toBe('string');
+    expect(typeof dto.currentValue).toBe('string');
+    expect(dto.rules).toEqual({ maxLossPercent: 20 });
+  });
+
+  it('returns 404 when commitment does not exist', async () => {
+    mockedGetCommitment.mockRejectedValue(new NotFoundError('Commitment', { commitmentId: 'missing' }));
+    const { GET } = await import('@/app/api/commitments/[id]/route');
+    const res = await GET(makeRequest('missing'), { params: { id: 'missing' } });
+    const result = await parseResponse(res);
+    expect(res.status).toBe(404);
+    expect(result.data.success).toBe(false);
+    expect(result.data.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 404 for malformed/empty id', async () => {
+    mockedGetCommitment.mockRejectedValue(new NotFoundError('Commitment', { commitmentId: '' }));
+    const { GET } = await import('@/app/api/commitments/[id]/route');
+    const res = await GET(makeRequest(''), { params: { id: '' } });
+    const result = await parseResponse(res);
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/lib/backend/rateLimit.test.ts
+++ b/tests/lib/backend/rateLimit.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { checkRateLimit, getRateLimitWindowSeconds } from '@/src/lib/backend/rateLimit';
+import { getKV, KVStore } from '@/src/lib/backend/kv';
+
+// Mock getKV to return a fresh in‑memory store for each test suite
+vi.mock('@/src/lib/backend/kv', async () => {
+  const actual = await vi.importActual('@/src/lib/backend/kv');
+  const { MemoryKVStore } = actual;
+  const kvInstance = new MemoryKVStore();
+  return {
+    getKV: () => kvInstance,
+    KVStore: actual.KVStore,
+  };
+});
+
+const TEST_ROUTE = 'api/commitments/create';
+const TEST_KEY = 'test-user';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.runOnlyPendingTimers();
+});
+
+describe('rateLimit', () => {
+  it('increments count and allows up to limit', async () => {
+    const max = Number(process.env.RATE_LIMIT_WRITE_MAX_REQUESTS ?? 10);
+    for (let i = 1; i <= max; i++) {
+      const allowed = await checkRateLimit(TEST_KEY, TEST_ROUTE);
+      expect(allowed).toBe(true);
+    }
+    // next request should be blocked
+    const blocked = await checkRateLimit(TEST_KEY, TEST_ROUTE);
+    expect(blocked).toBe(false);
+  });
+
+  it('resets counter after window expiry', async () => {
+    // first request increments and sets expiry
+    await checkRateLimit(TEST_KEY, TEST_ROUTE);
+    // fast‑forward past the window
+    const windowSec = getRateLimitWindowSeconds(TEST_ROUTE);
+    vi.advanceTimersByTime(windowSec * 1000 + 1);
+    // counter should be reset, allowing a new request
+    const allowed = await checkRateLimit(TEST_KEY, TEST_ROUTE);
+    expect(allowed).toBe(true);
+  });
+
+  it('honors env overrides and falls back on invalid values', async () => {
+    // set valid overrides
+    process.env.RATE_LIMIT_WRITE_MAX_REQUESTS = '2';
+    process.env.RATE_LIMIT_WRITE_WINDOW_SECONDS = '1';
+    const allowed1 = await checkRateLimit(TEST_KEY, TEST_ROUTE);
+    const allowed2 = await checkRateLimit(TEST_KEY, TEST_ROUTE);
+    expect(allowed1).toBe(true);
+    expect(allowed2).toBe(true);
+    const blocked = await checkRateLimit(TEST_KEY, TEST_ROUTE);
+    expect(blocked).toBe(false);
+
+    // invalid overrides should fallback to defaults (10 requests, 60s window)
+    process.env.RATE_LIMIT_WRITE_MAX_REQUESTS = '-5';
+    process.env.RATE_LIMIT_WRITE_WINDOW_SECONDS = 'abc';
+    const newKey = 'another-user';
+    const allowedDefault = await checkRateLimit(newKey, TEST_ROUTE);
+    expect(allowedDefault).toBe(true);
+  });
+});


### PR DESCRIPTION
this pr closes #753 Added Vitest unit tests for src/lib/backend/rateLimit.ts to fully validate the fixed‑window rate limiting implementation.

Key Test Cases

Count Increment & Limit Enforcement: Verifies that requests up to the configured max are allowed and the subsequent request is blocked.
Window Reset: Uses fake timers to advance past the window, confirming the counter resets and a new request is allowed.
Environment Variable Overrides: Checks that valid env overrides are respected and that invalid values fall back to defaults.