### PR TITLE
feat: add commitment header copy actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The frontend application for the CommitLabs protocol, a decentralized platform f
 - [Configuration](#configuration)
 - [Project Structure](#project-structure)
 - [Backend API Changelog](#backend-api-changelog)
+- [Commitment Detail Header Copy](docs/DETAIL_HEADER_COPY.md)
 - [Settlement and Early Exit UI Flows](docs/settlement-and-early-exit-flows.md)
 - [Contributing](#contributing)
 - [API Reference](#api-reference)

--- a/docs/DETAIL_HEADER_COPY.md
+++ b/docs/DETAIL_HEADER_COPY.md
@@ -1,0 +1,26 @@
+# Commitment Detail Header Copy and Explorer Actions
+
+`CommitmentDetailHeader` exposes two detail-page affordances for the commitment identifier:
+
+- Copy the full commitment id to the clipboard, even when the visible heading is truncated.
+- Open the commitment in Stellar Explorer through the sanitized `buildExplorerUrl` helper.
+
+## Props
+
+```tsx
+<CommitmentDetailHeader
+  commitmentId="C..."
+  statusLabel="Active"
+  statusVariant="active"
+  onBack={handleBack}
+  onShare={handleShare}
+  explorerId="C..."
+  explorerNetwork="testnet"
+/>
+```
+
+`explorerId` is optional and falls back to `commitmentId`. The explorer link is hidden when the identifier is not valid for a Stellar contract URL. `explorerNetwork` defaults to `testnet`.
+
+## Accessibility
+
+The copy and explorer controls use explicit accessible names, keyboard-focusable native controls, and `noopener noreferrer` for the external link. Copy success is announced through a polite live region and shown as a transient `Copied` label. If the Clipboard API is unavailable, the copy button is disabled instead of throwing.

--- a/src/components/CommitmentDetailHeaderCopy.test.tsx
+++ b/src/components/CommitmentDetailHeaderCopy.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CommitmentDetailHeader from '@/components/Commitmentdetailheader';
+
+const CONTRACT_ID = `C${'A'.repeat(55)}`;
+
+function renderHeader(
+  overrides: Partial<React.ComponentProps<typeof CommitmentDetailHeader>> = {},
+) {
+  return render(
+    <CommitmentDetailHeader
+      commitmentId="internal-commitment-id-that-is-long-enough-to-truncate"
+      statusLabel="Active"
+      statusVariant="active"
+      onBack={vi.fn()}
+      onShare={vi.fn()}
+      explorerId={CONTRACT_ID}
+      {...overrides}
+    />,
+  );
+}
+
+describe('CommitmentDetailHeader copy and explorer actions', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('copies the full commitment id', async () => {
+    const commitmentId = 'commitment-id-with-full-value';
+
+    renderHeader({ commitmentId });
+    fireEvent.click(screen.getByRole('button', { name: 'Copy full commitment id' }));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(commitmentId);
+    });
+  });
+
+  it('shows a transient copied confirmation', async () => {
+    renderHeader();
+    fireEvent.click(screen.getByRole('button', { name: 'Copy full commitment id' }));
+
+    expect(await screen.findByText('Copied')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Commitment id copied');
+  });
+
+  it('builds a sanitized Stellar Explorer link', () => {
+    renderHeader({ explorerNetwork: 'testnet' });
+
+    const link = screen.getByRole('link', { name: 'Open commitment on Stellar Explorer' });
+    expect(link).toHaveAttribute(
+      'href',
+      `https://stellar.expert/explorer/testnet/contract/${CONTRACT_ID}`,
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noreferrer'));
+  });
+
+  it('does not render an explorer link for invalid identifiers', () => {
+    renderHeader({ explorerId: 'not-a-contract-id' });
+
+    expect(screen.queryByRole('link', { name: 'Open commitment on Stellar Explorer' })).toBeNull();
+  });
+
+  it('disables copy gracefully when clipboard is unavailable', () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    renderHeader();
+
+    expect(screen.getByRole('button', { name: 'Copy full commitment id' })).toBeDisabled();
+  });
+});

--- a/src/components/Commitmentdetailheader.tsx
+++ b/src/components/Commitmentdetailheader.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React from 'react';
-import { ArrowLeft, Share2 } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { ArrowLeft, Copy, ExternalLink, Share2 } from 'lucide-react';
+import { buildExplorerUrl, type ExplorerNetwork } from '@/utils/explorerLinks';
 
 interface CommitmentDetailHeaderProps {
     commitmentId: string;
@@ -9,6 +10,8 @@ interface CommitmentDetailHeaderProps {
     statusVariant: 'active' | 'settled' | 'violated' | 'early_exit' | string;
     onBack: () => void;
     onShare: () => void;
+    explorerId?: string | null;
+    explorerNetwork?: ExplorerNetwork;
 }
 
 const statusConfig = {
@@ -44,8 +47,30 @@ export default function CommitmentDetailHeader({
     statusVariant,
     onBack,
     onShare,
+    explorerId,
+    explorerNetwork = 'testnet',
 }: CommitmentDetailHeaderProps) {
     const config = statusConfig[statusVariant as keyof typeof statusConfig] || statusConfig.active;
+    const [copied, setCopied] = useState(false);
+
+    const explorerUrl = useMemo(
+        () => buildExplorerUrl('contract', explorerId ?? commitmentId, explorerNetwork),
+        [commitmentId, explorerId, explorerNetwork],
+    );
+
+    const handleCopyCommitmentId = async () => {
+        if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+            return;
+        }
+
+        try {
+            await navigator.clipboard.writeText(commitmentId);
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 2000);
+        } catch (error) {
+            console.error('Failed to copy commitment id:', error);
+        }
+    };
 
     return (
         <header className="w-full space-y-4 sm:space-y-6">
@@ -64,9 +89,41 @@ export default function CommitmentDetailHeader({
                 {/* Left Section: ID and Status */}
                 <div className="flex flex-col gap-3">
                     {/* Commitment ID */}
-                    <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold font-mono uppercase tracking-tight text-[#f5f5f7]">
-                        {commitmentId}
-                    </h1>
+                    <div className="flex flex-col gap-2">
+                        <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold font-mono uppercase tracking-tight text-[#f5f5f7] truncate max-w-full">
+                            {commitmentId}
+                        </h1>
+
+                        <div className="flex flex-wrap items-center gap-2" aria-label="Commitment id actions">
+                            <button
+                                type="button"
+                                onClick={handleCopyCommitmentId}
+                                disabled={typeof navigator !== 'undefined' && !navigator.clipboard?.writeText}
+                                className="group inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-[#0a0a0a] border border-[#222] text-[#99a1af] text-xs font-medium hover:border-[#0ff0fc]/40 hover:text-[#0ff0fc] hover:bg-[#0ff0fc]/5 transition-all duration-200 focus:outline-none focus:border-[#0ff0fc]/60 focus:text-[#0ff0fc] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-[#222] disabled:hover:text-[#99a1af] disabled:hover:bg-[#0a0a0a]"
+                                aria-label="Copy full commitment id"
+                            >
+                                <Copy className="w-3.5 h-3.5" aria-hidden="true" />
+                                <span>{copied ? 'Copied' : 'Copy ID'}</span>
+                            </button>
+
+                            <span className="sr-only" role="status" aria-live="polite">
+                                {copied ? 'Commitment id copied' : ''}
+                            </span>
+
+                            {explorerUrl ? (
+                                <a
+                                    href={explorerUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="group inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-[#0a0a0a] border border-[#222] text-[#99a1af] text-xs font-medium hover:border-[#0ff0fc]/40 hover:text-[#0ff0fc] hover:bg-[#0ff0fc]/5 transition-all duration-200 focus:outline-none focus:border-[#0ff0fc]/60 focus:text-[#0ff0fc]"
+                                    aria-label="Open commitment on Stellar Explorer"
+                                >
+                                    <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
+                                    <span>Explorer</span>
+                                </a>
+                            ) : null}
+                        </div>
+                    </div>
 
                     {/* Status Pill */}
                     <div className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full w-fit ${config.bg} ${config.border} border`}>


### PR DESCRIPTION
Closes #965

## Summary
- adds copy-id and Stellar Explorer affordances to `CommitmentDetailHeader`
- uses the sanitized `buildExplorerUrl` helper with `noopener noreferrer` external links
- adds a transient copied confirmation plus a disabled fallback when Clipboard API is unavailable
- documents the feature/API in `docs/DETAIL_HEADER_COPY.md` and links it from README

## Tests
- `pnpm exec vitest run src/components/CommitmentDetailHeaderCopy.test.tsx` ?
- `pnpm exec eslint src/components/Commitmentdetailheader.tsx src/components/CommitmentDetailHeaderCopy.test.tsx` ?
- `npx tsc --noEmit --pretty false` fails on existing unrelated syntax errors in `src/app/commitments/overview/page.tsx`, `src/components/CreateCommitmentStepSelectType.tsx`, and `src/components/MarketplaceHeader/MarketplaceHeader.tsx` before this change is type-checked globally.