### PR TITLE
refactor: add shared EmptyState primitive and migrate grids and panels (#816)

### DIFF
--- a/docs/FRONTEND_ARCHITECTURE.md
+++ b/docs/FRONTEND_ARCHITECTURE.md
@@ -238,6 +238,7 @@ Component file convention: shared React components in `src/` should use TypeScri
 
 | Component | File | Usage |
 |-----------|------|-------|
+| `EmptyState` | `src/components/ui/EmptyState.tsx` | Shared empty-state primitive used by `MyCommitmentsGrid`, `MarketplaceGrid`, `RecentAttestationsPanel`; accepts `title`, `description`, `icon`, `cta` (href or onClick) |
 | `ErrorLayout` | `src/components/ErrorLayout.tsx` | 500, 404, network-error, transaction-error pages |
 | `ErrorButton` | `src/components/ErrorButton.tsx` | Buttons on all error pages (supports `href`, `onClick`, `isExternal`) |
 | `Skeleton` | `src/components/Skeleton.tsx` | Generic shimmer placeholder |

--- a/src/components/MarketplaceGrid.tsx
+++ b/src/components/MarketplaceGrid.tsx
@@ -1,5 +1,6 @@
 import type { MarketplaceCardProps } from './MarketplaceCard'
 import { MarketplaceCard } from './MarketplaceCard'
+import { EmptyState } from '@/components/ui/EmptyState'
 
 export interface MarketplaceGridProps {
   items: MarketplaceCardProps[]
@@ -9,18 +10,11 @@ export function MarketplaceGrid({ items }: MarketplaceGridProps) {
   if (!items || items.length === 0) {
     return (
       <section className="mt-10" aria-label="Marketplace listings">
-        <div
-          id="marketplace-empty-state"
-          tabIndex={-1}
-          className="focus-ring rounded-[20px] px-6 py-8 text-center border border-[rgba(255,255,255,0.12)] bg-[radial-gradient(140%_140%_at_0%_0%,rgba(255,255,255,0.06),rgba(255,255,255,0.01)_65%),rgba(0,0,0,0.45)] shadow-[0_18px_45px_rgba(0,0,0,0.55),inset_0_0_0_1px_rgba(255,255,255,0.04)]"
-        >
-          <p className="text-[1.1rem] font-semibold mb-2">
-            No commitments available
-          </p>
-          <p className="text-[0.95rem] text-white/70">
-            New offers will appear here once they are listed.
-          </p>
-        </div>
+        <EmptyState
+          title="No commitments available"
+          description="New offers will appear here once they are listed."
+          className="rounded-[20px] px-6 border border-[rgba(255,255,255,0.12)] bg-[radial-gradient(140%_140%_at_0%_0%,rgba(255,255,255,0.06),rgba(255,255,255,0.01)_65%),rgba(0,0,0,0.45)] shadow-[0_18px_45px_rgba(0,0,0,0.55),inset_0_0_0_1px_rgba(255,255,255,0.04)]"
+        />
       </section>
     )
   }

--- a/src/components/MyCommitmentsGrid.tsx
+++ b/src/components/MyCommitmentsGrid.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import MyCommitmentCard from './MyCommitmentCard';
 import { Commitment } from '@/types/commitment';
-import Link from 'next/link';
+import { EmptyState } from '@/components/ui/EmptyState';
 
 interface MyCommitmentsGridProps {
   commitments: Commitment[];
@@ -41,12 +41,11 @@ const MyCommitmentsGrid: React.FC<MyCommitmentsGridProps> = ({
           ))}
         </div>
       ) : (
-        <div className="flex flex-col items-center justify-center gap-4 py-[60px] text-[#94A3B8]">
-          <p>No commitments found matching your filters.</p>
-          <Link href="/create" className="font-semibold text-[#0FF0FC] transition-all duration-200 ease-[ease] border-b border-transparent hover:border-[#0FF0FC]">
-            Create your first commitment
-          </Link>
-        </div>
+        <EmptyState
+          title="No commitments found"
+          description="No commitments found matching your filters."
+          cta={{ label: 'Create your first commitment', href: '/create' }}
+        />
       )}
     </div>
   );

