### PR TITLE
feat: add structured client error reporting wired into error.tsx

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -364,3 +364,67 @@ The backend source of truth remains `src/lib/backend/errorCodes.ts` and the Soro
 ---
 
 *This document was created as part of issue #133. Update it as new error types are introduced.*
+
+---
+
+## Client Error Reporting
+
+**Reference:** [#792 – Add a client error boundary with structured error reporting](https://github.com/Commitlabs-Org/Commitlabs-Frontend/issues/792)
+
+`src/lib/observability/reportError.ts` centralises client-side error capture into a tested, redaction-aware reporter that is called automatically by the Next.js route error boundary (`src/app/error.tsx`).
+
+### Structured record
+
+Every captured error produces a `ClientErrorRecord`:
+
+```ts
+interface ClientErrorRecord {
+  message: string        // redacted error message
+  digest: string | undefined  // Next.js error digest (if available)
+  route: string          // window.location.pathname at time of error
+  timestamp: string      // ISO 8601 UTC timestamp
+  stack?: string         // stack trace — omitted in production
+}
+```
+
+### Redaction
+
+The `message` field is scanned for `key=value` / `key: value` patterns. Any key matching the sensitive denylist is replaced with `[REDACTED]` before the record leaves the browser.
+
+Sensitive keys: `token`, `authorization`, `password`, `secret`, `key`, `privatekey`, `publickey`, `mnemonic`, `seed`, `auth`, `bearer`, `apikey`, `api_key`, `session`, `cookie`, `csrf`, `signature`, `nonce`.
+
+### Transport (pluggable)
+
+The default transport writes to `console.error`. Replace it before your app mounts with `setErrorTransport`:
+
+```ts
+import { setErrorTransport } from '@/lib/observability/reportError'
+
+// Wire up your observability sink (Sentry, Datadog, custom ingest…)
+setErrorTransport((record) => {
+  fetch('/api/client-errors', {
+    method: 'POST',
+    body: JSON.stringify(record),
+  })
+})
+```
+
+No runtime dependency is added — the transport is a plain function and the default is a console call.
+
+### How it is wired
+
+`src/app/error.tsx` calls `reportError` inside a `useEffect` that re-runs whenever the `error` prop changes:
+
+```ts
+useEffect(() => {
+  reportError(error, window.location.pathname)
+}, [error])
+```
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `src/lib/observability/reportError.ts` | Reporter, `ClientErrorRecord` type, `setErrorTransport` |
+| `src/lib/observability/__tests__/reportError.test.ts` | Unit tests (transport, redaction, stack-trace behaviour) |
+| `src/app/error.tsx` | Route error boundary — calls `reportError` on mount/update |

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import ErrorLayout from '@/components/ErrorLayout'
 import ErrorButton from '@/components/ErrorButton'
+import { reportError } from '@/lib/observability/reportError'
 import styles from './error.module.css'
 
 interface ErrorProps {
@@ -11,6 +12,10 @@ interface ErrorProps {
 }
 
 export default function Error({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    reportError(error, window.location.pathname)
+  }, [error])
+
   const handleRetry = useCallback(() => {
     reset()
   }, [reset])

--- a/src/lib/observability/__tests__/reportError.test.ts
+++ b/src/lib/observability/__tests__/reportError.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  reportError,
+  setErrorTransport,
+  type ClientErrorRecord,
+} from '../reportError'
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeError(message: string, digest?: string): Error & { digest?: string } {
+  const e = new Error(message)
+  if (digest !== undefined) (e as Error & { digest?: string }).digest = digest
+  return e as Error & { digest?: string }
+}
+
+// ─── transport capture ───────────────────────────────────────────────────────
+
+describe('reportError — transport', () => {
+  let captured: ClientErrorRecord[] = []
+
+  beforeEach(() => {
+    captured = []
+    setErrorTransport((r) => captured.push(r))
+  })
+
+  afterEach(() => {
+    // restore default (console) transport
+    setErrorTransport((r) => console.error('[reportError]', r))
+  })
+
+  it('calls the registered transport once per invocation', () => {
+    reportError(makeError('boom'), '/dashboard')
+    expect(captured).toHaveLength(1)
+  })
+
+  it('record contains the expected fields', () => {
+    reportError(makeError('oops', 'abc123'), '/home')
+    const r = captured[0]
+    expect(r.message).toBe('oops')
+    expect(r.digest).toBe('abc123')
+    expect(r.route).toBe('/home')
+    expect(r.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('digest is undefined when not set on the error', () => {
+    reportError(makeError('plain error'), '/page')
+    expect(captured[0].digest).toBeUndefined()
+  })
+
+  it('timestamp is a valid ISO string close to now', () => {
+    const before = Date.now()
+    reportError(makeError('ts check'), '/ts')
+    const after = Date.now()
+    const ts = new Date(captured[0].timestamp).getTime()
+    expect(ts).toBeGreaterThanOrEqual(before)
+    expect(ts).toBeLessThanOrEqual(after)
+  })
+
+  it('falls back to "Unknown error" when message is empty', () => {
+    const e = makeError('')
+    reportError(e, '/')
+    expect(captured[0].message).toBe('Unknown error')
+  })
+
+  it('setErrorTransport replaces the previous transport', () => {
+    const first: ClientErrorRecord[] = []
+    const second: ClientErrorRecord[] = []
+    setErrorTransport((r) => first.push(r))
+    setErrorTransport((r) => second.push(r))
+    reportError(makeError('x'), '/')
+    expect(first).toHaveLength(0)
+    expect(second).toHaveLength(1)
+  })
+})
+
+// ─── redaction ───────────────────────────────────────────────────────────────
+
+describe('reportError — message redaction', () => {
+  let captured: ClientErrorRecord[] = []
+
+  beforeEach(() => {
+    captured = []
+    setErrorTransport((r) => captured.push(r))
+  })
+
+  afterEach(() => {
+    setErrorTransport((r) => console.error('[reportError]', r))
+  })
+
+  const SENSITIVE_PAIRS: [string, string][] = [
+    ['token=abc123', 'token=[REDACTED]'],
+    ['authorization=Bearer xyz', 'authorization=[REDACTED]'],
+    ['password: hunter2', 'password=[REDACTED]'],
+    ['secret=mysecret', 'secret=[REDACTED]'],
+    ['nonce=0xdeadbeef', 'nonce=[REDACTED]'],
+    ['signature=0xabc', 'signature=[REDACTED]'],
+    ['apikey=key123', 'apikey=[REDACTED]'],
+    ['session=sess_abc', 'session=[REDACTED]'],
+    ['cookie=cval', 'cookie=[REDACTED]'],
+    ['csrf=tok', 'csrf=[REDACTED]'],
+  ]
+
+  it.each(SENSITIVE_PAIRS)(
+    'redacts "%s" in message',
+    (input, expected) => {
+      reportError(makeError(input), '/')
+      expect(captured[0].message).toContain(expected)
+    },
+  )
+
+  it('leaves non-sensitive fields untouched', () => {
+    reportError(makeError('route=/api/health status=200'), '/')
+    expect(captured[0].message).toBe('route=/api/health status=200')
+  })
+
+  it('is case-insensitive for key matching', () => {
+    reportError(makeError('TOKEN=abc'), '/')
+    expect(captured[0].message).toContain('[REDACTED]')
+    expect(captured[0].message).not.toContain('abc')
+  })
+
+  it('does not redact values in the route field', () => {
+    reportError(makeError('ok'), '/api?token=should-stay')
+    // route is passed through verbatim — only message is redacted
+    expect(captured[0].route).toBe('/api?token=should-stay')
+  })
+})
+
+// ─── stack trace behaviour ───────────────────────────────────────────────────
+
+describe('reportError — stack trace', () => {
+  let captured: ClientErrorRecord[] = []
+
+  beforeEach(() => {
+    captured = []
+    setErrorTransport((r) => captured.push(r))
+  })
+
+  afterEach(() => {
+    setErrorTransport((r) => console.error('[reportError]', r))
+  })
+
+  it('omits stack in production', () => {
+    const original = process.env.NODE_ENV
+    // @ts-expect-error override read-only for test
+    process.env.NODE_ENV = 'production'
+    reportError(makeError('prod error'), '/')
+    expect(captured[0].stack).toBeUndefined()
+    // @ts-expect-error restore
+    process.env.NODE_ENV = original
+  })
+
+  it('includes stack outside production when present', () => {
+    // NODE_ENV is 'test' in vitest — not 'production'
+    const e = makeError('dev error')
+    reportError(e, '/')
+    if (e.stack) {
+      expect(captured[0].stack).toBeTruthy()
+    }
+  })
+})

--- a/src/lib/observability/reportError.ts
+++ b/src/lib/observability/reportError.ts
@@ -1,0 +1,75 @@
+/**
+ * Client-side structured error reporter.
+ *
+ * Produces a redaction-safe record from a caught Error and emits it through a
+ * pluggable transport (console by default). Wire a custom sink via
+ * `setErrorTransport` before your app mounts — no runtime dependency required.
+ *
+ * @see docs/error-handling.md — "Client Error Reporting"
+ */
+
+/** Sensitive field names that must never appear in a reported record. */
+const SENSITIVE_FIELDS = new Set([
+  'token', 'authorization', 'password', 'secret', 'key', 'privatekey',
+  'publickey', 'mnemonic', 'seed', 'auth', 'bearer', 'apikey', 'api_key',
+  'session', 'cookie', 'csrf', 'signature', 'nonce',
+])
+
+/** A structured, serialisable client error record. */
+export interface ClientErrorRecord {
+  message: string
+  digest: string | undefined
+  route: string
+  timestamp: string
+  /** Stack trace — omitted in production. */
+  stack?: string
+}
+
+/** Transport function type. Receives a finalised record for delivery. */
+export type ErrorTransport = (record: ClientErrorRecord) => void
+
+let transport: ErrorTransport = (record) => {
+  // eslint-disable-next-line no-console
+  console.error('[reportError]', record)
+}
+
+/**
+ * Override the default console transport with a custom sink (e.g. Sentry,
+ * Datadog, a backend ingest endpoint).
+ */
+export function setErrorTransport(fn: ErrorTransport): void {
+  transport = fn
+}
+
+/** Redact a message string by replacing values after sensitive key patterns. */
+function redactMessage(message: string): string {
+  // Replace patterns like "token=<value>" or "password: <value>"
+  return message.replace(
+    /\b([a-z_]+)\s*[=:]\s*\S+/gi,
+    (match, key: string) =>
+      SENSITIVE_FIELDS.has(key.toLowerCase()) ? `${key}=[REDACTED]` : match,
+  )
+}
+
+/**
+ * Build and emit a structured client error record.
+ *
+ * @param error  - The caught Error (from Next.js error boundary props).
+ * @param route  - The pathname where the error occurred (`window.location.pathname`).
+ */
+export function reportError(
+  error: Error & { digest?: string },
+  route: string,
+): void {
+  const record: ClientErrorRecord = {
+    message: redactMessage(error.message || 'Unknown error'),
+    digest: error.digest,
+    route,
+    timestamp: new Date().toISOString(),
+    ...(process.env.NODE_ENV !== 'production' && error.stack
+      ? { stack: error.stack }
+      : {}),
+  }
+
+  transport(record)
+}


### PR DESCRIPTION
## Summary

Closes #792

Centralises client-side error capture into a tested, redaction-aware reporter and wires it into the existing Next.js route error boundary.

## Changes

### `src/lib/observability/reportError.ts` (new)
- Exports `reportError(error, route)` — builds and emits a `ClientErrorRecord` (message, digest, route, timestamp, optional stack).
- Redacts sensitive `key=value` / `key: value` patterns in the message (token, authorization, password, secret, key, privatekey, publickey, mnemonic, seed, auth, bearer, apikey, api_key, session, cookie, csrf, signature, nonce).
- Exports `setErrorTransport` for a pluggable sink (console by default — no runtime dependency added).
- Stack trace included only outside production.

### `src/app/error.tsx` (modified)
- Added `useEffect` that calls `reportError(error, window.location.pathname)` whenever the boundary re-fires.

### `src/lib/observability/__tests__/reportError.test.ts` (new)
- 21 tests covering: transport call count, record fields, digest/timestamp, empty-message fallback, transport replacement, redaction of all 10 sensitive field types, case-insensitive matching, route passthrough, production stack omission, dev stack inclusion.

### `docs/error-handling.md` (extended)
- New **Client Error Reporting** section: `ClientErrorRecord` shape, redaction denylist, transport API, wiring in `error.tsx`, file table.

## Test results

```
Test Files  1 passed (1)
     Tests  21 passed (21)
```

## Merge conflicts
None — only new files and a two-line addition to `error.tsx`.