### PR TITLE
feat: add shareable marketplace compare URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This frontend interacts with the CommitLabs Soroban smart contracts to:
 - **Commitment Creation Wizard**: Step-by-step process to configure asset, amount, duration, and risk parameters.
 - **Dashboard**: Real-time visualization of commitment health, including value history, drawdown, and compliance scores.
 - **Marketplace**: Browse and filter active commitments available for purchase.
+- **Shareable Marketplace Comparison**: Persist and share selected marketplace listings with URL-backed compare sets. See [Marketplace Compare Share URLs](docs/COMPARE_SHARE.md).
 - **Wallet Integration**: Connect with Stellar wallets (e.g., Freighter) to sign transactions.
 - **Settlement and Early Exit Flows**: Guided settlement eligibility, settlement success, and early-exit confirmation surfaces backed by preview and execution endpoints. See [Settlement and Early Exit UI Flows](docs/settlement-and-early-exit-flows.md).
 - **Responsive Design**: Optimized for both desktop and mobile devices.

--- a/docs/COMPARE_SHARE.md
+++ b/docs/COMPARE_SHARE.md
@@ -1,0 +1,57 @@
+# Marketplace Compare Share URLs
+
+Marketplace comparison selections are reload-safe and shareable through the
+`compare` query parameter on `/marketplace`.
+
+## Behavior
+
+- `useCompareListings` reads `?compare=001,002` on mount and resolves those ids
+  against the current marketplace listing set.
+- Only listing ids are written to the URL. Full listing payloads remain in
+  component state and `sessionStorage`.
+- Invalid, duplicate, or expired ids are ignored.
+- Restored sets are capped at `MAX_COMPARE_LISTINGS` so shared URLs cannot
+  exceed the same limit enforced by the card UI.
+- When a shared URL restores at least two valid listings, `CompareTray` opens
+  `CompareView` once so the side-by-side view is reproduced deterministically.
+- Removing a listing, toggling a card, or clearing the tray updates the URL
+  immediately with `history.replaceState`.
+
+## Usage
+
+Pass the full set of marketplace listings to the hook so ids from the URL can
+be resolved even when the current page or filters do not show those cards.
+
+```tsx
+const {
+  listings,
+  isPinned,
+  isFull,
+  toggleListing,
+  removeListing,
+  clearAll,
+  restoredFromUrl,
+} = useCompareListings(allMarketplaceListings);
+
+<CompareTray
+  listings={listings}
+  onRemove={removeListing}
+  onClear={clearAll}
+  openOnRestore={restoredFromUrl}
+/>
+```
+
+## Accessibility
+
+The share URL does not introduce extra focus targets. When the comparison view
+opens from a restored URL, it uses the existing modal focus behavior: focus
+moves to the close button, Escape closes the dialog, and focus returns to the
+previous element when possible.
+
+## Tests
+
+Coverage lives in:
+
+- `src/hooks/useCompareListingsShare.test.ts`
+- `src/hooks/useCompareListings.test.ts`
+- `src/components/marketplace/CompareTray.test.tsx`

--- a/docs/FRONTEND_ARCHITECTURE.md
+++ b/docs/FRONTEND_ARCHITECTURE.md
@@ -184,6 +184,7 @@ MarketplaceFilters
 │   └── MarketplaceCard (per item)
 └── MarketplaceResultsLayout  (pagination, view toggle)
 MarketplaceGridSkeleton  (loading)
