### PR TITLE
docs: add changelog and release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable frontend changes for CommitLabs are tracked in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+for release labels when a public version is cut.
+
+For backend API breaking changes that may require frontend migration work, see
+[`docs/backend-changelog.md`](./docs/backend-changelog.md). For the release
+process and entry rules, see
+[`docs/RELEASE_PROCESS.md`](./docs/RELEASE_PROCESS.md).
+
+## Unreleased
+
+### Added
+
+- Added the top-level changelog and documented release process.
+
+### Changed
+
+- No frontend runtime changes.
+
+### Fixed
+
+- No fixes yet.
+
+### Security
+
+- No security updates yet.
+
+## 0.1.0 - 2026-02-25
+
+### Added
+
+- Initial CommitLabs frontend baseline.
+- Next.js application shell for liquidity commitment workflows.
+- Vitest-based API route testing setup.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The frontend application for the CommitLabs protocol, a decentralized platform for managing liquidity commitments on the Stellar network. Built with Next.js, TypeScript, and Tailwind CSS.
 
-## 📋 Table of Contents
+## 馃搵 Table of Contents
 
 - [Overview](#overview)
 - [Features](#features)
@@ -10,13 +10,14 @@ The frontend application for the CommitLabs protocol, a decentralized platform f
 - [Getting Started](#getting-started)
 - [Configuration](#configuration)
 - [Project Structure](#project-structure)
+- [Changelog](./CHANGELOG.md)
 - [Backend API Changelog](#backend-api-changelog)
 - [Settlement and Early Exit UI Flows](docs/settlement-and-early-exit-flows.md)
 - [Contributing](#contributing)
 - [API Reference](#api-reference)
 - [License](#license)
 
-## 🔭 Overview
+## 馃敪 Overview
 
 CommitLabs allows users to create, manage, and trade liquidity commitments. These commitments are on-chain contracts that lock assets for a specified duration in exchange for yield, with specific compliance and risk parameters.
 
@@ -26,7 +27,7 @@ This frontend interacts with the CommitLabs Soroban smart contracts to:
 2.  Monitor the health and performance of existing commitments.
 3.  Trade commitments on a secondary marketplace.
 
-## ✨ Features
+## 鉁?Features
 
 - **Commitment Creation Wizard**: Step-by-step process to configure asset, amount, duration, and risk parameters.
 - **Dashboard**: Real-time visualization of commitment health, including value history, drawdown, and compliance scores.
@@ -35,7 +36,7 @@ This frontend interacts with the CommitLabs Soroban smart contracts to:
 - **Settlement and Early Exit Flows**: Guided settlement eligibility, settlement success, and early-exit confirmation surfaces backed by preview and execution endpoints. See [Settlement and Early Exit UI Flows](docs/settlement-and-early-exit-flows.md).
 - **Responsive Design**: Optimized for both desktop and mobile devices.
 
-## 🏗 Architecture
+## 馃彈 Architecture
 
 The application is built using the **Next.js App Router** architecture.
 
@@ -50,7 +51,7 @@ For a deep dive into the system design, modules, and data flow, please refer to 
 
 For a frontend-focused map of pages to components to API routes, plus wallet/auth state flow, see [FRONTEND_ARCHITECTURE.md](./docs/FRONTEND_ARCHITECTURE.md).
 
-## 🧪 Testing
+## 馃И Testing
 
 This project uses **Vitest** for unit and integration testing of API routes.
 
@@ -73,10 +74,10 @@ Tests are organized in the `tests/` directory:
 
 ```
 tests/
-└── api/
-    ├── helpers.ts           # Test utilities and mock request helpers
-    ├── health.test.ts       # Tests for /api/health route
-    └── commitments.test.ts  # Tests for /api/commitments route
+鈹斺攢鈹€ api/
+    鈹溾攢鈹€ helpers.ts           # Test utilities and mock request helpers
+    鈹溾攢鈹€ health.test.ts       # Tests for /api/health route
+    鈹斺攢鈹€ commitments.test.ts  # Tests for /api/commitments route
 ```
 
 ### API Routes
@@ -95,11 +96,13 @@ Tests demonstrate:
 
 To add new API route tests, create a `.test.ts` file in `tests/api/` following the same pattern.
 
-## 🔄 Backend API Changelog
+## 馃攧 Backend API Changelog
 
 Breaking backend API changes are tracked in [docs/backend-changelog.md](./docs/backend-changelog.md). Update this changelog whenever a backend change can break existing frontend integrations.
 
-## 🚀 Getting Started
+Frontend release notes are tracked in [CHANGELOG.md](./CHANGELOG.md), with release and versioning guidance in [docs/RELEASE_PROCESS.md](./docs/RELEASE_PROCESS.md).
+
+## 馃殌 Getting Started
 
 ### Prerequisites
 
@@ -144,7 +147,7 @@ Breaking backend API changes are tracked in [docs/backend-changelog.md](./docs/b
 5.  **Open the application:**
     Visit [http://localhost:3000](http://localhost:3000) in your browser.
 
-## ⚙️ Configuration
+## 鈿欙笍 Configuration
 
 The application requires the following environment variables (defined in `.env`):
 
@@ -167,30 +170,30 @@ Backend API storage uses a provider-agnostic adapter. Configure
 `COMMITLABS_STORAGE_PROVIDER=memory` by default and see
 [docs/backend-storage.md](docs/backend-storage.md) for adapter details.
 
-## 📂 Project Structure
+## 馃搨 Project Structure
 
 ```
 src/
-├── app/                    # Next.js App Router pages and layouts
-│   ├── commitments/        # Dashboard & Commitment Details
-│   ├── create/             # Commitment Creation Wizard
-│   ├── marketplace/        # Marketplace Listing
-│   └── page.tsx            # Landing Page
-├── components/             # Reusable UI components
-│   ├── dashboard/          # Charts and metrics components
-│   ├── modals/             # Global modals (Success, Errors)
-│   └── ...
-├── types/                  # TypeScript interfaces and types
-├── hooks/                  # React hooks (useWallet, etc.)
-├── lib/                    # Backend lib, services, mocks
-├── utils/                  # Utility functions (Soroban, formatting)
-└── ...
+鈹溾攢鈹€ app/                    # Next.js App Router pages and layouts
+鈹?  鈹溾攢鈹€ commitments/        # Dashboard & Commitment Details
+鈹?  鈹溾攢鈹€ create/             # Commitment Creation Wizard
+鈹?  鈹溾攢鈹€ marketplace/        # Marketplace Listing
+鈹?  鈹斺攢鈹€ page.tsx            # Landing Page
+鈹溾攢鈹€ components/             # Reusable UI components
+鈹?  鈹溾攢鈹€ dashboard/          # Charts and metrics components
+鈹?  鈹溾攢鈹€ modals/             # Global modals (Success, Errors)
+鈹?  鈹斺攢鈹€ ...
+鈹溾攢鈹€ types/                  # TypeScript interfaces and types
+鈹溾攢鈹€ hooks/                  # React hooks (useWallet, etc.)
+鈹溾攢鈹€ lib/                    # Backend lib, services, mocks
+鈹溾攢鈹€ utils/                  # Utility functions (Soroban, formatting)
+鈹斺攢鈹€ ...
 
 See [docs/FRONTEND_ARCHITECTURE.md](./docs/FRONTEND_ARCHITECTURE.md) for a
-detailed page→component→API-route map and state/data-flow conventions.
+detailed page鈫抍omponent鈫扐PI-route map and state/data-flow conventions.
 ```
 
-## 🤝 Contributing
+## 馃 Contributing
 
 ## Security Headers
 
@@ -231,7 +234,7 @@ This project includes a reusable helper to attach standard security headers to H
 
 We welcome contributions! Please see our [Developer Guide](./DEVELOPER_GUIDE.md) for detailed instructions on coding standards, testing procedures, and the pull request process.
 
-## 📡 API Reference
+## 馃摗 API Reference
 
 A description of the backend endpoints exposed under `/api` can be found in:
 
@@ -244,11 +247,11 @@ requests/responses.  It is intended for developers building against or testing
 the backend.
 
 
-## 📄 License
+## 馃搫 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-## 🤝 Contributing
+## 馃 Contributing
 Fork the repository and clone it to your local machine
 Create a new branch for your changes
 Make and test your updates following the project guidelines

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,65 @@
+# Release Process
+
+This document describes how frontend releases are prepared, versioned, and
+recorded. It complements the top-level [`CHANGELOG.md`](../CHANGELOG.md) and
+the backend API breaking-change log in
+[`backend-changelog.md`](./backend-changelog.md).
+
+## Versioning
+
+Use Semantic Versioning for public frontend releases:
+
+- `MAJOR` for incompatible app behavior, deployment, or API-consumption changes.
+- `MINOR` for backward-compatible features and user-visible improvements.
+- `PATCH` for backward-compatible fixes, documentation, and maintenance work.
+
+The package version in [`package.json`](../package.json) should match the
+release tag when a versioned frontend release is cut.
+
+## Changelog Entries
+
+Every user-facing, operator-facing, or contributor-facing change should update
+the `Unreleased` section of [`CHANGELOG.md`](../CHANGELOG.md) in the same PR.
+
+Use these categories:
+
+- `Added` for new features, docs, or workflows.
+- `Changed` for behavior or process changes.
+- `Deprecated` for supported but discouraged functionality.
+- `Removed` for deleted functionality.
+- `Fixed` for bug fixes.
+- `Security` for vulnerability fixes or hardening work.
+
+Keep entries concise, written for users and contributors, and link issues or
+PRs when the rationale is not obvious from the entry.
+
+## Backend API Coordination
+
+If a release depends on a backend API breaking change, add or update an entry in
+[`backend-changelog.md`](./backend-changelog.md). The frontend changelog should
+summarize the user-visible impact, while the backend changelog should capture
+the contract change, rollout status, and required migration steps.
+
+## Cutting A Release
+
+1. Confirm the default branch has the intended changes and no release-blocking
+   PRs.
+2. Move completed `Unreleased` entries in `CHANGELOG.md` under the new
+   version heading, for example `## [0.2.0] - YYYY-MM-DD`.
+3. Update `package.json` if the release changes the public frontend version.
+4. Add or update compare links at the bottom of `CHANGELOG.md` when release
+   tags exist.
+5. Run the available validation commands and record any known baseline failures
+   in the release PR.
+6. Open a release PR titled `chore: release vX.Y.Z`.
+7. After merge, create a `vX.Y.Z` tag from the merge commit and publish GitHub
+   release notes using the changelog section as the starting point.
+
+## Pull Request Checklist
+
+- [ ] `CHANGELOG.md` has an `Unreleased` entry or the PR explains why no entry
+      is needed.
+- [ ] Backend API contract changes are reflected in
+      `docs/backend-changelog.md`.
+- [ ] The release type is clear: major, minor, patch, or no release impact.
+- [ ] Validation output is included in the PR description.

--- a/docs/backend-changelog.md
+++ b/docs/backend-changelog.md
@@ -2,6 +2,10 @@
 
 This document tracks **breaking backend API changes** that may impact this frontend. Keep entries brief, actionable, and linked to implementation artifacts.
 
+For frontend release notes and versioning rules, see the top-level
+[`CHANGELOG.md`](../CHANGELOG.md) and the frontend
+[`RELEASE_PROCESS.md`](./RELEASE_PROCESS.md).
+
 ## Purpose
 
 - Provide a single source of truth for backend API breaking changes.
@@ -30,7 +34,7 @@ Add an entry when any backend change can break existing clients, including:
 Copy this block for each new change:
 
 ```md
-## YYYY-MM-DD — <Short Change Title>
+## YYYY-MM-DD 鈥?<Short Change Title>
 
 - **Status:** Planned | Released | Rolled Back
 - **Effective Date:** YYYY-MM-DD
@@ -60,7 +64,7 @@ Copy this block for each new change:
 
 ---
 
-## 2026-02-25 — Backend API changelog process introduced
+## 2026-02-25 鈥?Backend API changelog process introduced
 
 - **Status:** Released
 - **Effective Date:** 2026-02-25
@@ -88,7 +92,7 @@ Copy this block for each new change:
 
 - This is a non-runtime governance entry that establishes the baseline process.
 
-## 2026-02-25 — Initial baseline: no pending breaking backend changes
+## 2026-02-25 鈥?Initial baseline: no pending breaking backend changes
 
 - **Status:** Released
 - **Effective Date:** 2026-02-25
@@ -113,7 +117,7 @@ Copy this block for each new change:
 
 - First true backend contract break after this date must be added as a new dated entry.
 
-## 2026-05-28 — Compliance score scaling consistency fix
+## 2026-05-28 鈥?Compliance score scaling consistency fix
 
 - **Status:** Released
 - **Effective Date:** 2026-05-28
@@ -147,5 +151,5 @@ Copy this block for each new change:
 
 - This fix corrects a data consistency bug where compliance scores were incorrectly displayed
 - The scaling convention is now: divide by 100 on write, multiply by 100 on read
-- Example: Score 85 → 0.85 on-chain → 85 in application (correct round-trip)
+- Example: Score 85 鈫?0.85 on-chain 鈫?85 in application (correct round-trip)
 - Tests verify no float precision loss for typical scores (0, 25, 50, 75, 85, 92, 100)


### PR DESCRIPTION
## Summary
- add a top-level Keep-a-Changelog style `CHANGELOG.md` with an Unreleased section
- document frontend versioning, changelog categories, and release steps in `docs/RELEASE_PROCESS.md`
- cross-link the backend API changelog with the frontend release process
- link the changelog from the README table of contents and backend changelog section

Closes #1024

## Validation
- `git diff --check`
- PowerShell file/link existence check for `CHANGELOG.md`, `docs/RELEASE_PROCESS.md`, and `docs/backend-changelog.md`
- `pnpm lint` (fails on existing repository lint/parsing issues outside this docs change, including `src/app/commitments/overview/page.tsx`, `src/components/CreateCommitmentStepSelectType.tsx`, and many pre-existing no-explicit-any / unused-var findings)