### PR TITLE
docs: add architecture decision records directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The frontend application for the CommitLabs protocol, a decentralized platform f
 - [Overview](#overview)
 - [Features](#features)
 - [Architecture](#architecture)
+- [Architecture Decision Records](./docs/adr/README.md)
 - [Getting Started](#getting-started)
 - [Configuration](#configuration)
 - [Project Structure](#project-structure)
@@ -49,6 +50,8 @@ The application is built using the **Next.js App Router** architecture.
 For a deep dive into the system design, modules, and data flow, please refer to [ARCHITECTURE.md](./ARCHITECTURE.md).
 
 For a frontend-focused map of pages to components to API routes, plus wallet/auth state flow, see [FRONTEND_ARCHITECTURE.md](./docs/FRONTEND_ARCHITECTURE.md).
+
+For cross-cutting decision history and contributor guidance, see the [Architecture Decision Records](./docs/adr/README.md).
 
 ## 🧪 Testing
 

--- a/docs/adr/0001-cookie-session-auth.md
+++ b/docs/adr/0001-cookie-session-auth.md
@@ -1,0 +1,61 @@
+# ADR 0001: Use Opaque Cookie-Backed Browser Sessions With Synchronizer CSRF Protection
+
+- Status: Accepted
+- Date: 2026-06-28
+- Supersedes: None
+- Superseded by: None
+
+## Context
+
+CommitLabs browser flows need an authenticated session model after wallet
+signature verification. The session model has to work with Next.js route
+handlers, protect browser-originated mutations from CSRF, and leave room for
+non-browser API clients that use bearer tokens instead of cookies.
+
+The existing implementation described in
+[`backend-session-csrf.md`](../backend-session-csrf.md) uses an opaque
+`cl_session` cookie for browser sessions. The server maps that session id to
+session metadata and a CSRF synchronizer token. State-changing browser requests
+send `X-CSRF-Token` and must pass same-origin `Origin` or `Referer` checks when
+the session cookie is present. Requests with a non-empty bearer token skip CSRF
+because they are not using browser cookies as the trust anchor.
+
+## Decision
+
+Use opaque, cookie-backed browser sessions with synchronizer-token CSRF
+protection as the documented browser authentication pattern.
+
+The session cookie is the browser credential. The CSRF token is server-generated
+and sent back to the client after session creation or via the CSRF endpoint.
+Mutating browser requests include both the session cookie and `X-CSRF-Token`.
+API clients that authenticate with `Authorization: Bearer <token>` remain a
+separate path and do not rely on browser cookie semantics.
+
+## Consequences
+
+- Browser mutation routes can share one CSRF enforcement model instead of
+  reimplementing per-route checks.
+- The app avoids storing the primary browser session credential in JavaScript
+  readable storage.
+- Horizontal scaling still requires replacing the in-memory session store with a
+  shared Redis, database, or equivalent store.
+- Contributors changing auth, cookies, CSRF, or protected mutation behavior
+  should update this ADR or add a superseding ADR if the decision changes.
+
+## Alternatives Considered
+
+### JWT Access Token And Refresh Token
+
+JWT access tokens can work well for APIs and edge verification, but they add
+revocation and rotation complexity for the browser session path.
+
+### Stateless Wallet Signatures On Every Mutation
+
+Signing every sensitive request avoids server sessions, but it adds repeated
+wallet prompts and more complex nonce handling for normal app usage.
+
+## References
+
+- [`backend-session-csrf.md`](../backend-session-csrf.md)
+- [`backend-threat-model.md`](../backend-threat-model.md)
+- [`session-implementation.md`](../session-implementation.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,43 @@
+# Architecture Decision Records
+
+This directory captures cross-cutting architecture decisions that affect more
+than one feature, route, or contributor workflow. ADRs explain why a decision
+was made, what tradeoffs were accepted, and what future changes should revisit.
+
+## Index
+
+| ADR | Title | Status |
+| --- | --- | --- |
+| [0001](./0001-cookie-session-auth.md) | Use opaque cookie-backed browser sessions with synchronizer CSRF protection | Accepted |
+
+## When To Add An ADR
+
+Add or update an ADR when a change introduces or revises a project-level
+decision, including:
+
+- authentication, authorization, or session models;
+- persistent storage, cache, or queue choices;
+- rate limiting, API compatibility, observability, or security boundaries;
+- contributor workflows that affect releases, testing, or deployment.
+
+Small component-level implementation details usually do not need an ADR unless
+they create a reusable pattern or constraint for future work.
+
+## Process
+
+1. Copy [template.md](./template.md) to the next numeric filename, for example
+   `0002-short-title.md`.
+2. Start with `Status: Proposed` while the decision is under discussion.
+3. Change the status to `Accepted` when the decision is merged and expected to
+   guide future work.
+4. If a later ADR replaces it, keep the old file and mark it `Superseded`,
+   linking both records in their `Supersedes` or `Superseded by` fields.
+5. Link the ADR from related docs, PRs, or issues so contributors can find the
+   rationale near the implementation details.
+
+## Status Values
+
+- `Proposed` - under discussion or included in an unmerged PR.
+- `Accepted` - current guidance for the codebase.
+- `Deprecated` - still historically useful, but no longer recommended.
+- `Superseded` - replaced by a newer ADR.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,34 @@
+# ADR NNNN: Title
+
+- Status: Proposed
+- Date: YYYY-MM-DD
+- Supersedes: None
+- Superseded by: None
+
+## Context
+
+Describe the problem, constraints, and relevant existing behavior. Link related
+issues, PRs, implementation files, and docs when they help future contributors
+understand the decision.
+
+## Decision
+
+State the chosen approach. Keep this section direct enough that a future PR can
+check whether it still follows the decision.
+
+## Consequences
+
+List the expected benefits, tradeoffs, operational follow-up, and known risks.
+Call out migration or testing expectations when they affect contributors.
+
+## Alternatives Considered
+
+### Alternative Name
+
+Explain why this option was not selected, or when it may become appropriate.
+
+## References
+
+- Related issue or PR
+- Related implementation file
+- Related documentation


### PR DESCRIPTION
## Summary
- add an ADR directory with an index and contributor process
- add a reusable ADR template with status and superseding fields
- seed ADR 0001 documenting the existing opaque cookie session and synchronizer CSRF decision
- link the ADR index from the README architecture section

Closes #1022

## Validation
- `git diff --check HEAD~1..HEAD`
- PowerShell link/file existence check for the new ADR docs
- `pnpm lint` (fails on existing repository lint/parsing issues outside this docs change, including `src/app/commitments/overview/page.tsx`, `src/components/CreateCommitmentStepSelectType.tsx`, and many pre-existing no-explicit-any / unused-var findings)