+CompareTray + CompareView  (URL-restored compare sets via `?compare=`)
 TrustBadge
 ```
 

--- a/docs/MARKETPLACE_COMPARE.md
+++ b/docs/MARKETPLACE_COMPARE.md
@@ -6,14 +6,15 @@ Buyers can pin up to three marketplace listings and open a side-by-side comparis
 
 1. Each grid card exposes a **Compare** toggle in the header.
 2. Pinned listings appear in a fixed bottom **Compare tray** with a count badge.
-3. Click **Compare** in the tray (requires at least two listings) to open the comparison dialog.
-4. Use **Clear** or **Dismiss** to empty the tray, or remove individual pins from the tray chips.
+3. Share or reload `/marketplace?compare=001,002` to restore a saved comparison set.
+4. Click **Compare** in the tray (requires at least two listings) to open the comparison dialog.
+5. Use **Clear** or **Dismiss** to empty the tray, or remove individual pins from the tray chips.
 
 ## Implementation
 
 | Piece | Location |
 |-------|----------|
-| Selection state + session persistence | `src/hooks/useCompareListings.ts` |
+| Selection state + session persistence + URL sync | `src/hooks/useCompareListings.ts` |
 | Bottom tray UI | `src/components/marketplace/CompareTray.tsx` |
 | Side-by-side table | `src/components/marketplace/CompareView.tsx` |
 | Card toggle | `src/components/MarketplaceCard.tsx` |
@@ -23,6 +24,8 @@ Buyers can pin up to three marketplace listings and open a side-by-side comparis
 ## Persistence
 
 Pinned listing payloads are stored in `sessionStorage` under `marketplace-compare-listings`. The set survives filter, sort, and pagination changes within the same browser tab.
+
+The selected ids are also mirrored into the `compare` URL query parameter. See [Marketplace Compare Share URLs](./COMPARE_SHARE.md) for the restore rules, invalid-id handling, and auto-open behavior.
 
 ## Limits and accessibility
 

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -357,7 +357,8 @@ export default function Marketplace() {
     toggleListing,
     removeListing,
     clearAll: clearCompareListings,
-  } = useCompareListings()
+    restoredFromUrl: compareRestoredFromUrl,
+  } = useCompareListings(mockListings)
   const [filters, setFilters] = useState<Filters>({
     sortBy: 'price',
     commitmentType: ['balanced'],
@@ -513,6 +514,7 @@ export default function Marketplace() {
         listings={compareListings}
         onRemove={removeListing}
         onClear={clearCompareListings}
+        openOnRestore={compareRestoredFromUrl}
       />
 
       <style jsx global>{`

--- a/src/components/marketplace/CompareTray.test.tsx
+++ b/src/components/marketplace/CompareTray.test.tsx
@@ -97,6 +97,21 @@ describe('CompareTray', () => {
     expect(screen.getByText('12.5%')).toBeTruthy();
   });
 