--- a/src/components/RecentAttestationsPanel/RecentAttestationsPanel.tsx
+++ b/src/components/RecentAttestationsPanel/RecentAttestationsPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import styles from './RecentAttestationsPanel.module.css'
+import { EmptyState } from '@/components/ui/EmptyState'
 
 export interface Attestation {
   id: string
@@ -177,8 +178,8 @@ export default function RecentAttestationsPanel({
 
       <div className={styles.attestationsList} role="list">
         {attestations.length === 0 ? (
-          <div className={styles.emptyState} role="listitem">
-            <p>No attestations available</p>
+          <div role="listitem">
+            <EmptyState title="No attestations available" />
           </div>
         ) : (
           attestations.map((attestation) => (

--- a/src/components/ui/EmptyState.test.tsx
+++ b/src/components/ui/EmptyState.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { EmptyState } from './EmptyState'
+
+describe('EmptyState', () => {
+  afterEach(cleanup)
+
+  // ── Rendering ────────────────────────────────────────────────────────────
+
+  it('renders the title', () => {
+    render(<EmptyState title="Nothing here yet" />)
+    expect(screen.getByText('Nothing here yet')).toBeTruthy()
+  })
+
+  it('renders description when provided', () => {
+    render(<EmptyState title="Empty" description="Try adjusting your filters." />)
+    expect(screen.getByText('Try adjusting your filters.')).toBeTruthy()
+  })
+
+  it('does not render a description element when omitted', () => {
+    render(<EmptyState title="Empty" />)
+    expect(screen.queryByText(/Try adjusting/)).toBeNull()
+  })
+
+  it('renders a custom icon', () => {
+    render(<EmptyState title="Empty" icon={<svg data-testid="icon" />} />)
+    expect(screen.getByTestId('icon')).toBeTruthy()
+  })
+
+  it('does not render an icon area when omitted', () => {
+    const { container } = render(<EmptyState title="Empty" />)
+    // No <span> wrapping an icon should exist
+    expect(container.querySelector('span')).toBeNull()
+  })
+
+  // ── Accessibility ─────────────────────────────────────────────────────────
+
+  it('has role="status" on the root element', () => {
+    render(<EmptyState title="No results" />)
+    expect(screen.getByRole('status')).toBeTruthy()
+  })
+
+  it('sets aria-label to the title on the root element', () => {
+    render(<EmptyState title="No commitments found" />)
+    const el = screen.getByRole('status')
+    expect(el.getAttribute('aria-label')).toBe('No commitments found')
+  })
+
+  it('icon wrapper has aria-hidden="true"', () => {
+    render(<EmptyState title="Empty" icon={<svg />} />)
+    const iconWrapper = screen.getByRole('status').querySelector('span')
+    expect(iconWrapper?.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  // ── CTA – href variant (renders as <a>) ───────────────────────────────────
+
+  it('renders a link CTA when href is provided', () => {
+    render(<EmptyState title="Empty" cta={{ label: 'Go home', href: '/' }} />)
+    const link = screen.getByRole('link', { name: 'Go home' })
+    expect(link).toBeTruthy()
+    expect(link.getAttribute('href')).toBe('/')
+  })
+
+  it('does not render a <button> when href CTA is provided', () => {
+    render(<EmptyState title="Empty" cta={{ label: 'Go home', href: '/' }} />)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('uses custom ariaLabel on link CTA', () => {
+    render(
+      <EmptyState
+        title="Empty"
+        cta={{ label: 'Go', href: '/create', ariaLabel: 'Create your first commitment' }}
+      />,
+    )
+    expect(screen.getByRole('link', { name: 'Create your first commitment' })).toBeTruthy()
+  })
+
+  // ── CTA – onClick variant (renders as <button>) ───────────────────────────
+
+  it('renders a button CTA when onClick is provided', () => {
+    const handler = vi.fn()
+    render(<EmptyState title="Empty" cta={{ label: 'Retry', onClick: handler }} />)
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy()
+  })
+
+  it('calls onClick when button CTA is clicked', () => {
+    const handler = vi.fn()
+    render(<EmptyState title="Empty" cta={{ label: 'Retry', onClick: handler }} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses custom ariaLabel on button CTA', () => {
+    render(
+      <EmptyState
+        title="Empty"
+        cta={{ label: 'Retry', onClick: vi.fn(), ariaLabel: 'Retry loading listings' }}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'Retry loading listings' })).toBeTruthy()
+  })
+
+  it('does not render a CTA when none is provided', () => {
+    render(<EmptyState title="Empty" />)
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+
+  // ── className passthrough ─────────────────────────────────────────────────
+
+  it('applies a custom className to the root element', () => {
+    const { container } = render(<EmptyState title="Empty" className="my-custom-class" />)
+    expect(container.firstElementChild?.className).toContain('my-custom-class')
+  })
+})

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+
+export interface EmptyStateCTA {
+  label: string
+  /** Render as an anchor when provided; otherwise renders a <button>. */
+  href?: string
+  onClick?: () => void
+  /** aria-label override for the CTA element. */
+  ariaLabel?: string
+}
+
+export interface EmptyStateProps {
+  /** Short headline, e.g. "No commitments found" */
+  title: string
+  /** Supporting sentence shown below the title. */
+  description?: string
+  /** Optional icon node rendered above the title. */
+  icon?: React.ReactNode
+  /** Optional call-to-action button or link. */
+  cta?: EmptyStateCTA
+  /** Additional className for the root element. */
+  className?: string
+}
+
+const ctaClass =
+  'mt-4 inline-block rounded-xl border border-[rgba(255,255,255,0.15)] px-6 py-3 text-[0.95rem] ' +
+  'bg-[rgba(8,12,16,0.95)] text-white/90 transition-[border-color,box-shadow] duration-200 ease-[ease] ' +
+  'hover:border-[rgba(0,212,255,0.45)] hover:shadow-[0_0_10px_rgba(0,212,255,0.2)] active:scale-95 ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#00d4ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#050505]'
+
+export function EmptyState({ title, description, icon, cta, className = '' }: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      aria-label={title}
+      className={`flex flex-col items-center justify-center gap-3 py-14 text-center text-[#94A3B8] ${className}`}
+    >
+      {icon && <span aria-hidden="true">{icon}</span>}
+
+      <p className="text-[1.05rem] font-semibold text-white">{title}</p>
+
+      {description && <p className="text-[0.95rem] text-white/70 max-w-sm">{description}</p>}
+
+      {cta &&
+        (cta.href ? (
+          <a
+            href={cta.href}
+            aria-label={cta.ariaLabel ?? cta.label}
+            className={ctaClass}
+          >
+            {cta.label}
+          </a>
+        ) : (
+          <button
+            type="button"
+            onClick={cta.onClick}
+            aria-label={cta.ariaLabel ?? cta.label}
+            className={ctaClass}
+          >
+            {cta.label}
+          </button>
+        ))}
+    </div>
+  )
+}
+
+export default EmptyState


### PR DESCRIPTION
## Summary

Closes #816.

Introduces a typed shared `EmptyState` primitive and migrates all ad-hoc empty-state markup to it.

## Changes

- **New** `src/components/ui/EmptyState.tsx` — accepts `title`, `description`, `icon`, `cta` (href link or onClick button), `className`. Uses `role="status"` + `aria-label` for accessibility; icon wrapper gets `aria-hidden`.
- **Migrated** `MyCommitmentsGrid.tsx` — replaced inline div/Link empty block
- **Migrated** `MarketplaceGrid.tsx` — replaced inline glass-card div (visual styling preserved via `className` passthrough)
- **Migrated** `RecentAttestationsPanel/RecentAttestationsPanel.tsx` — replaced `<div className={styles.emptyState}>`
- **Docs** `docs/FRONTEND_ARCHITECTURE.md` — added `EmptyState` to Shared Components table

## Tests

`src/components/ui/EmptyState.test.tsx` — 16 tests:
- Title / description / icon rendering
- `role="status"` and `aria-label` (a11y)
- `aria-hidden` on icon wrapper
- Link CTA (href) and button CTA (onClick) variants
- Custom `ariaLabel` override, no-CTA path, `className` passthrough

All 16 pass. Architecture doc tests (12) also pass.

## Labels
`type-refactor` · `area-frontend`