### PR TITLE
docs: add CONTRIBUTING, CODE_OF_CONDUCT, and SECURITY policy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[placeholder@commitlabs.com].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to CommitLabs
+
+First off, thank you for considering contributing to CommitLabs! It's people like you that make this tool great.
+
+Before diving into the code, please read through our [Developer Guide](./DEVELOPER_GUIDE.md) for comprehensive instructions on local setup, coding standards, and system architecture.
+
+## Branching
+1. Fork the repository and clone it locally.
+2. Ensure your fork is synced with the upstream `master` branch.
+3. Create a feature branch off of `master` using standard prefixes: `feat/<description>`, `fix/<description>`, `docs/<description>`, or `test/<description>`.
+
+## Pull Request Flow
+1. Commit your changes logically and with clear, descriptive commit messages.
+2. Push your feature branch to your fork.
+3. Open a Pull Request (PR) against the `master` branch of the upstream repository.
+4. Provide a clear PR description explaining the context, what was changed, and how to verify it.
+5. Wait for a review from the maintainers and address any feedback promptly.
+
+## Test and Coverage Expectations
+- All new features and bug fixes must be accompanied by appropriate tests (Vitest).
+- We require a **minimum of 95% test coverage** on any new or changed logic.
+- Before opening your PR, run tests and check coverage locally using `npm run test:coverage` (or `pnpm test:coverage`).
+- The build, tests, and linters must pass in CI before the PR can be merged.
+
+## 96-Hour Timeframe Convention
+To keep the momentum of the project moving, we enforce a **96-hour timeframe convention**:
+- Once an issue is assigned to you, you are expected to submit a draft or open a PR within 96 hours.
+- If you receive feedback on your PR, please address it within 96 hours.
+- If there is no activity or communication within this window, the issue may be reassigned to another contributor.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The frontend application for the CommitLabs protocol, a decentralized platform f
 - [Project Structure](#project-structure)
 - [Backend API Changelog](#backend-api-changelog)
 - [Settlement and Early Exit UI Flows](docs/settlement-and-early-exit-flows.md)
-- [Contributing](#contributing)
+- [Community & Contributing](#community--contributing)
 - [API Reference](#api-reference)
 - [License](#license)
 
@@ -190,8 +190,6 @@ See [docs/FRONTEND_ARCHITECTURE.md](./docs/FRONTEND_ARCHITECTURE.md) for a
 detailed page→component→API-route map and state/data-flow conventions.
 ```
 
-## 🤝 Contributing
-
 ## Security Headers
 
 This project includes a reusable helper to attach standard security headers to HTTP responses.
@@ -227,10 +225,6 @@ This project includes a reusable helper to attach standard security headers to H
 - **Disabling/Modifying Headers:**
   The `attachSecurityHeaders` function returns the modified `Response` object. You can further modify headers on the returned object if needed, or update the `src/utils/response.ts` file to change default behaviors globally.
 
-## License
-
-We welcome contributions! Please see our [Developer Guide](./DEVELOPER_GUIDE.md) for detailed instructions on coding standards, testing procedures, and the pull request process.
-
 ## 📡 API Reference
 
 A description of the backend endpoints exposed under `/api` can be found in:
@@ -248,9 +242,18 @@ the backend.
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-## 🤝 Contributing
-Fork the repository and clone it to your local machine
-Create a new branch for your changes
-Make and test your updates following the project guidelines
-Commit and push your changes to your fork
-Open a Pull Request with a clear description
+## 🤝 Community & Contributing
+
+We welcome contributions! Please review our community guidelines before getting started:
+
+- **[Contributing Guidelines](./CONTRIBUTING.md)**: Details on branching, PR flow, and test expectations.
+- **[Code of Conduct](./CODE_OF_CONDUCT.md)**: Our expectations for community interactions.
+- **[Security Policy](./SECURITY.md)**: How to report vulnerabilities privately.
+- **[Developer Guide](./DEVELOPER_GUIDE.md)**: Instructions on local setup, testing, and architecture.
+
+### Quick Start
+1. Fork the repository and clone it to your local machine.
+2. Create a new branch for your changes.
+3. Make and test your updates following the project guidelines.
+4. Commit and push your changes to your fork.
+5. Open a Pull Request with a clear description.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+We are committed to resolving security vulnerabilities quickly and carefully. Currently, the following versions of CommitLabs are actively supported with security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+
+*Older versions may not receive security updates. Please ensure you are running the latest version.*
+
+## Reporting a Vulnerability
+
+We take the security of CommitLabs very seriously. If you discover a security vulnerability, please do **not** open a public issue.
+
+Instead, please report it privately to our security team via email:
+**[placeholder: security@commitlabs.com]**
+
+When reporting a vulnerability, please include:
+- A detailed description of the vulnerability and its potential impact.
+- Step-by-step instructions or a proof-of-concept to reproduce the issue.
+- Any suggested mitigations or fixes, if you have them.
+
+### What to Expect
+- We will acknowledge receipt of your vulnerability report within 48 hours.
+- We will provide a status update as we investigate and work on a fix.
+- We will notify you when the vulnerability is patched and a release is available.
+- We kindly ask that you keep the vulnerability confidential until we have published a fix.
+
+Thank you for helping keep the CommitLabs community safe!


### PR DESCRIPTION
## Closes #796

   ### Summary
   This PR adds the missing standard open-source community health files (`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`) and cross-links them in the `README.md`.

   ### What Changed
   - Added `CONTRIBUTING.md` documenting the PR flow, the 95% minimum test coverage rule, and the strict 96-hour timeframe convention.
   - Added `CODE_OF_CONDUCT.md` using the standard Contributor Covenant v2.1 template.
   - Added `SECURITY.md` establishing a vulnerability-disclosure policy and private email channel.
   - Updated `README.md` to cleanly consolidate and cross-link to these new files.

   ### Key Design Decisions & Notes
   - *Note on README cleanup:* I noticed the existing `README.md` had a few scattered and duplicated `## Contributing` and `## License` headers. I took the liberty of cleanly consolidating them into a single `Community & Contributing` section at the bottom for readability.
   - Used a placeholder `[placeholder: security@commitlabs.com]` in `SECURITY.md` and `CODE_OF_CONDUCT.md` per discussion, which may need to be updated to a real inbox by the team.

   ### Acceptance Criteria Checklist
   - [x] Add `CONTRIBUTING.md` (branching, PR flow, coverage, 96-hour timeframe).
   - [x] Add `CODE_OF_CONDUCT.md`.
   - [x] Add `SECURITY.md` with private disclosure channel.
   - [x] Cross-link all three from `README.md`.
   - [x] Ensure `README.md` links resolve properly.
   - [x] Minimum 95% test coverage requirement codified in documentation.

   ### Test Output
   *No new code logic was added in this PR. Markdown files were manually verified and cross-links resolve successfully against the root directory.*

   ### Follow-ups
   - The core team will need to replace the `security@commitlabs.com` placeholder with an active, monitored mailbox.

   ### Security Note
   This PR introduces the formal Vulnerability Disclosure Policy, ensuring ethical hackers have a defined channel to report issues without disclosing them publicly.