+  it('auto-opens comparison view once for restored share URLs', async () => {
+    render(
+      <CompareTray
+        listings={[LISTING_A, LISTING_B]}
+        onRemove={vi.fn()}
+        onClear={vi.fn()}
+        openOnRestore
+      />,
+    );
+
+    expect(
+      await screen.findByRole('dialog', { name: /Compare Listings/i }),
+    ).toBeTruthy();
+  });
+
   it('calls onClear when Clear or Dismiss is clicked', () => {
     const onClear = vi.fn();
     render(

--- a/src/components/marketplace/CompareTray.tsx
+++ b/src/components/marketplace/CompareTray.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { MarketplaceCardProps } from '@/components/MarketplaceCard';
 import { MAX_COMPARE_LISTINGS } from '@/hooks/useCompareListings';
 import { CompareView } from './CompareView';
@@ -9,10 +9,29 @@ interface CompareTrayProps {
   listings: MarketplaceCardProps[];
   onRemove: (id: string) => void;
   onClear: () => void;
+  openOnRestore?: boolean;
 }
 
-export function CompareTray({ listings, onRemove, onClear }: CompareTrayProps) {
+export function CompareTray({
+  listings,
+  onRemove,
+  onClear,
+  openOnRestore = false,
+}: CompareTrayProps) {
   const [isCompareOpen, setIsCompareOpen] = useState(false);
+  const hasAutoOpenedRef = useRef(false);
+
+  useEffect(() => {
+    if (!openOnRestore) {
+      hasAutoOpenedRef.current = false;
+      return;
+    }
+
+    if (hasAutoOpenedRef.current || listings.length < 2) return;
+
+    setIsCompareOpen(true);
+    hasAutoOpenedRef.current = true;
+  }, [listings.length, openOnRestore]);
 
   if (listings.length === 0) {
     return null;

--- a/src/hooks/useCompareListings.test.ts
+++ b/src/hooks/useCompareListings.test.ts
@@ -22,6 +22,7 @@ const makeListing = (id: string): MarketplaceCardProps => ({
 describe('useCompareListings', () => {
   beforeEach(() => {
     sessionStorage.clear();
+    window.history.replaceState(null, '', '/marketplace');
     vi.restoreAllMocks();
   });
 

--- a/src/hooks/useCompareListings.ts
+++ b/src/hooks/useCompareListings.ts
@@ -1,10 +1,61 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MarketplaceCardProps } from '@/components/MarketplaceCard';
 
 export const MAX_COMPARE_LISTINGS = 3;
 const STORAGE_KEY = 'marketplace-compare-listings';
+export const COMPARE_QUERY_PARAM = 'compare';
+
+function uniqueIds(ids: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+
+  for (const id of ids) {
+    const trimmed = id.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    unique.push(trimmed);
+  }
+
+  return unique;
+}
+
+function readUrlListingIds(): string[] {
+  if (typeof window === 'undefined') return [];
+
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get(COMPARE_QUERY_PARAM);
+    if (!raw) return [];
+    return uniqueIds(raw.split(','));
+  } catch {
+    return [];
+  }
+}
+
+function writeUrlListingIds(ids: string[]): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const url = new URL(window.location.href);
+    const cappedIds = uniqueIds(ids).slice(0, MAX_COMPARE_LISTINGS);
+
+    if (cappedIds.length > 0) {
+      url.searchParams.set(COMPARE_QUERY_PARAM, cappedIds.join(','));
+    } else {
+      url.searchParams.delete(COMPARE_QUERY_PARAM);
+    }
+
+    window.history.replaceState(
+      window.history.state,
+      '',
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+  } catch {
+    // URL synchronization should never block comparison selection.
+  }
+}
 
 function readStoredListings(): MarketplaceCardProps[] {
   if (typeof window === 'undefined') return [];
@@ -27,19 +78,74 @@ function writeStoredListings(listings: MarketplaceCardProps[]): void {
   }
 }
 
-export function useCompareListings() {
+function resolveListingsFromIds(
+  ids: string[],
+  listingById: Map<string, MarketplaceCardProps>,
+): MarketplaceCardProps[] {
+  return ids
+    .map((id) => listingById.get(id))
+    .filter((listing): listing is MarketplaceCardProps => Boolean(listing))
+    .slice(0, MAX_COMPARE_LISTINGS);
+}
+
+export function useCompareListings(
+  availableListings: MarketplaceCardProps[] = [],
+) {
   const [listings, setListings] = useState<MarketplaceCardProps[]>([]);
   const [isHydrated, setIsHydrated] = useState(false);
+  const [restoredFromUrl, setRestoredFromUrl] = useState(false);
+  const hasHydratedRef = useRef(false);
+
+  const listingById = useMemo(
+    () => new Map(availableListings.map((listing) => [listing.id, listing])),
+    [availableListings],
+  );
+
+  const hydrateFromCurrentUrl = useCallback(() => {
+    const urlIds = readUrlListingIds();
+
+    if (urlIds.length > 0 && availableListings.length > 0) {
+      const restoredListings = resolveListingsFromIds(urlIds, listingById);
+      setListings(restoredListings);
+      setRestoredFromUrl(restoredListings.length >= 2);
+      setIsHydrated(true);
+      return true;
+    }
+
+    if (urlIds.length === 0) {
+      setListings(readStoredListings());
+      setRestoredFromUrl(false);
+      setIsHydrated(true);
+      return true;
+    }
+
+    return false;
+  }, [availableListings.length, listingById]);
 
   useEffect(() => {
-    setListings(readStoredListings());
-    setIsHydrated(true);
-  }, []);
+    if (hasHydratedRef.current) return;
+
+    if (hydrateFromCurrentUrl()) {
+      hasHydratedRef.current = true;
+    }
+  }, [hydrateFromCurrentUrl]);
 
   useEffect(() => {
     if (!isHydrated) return;
     writeStoredListings(listings);
+    writeUrlListingIds(listings.map((listing) => listing.id));
   }, [listings, isHydrated]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handlePopState = () => {
+      hydrateFromCurrentUrl();
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [hydrateFromCurrentUrl]);
 
   const isPinned = useCallback(
     (id: string) => listings.some((listing) => listing.id === id),
@@ -49,6 +155,7 @@ export function useCompareListings() {
   const isFull = listings.length >= MAX_COMPARE_LISTINGS;
 
   const toggleListing = useCallback((listing: MarketplaceCardProps) => {
+    setRestoredFromUrl(false);
     setListings((current) => {
       const exists = current.some((item) => item.id === listing.id);
       if (exists) {
@@ -62,10 +169,12 @@ export function useCompareListings() {
   }, []);
 
   const removeListing = useCallback((id: string) => {
+    setRestoredFromUrl(false);
     setListings((current) => current.filter((item) => item.id !== id));
   }, []);
 
   const clearAll = useCallback(() => {
+    setRestoredFromUrl(false);
     setListings([]);
   }, []);
 
@@ -78,5 +187,6 @@ export function useCompareListings() {
     clearAll,
     count: listings.length,
     isHydrated,
+    restoredFromUrl,
   };
 }

--- a/src/hooks/useCompareListingsShare.test.ts
+++ b/src/hooks/useCompareListingsShare.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  COMPARE_QUERY_PARAM,
+  MAX_COMPARE_LISTINGS,
+  useCompareListings,
+} from '@/hooks/useCompareListings';
+import type { MarketplaceCardProps } from '@/components/MarketplaceCard';
+
+const makeListing = (id: string): MarketplaceCardProps => ({
+  id,
+  type: 'Balanced',
+  score: 90,
+  amount: '$10,000',
+  duration: '30 days',
+  yield: '5%',
+  maxLoss: '2%',
+  owner: 'GOWNER1234567890',
+  price: '$10,500',
+  forSale: true,
+});
+
+const getCompareParam = () =>
+  new URLSearchParams(window.location.search).get(COMPARE_QUERY_PARAM);
+
+describe('useCompareListings share URL synchronization', () => {
+  const listings = ['001', '002', '003', '004'].map(makeListing);
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    window.history.replaceState(null, '', '/marketplace');
+    vi.restoreAllMocks();
+  });
+
+  it('restores a capped comparison set from the URL and ignores invalid ids', async () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/marketplace?compare=002,missing,001,002,003,004',
+    );
+
+    const { result } = renderHook(() => useCompareListings(listings));
+
+    await vi.waitFor(() => {
+      expect(result.current.isHydrated).toBe(true);
+    });
+
+    expect(result.current.listings.map((listing) => listing.id)).toEqual([
+      '002',
+      '001',
+      '003',
+    ]);
+    expect(result.current.count).toBe(MAX_COMPARE_LISTINGS);
+    expect(result.current.restoredFromUrl).toBe(true);
+    expect(getCompareParam()).toBe('002,001,003');
+  });
+
+  it('keeps the URL in sync while users edit the comparison set', async () => {
+    const { result } = renderHook(() => useCompareListings(listings));
+
+    await vi.waitFor(() => {
+      expect(result.current.isHydrated).toBe(true);
+    });
+
+    act(() => {
+      result.current.toggleListing(listings[0]);
+      result.current.toggleListing(listings[1]);
+    });
+
+    expect(getCompareParam()).toBe('001,002');
+
+    act(() => {
+      result.current.removeListing('001');
+    });
+
+    expect(getCompareParam()).toBe('002');
+
+    act(() => {
+      result.current.clearAll();
+    });
+
+    expect(getCompareParam()).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #933

## Summary
- mirror marketplace compare selections into the `compare` URL query parameter using listing ids only
- restore shared compare URLs against the current marketplace listing set while ignoring invalid/duplicate ids and enforcing the existing cap
- auto-open the side-by-side compare view once when a shared URL restores two or more valid listings
- document the share URL contract and add focused hook/tray coverage

## Tests
- `pnpm exec vitest run src/hooks/useCompareListings.test.ts src/hooks/useCompareListingsShare.test.ts src/components/marketplace/CompareTray.test.tsx`
- `pnpm exec eslint src/hooks/useCompareListings.ts src/hooks/useCompareListings.test.ts src/hooks/useCompareListingsShare.test.ts src/components/marketplace/CompareTray.tsx src/components/marketplace/CompareTray.test.tsx src/app/marketplace/page.tsx`
- `pnpm exec tsc --noEmit --pretty false` *(fails on existing syntax errors in `src/app/commitments/overview/page.tsx`, `src/components/CreateCommitmentStepSelectType.tsx`, and `src/components/MarketplaceHeader/MarketplaceHeader.tsx`)*