### PR TITLE
feat: centralize focus trap, escape, and scroll-lock in Dialog

### DIFF
--- a/docs/MODAL_SYSTEM.md
+++ b/docs/MODAL_SYSTEM.md
@@ -75,8 +75,15 @@ When building modals, verify the following:
 The following modals have been migrated to the `Dialog` primitive:
 - `CommitmentCreatedModal`
 - `CommitmentDetailsModal`
+- `CommitmentDisputeModal`
 - `SettlementModal`
 - `CommitmentEarlyExitModal`
 - `ExportCommitmentsModal`
 
-Do not reintroduce manual focus or scroll event listeners into these components.
+Do not reintroduce manual focus or scroll event listeners into these components. The `Dialog` primitive automatically guarantees:
+1. Focus trapping (cycles within the active dialog using keyboard Tab/Shift+Tab).
+2. Initial focus on mount (prioritizing the `initialFocusRef` if provided, falling back to the first focusable element, and then the dialog body).
+3. Focus restoration on unmount (returning focus to the previously active element).
+4. Body scroll locking while open.
+5. Sibling root elements accessibility hiding (setting `inert` and `aria-hidden="true"`).
+

--- a/src/components/modals/CommitmentCreatedModal.test.tsx
+++ b/src/components/modals/CommitmentCreatedModal.test.tsx
@@ -230,6 +230,9 @@ describe('CommitmentCreatedModal', () => {
     // Click retry
     fireEvent.click(screen.getByRole('button', { name: 'Retry funding' }));
 
+    // Click fund again since we are back in idle/ready state
+    fireEvent.click(await screen.findByRole('button', { name: 'Fund escrow now' }));
+
     // Retry should go back via idle then fund again → success
     expect(await screen.findByRole('status', { name: /escrow funded successfully/i })).toBeTruthy();
     expect(screen.getByText(/0xretried/i)).toBeTruthy();

--- a/src/components/modals/CommitmentCreatedModal.tsx
+++ b/src/components/modals/CommitmentCreatedModal.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import {
   AlertTriangle,
   ArrowRight,
@@ -12,6 +11,7 @@ import {
   X,
   Zap,
 } from 'lucide-react';
+import { Dialog } from '@/components/ui/Dialog';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -79,55 +79,6 @@ export default function CommitmentCreatedModal({
     }
   }, [isOpen, commitmentId]);
 
-  useEffect(() => {
-    setMounted(true);
-    return () => setMounted(false);
-  }, []);
-
-  // Focus trap + keyboard handling
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose();
-        return;
-      }
-
-      if (event.key !== 'Tab' || !modalRef.current) return;
-
-      const focusableElements = modalRef.current.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-      );
-
-      if (focusableElements.length === 0) return;
-
-      const firstElement = focusableElements[0];
-      const lastElement = focusableElements[focusableElements.length - 1];
-
-      if (event.shiftKey && document.activeElement === firstElement) {
-        event.preventDefault();
-        lastElement.focus();
-      } else if (!event.shiftKey && document.activeElement === lastElement) {
-        event.preventDefault();
-        firstElement.focus();
-      }
-    };
-
-    const focusTimer = window.setTimeout(() => {
-      primaryButtonRef.current?.focus();
-    }, 100);
-
-    document.addEventListener('keydown', handleKeyDown);
-    document.body.style.overflow = 'hidden';
-
-    return () => {
-      window.clearTimeout(focusTimer);
-      document.removeEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = '';
-    };
-  }, [isOpen, onClose]);
-
   // ── Fund handler ─────────────────────────────────────────────────────────────
 
   const handleFund = useCallback(async () => {
@@ -180,16 +131,6 @@ export default function CommitmentCreatedModal({
     setFundStep('idle');
     setFundError(null);
   }, []);
-
-  // ── Render guard ──────────────────────────────────────────────────────────────
-
-  if (!isOpen || !mounted) return null;
-
-  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (event.target === event.currentTarget) {
-      onClose();
-    }
-  };
 
   // ── Sub-views ─────────────────────────────────────────────────────────────────
 
@@ -336,159 +277,153 @@ export default function CommitmentCreatedModal({
 
   // ── Full render ───────────────────────────────────────────────────────────────
 
-  return createPortal(
-    <div
-      className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/80 p-4 backdrop-blur-md animate-in fade-in duration-300"
-      onClick={handleBackdropClick}
-      role="presentation"
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      initialFocusRef={primaryButtonRef}
+      labelledById="commitment-created-title"
+      describedById="commitment-created-description"
+      className="relative flex max-h-[100dvh] w-full max-w-[540px] flex-col overflow-y-auto rounded-[32px] border border-white/10 bg-[#0A0A0A] shadow-2xl sm:max-h-[90vh]"
+      backdropClassName="bg-black/80 p-4 backdrop-blur-md"
     >
-      <div
-        ref={modalRef}
-        className="relative flex max-h-[100dvh] w-full max-w-[540px] flex-col overflow-y-auto rounded-[32px] border border-white/10 bg-[#0A0A0A] shadow-2xl animate-in slide-in-from-bottom-8 duration-500 ease-out sm:max-h-[90vh]"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="commitment-created-title"
-        aria-describedby="commitment-created-description"
-      >
-        {/* Close button */}
-        <div className="absolute right-6 top-6 z-10">
-          <button
-            type="button"
-            onClick={onClose}
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 transition-all hover:scale-105 hover:bg-white/10 active:scale-95"
-            aria-label="Close modal"
-          >
-            <X className="h-5 w-5 text-white/50" />
-          </button>
-        </div>
-
-        <div className="flex-1 px-6 pb-10 pt-12 sm:px-10">
-          {/* Header */}
-          <div className="mb-8 flex flex-col items-center">
-            <div className="relative mb-6 h-20 w-20 sm:h-24 sm:w-24">
-              <div className="absolute inset-0 rounded-full bg-[#0FF0FC] opacity-20 blur-2xl animate-pulse" />
-              <div className="relative z-10 flex h-full w-full items-center justify-center rounded-full border-2 border-[#0FF0FC] bg-[#0FF0FC]/10 shadow-[inset_0_0_20px_rgba(15,240,252,0.2)]">
-                <CheckCircle
-                  className="h-10 w-10 text-[#0FF0FC] sm:h-12 sm:w-12"
-                  strokeWidth={2.5}
-                />
-              </div>
-            </div>
-          </div>
-
-            <div className="text-center">
-              <h2
-                id="commitment-created-title"
-                className="mb-2 text-[28px] font-bold leading-tight tracking-tight text-white sm:text-[32px]"
-              >
-                Commitment Created
-              </h2>
-              <p
-                id="commitment-created-description"
-                className="mx-auto max-w-[340px] text-[15px] font-medium leading-relaxed text-white/50 sm:text-[16px]"
-              >
-                {isFundSuccess
-                  ? 'Your commitment is now active and available in your dashboard.'
-                  : 'Complete the funding step to activate your commitment.'}
-              </p>
-            </div>
-
-          {/* Commitment ID */}
-          <div className="group relative mb-6 overflow-hidden rounded-[24px] border border-white/[0.08] bg-white/[0.03] p-6 text-center transition-colors hover:bg-white/[0.05]">
-            <div className="absolute -mr-12 -mt-12 right-0 top-0 h-24 w-24 rounded-full bg-[#0FF0FC] opacity-[0.02] blur-2xl transition-opacity group-hover:opacity-[0.04]" />
-            <div className="mb-3 ml-1 text-[13px] font-bold uppercase tracking-[0.2em] text-white/40">
-              Commitment ID
-            </div>
-            <div className="break-all rounded-xl border border-white/5 bg-white/5 px-4 py-3 font-mono text-[14px] font-bold tracking-wider text-[#0FF0FC] sm:text-[16px]">
-              {commitmentId}
-            </div>
-          </div>
-
-          {/* Fund step region */}
-          <div className="mb-8">
-            {fundStep === 'idle' && renderFundPrompt()}
-            {fundStep === 'funding' && renderFunding()}
-            {fundStep === 'success' && renderFundSuccess()}
-            {fundStep === 'error' && renderFundError()}
-            {fundStep === 'skipped' && renderSkipped()}
-          </div>
-
-          {/* Next steps — only after successful funding */}
-          {showNextSteps && (
-            <div className="mb-8 lg:px-2">
-              <h3 className="mb-5 ml-1 text-[14px] font-bold uppercase tracking-widest text-white/90">
-                Next Steps
-              </h3>
-              <div className="space-y-4">
-                {nextStepsAfterFund.map((s) => (
-                  <div key={s} className="flex items-start gap-4 p-1">
-                    <div className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-[#0FF0FC]/30 bg-[#0FF0FC]/10">
-                      <CheckCircle className="h-3 w-3 text-[#0FF0FC]" strokeWidth={3} />
-                    </div>
-                    <span className="text-[14px] font-medium leading-relaxed text-white/70 sm:text-[15px]">
-                      {s}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Action buttons */}
-          <div className="space-y-3">
-            {/* "View Commitment" is primary after success or skipped; hidden while funding */}
-            {(isFundSuccess || fundStep === 'skipped') && (
-              <button
-                ref={fundStep !== 'error' && fundStep !== 'idle' ? primaryButtonRef : undefined}
-                type="button"
-                onClick={onViewCommitment}
-                className="flex w-full items-center justify-center gap-3 rounded-2xl bg-[#0FF0FC] py-4 text-[16px] font-bold text-black transition-all shadow-[0_0_30px_rgba(15,240,252,0.3)] hover:scale-[1.01] hover:bg-[#0FF0FC]/90 active:scale-[0.98]"
-                aria-label="View commitment detail"
-              >
-                <Eye className="h-5 w-5" />
-                View Commitment
-              </button>
-            )}
-
-            <div className="grid grid-cols-2 gap-3">
-              <button
-                type="button"
-                onClick={onCreateAnother}
-                disabled={fundStep === 'funding'}
-                className="flex items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 py-3.5 text-[14px] font-bold text-white transition-all hover:bg-white/10 active:scale-[0.98] disabled:pointer-events-none disabled:opacity-40"
-                aria-label="Create another commitment"
-              >
-                <span className="opacity-70">Create Another</span>
-                <ArrowRight className="h-4 w-4" />
-              </button>
-              <button
-                type="button"
-                onClick={onClose}
-                disabled={fundStep === 'funding'}
-                className="rounded-2xl border border-white/10 bg-white/5 py-3.5 text-[14px] font-bold text-white transition-all hover:bg-white/10 active:scale-[0.98] disabled:pointer-events-none disabled:opacity-40"
-                aria-label="Close"
-              >
-                Close
-              </button>
-            </div>
-          </div>
-
-          {onViewOnExplorer && (
-            <div className="mt-8 border-t border-white/5 pt-6">
-              <button
-                type="button"
-                onClick={onViewOnExplorer}
-                className="flex w-full items-center justify-center gap-2 py-1 text-[13px] text-white/30 transition-colors hover:text-[#0FF0FC]"
-                aria-label="View on Stellar Explorer"
-              >
-                View on Stellar Explorer
-                <ExternalLink className="h-3.5 w-3.5" />
-              </button>
-            </div>
-          )}
-        </div>
+      {/* Close button */}
+      <div className="absolute right-6 top-6 z-10">
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 transition-all hover:scale-105 hover:bg-white/10 active:scale-95"
+          aria-label="Close modal"
+        >
+          <X className="h-5 w-5 text-white/50" />
+        </button>
       </div>
-    </div>,
-    document.body,
+
+      <div className="flex-1 px-6 pb-10 pt-12 sm:px-10">
+        {/* Header */}
+        <div className="mb-8 flex flex-col items-center">
+          <div className="relative mb-6 h-20 w-20 sm:h-24 sm:w-24">
+            <div className="absolute inset-0 rounded-full bg-[#0FF0FC] opacity-20 blur-2xl animate-pulse" />
+            <div className="relative z-10 flex h-full w-full items-center justify-center rounded-full border-2 border-[#0FF0FC] bg-[#0FF0FC]/10 shadow-[inset_0_0_20px_rgba(15,240,252,0.2)]">
+              <CheckCircle
+                className="h-10 w-10 text-[#0FF0FC] sm:h-12 sm:w-12"
+                strokeWidth={2.5}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="text-center">
+          <h2
+            id="commitment-created-title"
+            className="mb-2 text-[28px] font-bold leading-tight tracking-tight text-white sm:text-[32px]"
+          >
+            Commitment Created
+          </h2>
+          <p
+            id="commitment-created-description"
+            className="mx-auto max-w-[340px] text-[15px] font-medium leading-relaxed text-white/50 sm:text-[16px]"
+          >
+            {isFundSuccess
+              ? 'Your commitment is now active and available in your dashboard.'
+              : 'Complete the funding step to activate your commitment.'}
+          </p>
+        </div>
+
+        {/* Commitment ID */}
+        <div className="group relative mb-6 overflow-hidden rounded-[24px] border border-white/[0.08] bg-white/[0.03] p-6 text-center transition-colors hover:bg-white/[0.05]">
+          <div className="absolute -mr-12 -mt-12 right-0 top-0 h-24 w-24 rounded-full bg-[#0FF0FC] opacity-[0.02] blur-2xl transition-opacity group-hover:opacity-[0.04]" />
+          <div className="mb-3 ml-1 text-[13px] font-bold uppercase tracking-[0.2em] text-white/40">
+            Commitment ID
+          </div>
+          <div className="break-all rounded-xl border border-white/5 bg-white/5 px-4 py-3 font-mono text-[14px] font-bold tracking-wider text-[#0FF0FC] sm:text-[16px]">
+            {commitmentId}
+          </div>
+        </div>
+
+        {/* Fund step region */}
+        <div className="mb-8">
+          {fundStep === 'idle' && renderFundPrompt()}
+          {fundStep === 'funding' && renderFunding()}
+          {fundStep === 'success' && renderFundSuccess()}
+          {fundStep === 'error' && renderFundError()}
+          {fundStep === 'skipped' && renderSkipped()}
+        </div>
+
+        {/* Next steps — only after successful funding */}
+        {showNextSteps && (
+          <div className="mb-8 lg:px-2">
+            <h3 className="mb-5 ml-1 text-[14px] font-bold uppercase tracking-widest text-white/90">
+              Next Steps
+            </h3>
+            <div className="space-y-4">
+              {nextStepsAfterFund.map((s) => (
+                <div key={s} className="flex items-start gap-4 p-1">
+                  <div className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-[#0FF0FC]/30 bg-[#0FF0FC]/10">
+                    <CheckCircle className="h-3 w-3 text-[#0FF0FC]" strokeWidth={3} />
+                  </div>
+                  <span className="text-[14px] font-medium leading-relaxed text-white/70 sm:text-[15px]">
+                    {s}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Action buttons */}
+        <div className="space-y-3">
+          {/* "View Commitment" is primary after success or skipped; hidden while funding */}
+          {(isFundSuccess || fundStep === 'skipped') && (
+            <button
+              ref={fundStep !== 'error' && fundStep !== 'idle' ? primaryButtonRef : undefined}
+              type="button"
+              onClick={onViewCommitment}
+              className="flex w-full items-center justify-center gap-3 rounded-2xl bg-[#0FF0FC] py-4 text-[16px] font-bold text-black transition-all shadow-[0_0_30px_rgba(15,240,252,0.3)] hover:scale-[1.01] hover:bg-[#0FF0FC]/90 active:scale-[0.98]"
+              aria-label="View commitment detail"
+            >
+              <Eye className="h-5 w-5" />
+              View Commitment
+            </button>
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
+            <button
+              type="button"
+              onClick={onCreateAnother}
+              disabled={fundStep === 'funding'}
+              className="flex items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 py-3.5 text-[14px] font-bold text-white transition-all hover:bg-white/10 active:scale-[0.98] disabled:pointer-events-none disabled:opacity-40"
+              aria-label="Create another commitment"
+            >
+              <span className="opacity-70">Create Another</span>
+              <ArrowRight className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={fundStep === 'funding'}
+              className="rounded-2xl border border-white/10 bg-white/5 py-3.5 text-[14px] font-bold text-white transition-all hover:bg-white/10 active:scale-[0.98] disabled:pointer-events-none disabled:opacity-40"
+              aria-label="Close"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+
+        {onViewOnExplorer && (
+          <div className="mt-8 border-t border-white/5 pt-6">
+            <button
+              type="button"
+              onClick={onViewOnExplorer}
+              className="flex w-full items-center justify-center gap-2 py-1 text-[13px] text-white/30 transition-colors hover:text-[#0FF0FC]"
+              aria-label="View on Stellar Explorer"
+            >
+              View on Stellar Explorer
+              <ExternalLink className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        )}
+      </div>
+    </Dialog>
   );
 }

--- a/src/components/modals/CommitmentDisputeModal.test.tsx
+++ b/src/components/modals/CommitmentDisputeModal.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import CommitmentDisputeModal from '@/components/modals/CommitmentDisputeModal';
+
+const DEFAULT_PROPS = {
+  isOpen: true,
+  commitmentId: 'CMT-TEST1234',
+  onClose: vi.fn(),
+};
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof CommitmentDisputeModal>> = {},
+) {
+  const props = { ...DEFAULT_PROPS, ...overrides };
+  const view = render(<CommitmentDisputeModal {...props} />);
+  return { props, ...view };
+}
+
+describe('CommitmentDisputeModal', () => {
+  beforeEach(() => {
+    // Reset body style
+    document.body.style.overflow = '';
+    // Mock matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    document.body.style.overflow = '';
+  });
+
+  it('does not render when isOpen is false', () => {
+    renderModal({ isOpen: false });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders correctly when isOpen is true', () => {
+    renderModal();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Dispute commitment' })).toBeTruthy();
+    expect(screen.getByText(/CMT-TEST1234/)).toBeTruthy();
+  });
+
+  it('disables the submit button if the reason is empty or whitespace', () => {
+    renderModal();
+    const submitBtn = screen.getByRole('button', { name: /submit dispute/i });
+    expect(submitBtn).toBeDisabled();
+
+    const textarea = screen.getByPlaceholderText(/describe the issue/i);
+    fireEvent.change(textarea, { target: { value: '   ' } });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it('enables the submit button when reason is entered', () => {
+    renderModal();
+    const submitBtn = screen.getByRole('button', { name: /submit dispute/i });
+    const textarea = screen.getByPlaceholderText(/describe the issue/i);
+
+    fireEvent.change(textarea, { target: { value: 'This commitment is invalid' } });
+    expect(submitBtn).not.toBeDisabled();
+  });
+
+  it('submits the dispute successfully', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true }),
+      })
+    );
+
+    renderModal();
+    const textarea = screen.getByPlaceholderText(/describe the issue/i);
+    const submitBtn = screen.getByRole('button', { name: /submit dispute/i });
+
+    fireEvent.change(textarea, { target: { value: 'Some dispute reason' } });
+    fireEvent.click(submitBtn);
+
+    // Should display submitting state
+    expect(screen.getByRole('button', { name: /submitting dispute/i })).toBeTruthy();
+
+    // Wait for success status
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeTruthy();
+      expect(screen.getByText(/dispute submitted/i)).toBeTruthy();
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/commitments/CMT-TEST1234/dispute',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ reason: 'Some dispute reason' }),
+      })
+    );
+  });
+
+  it('handles submission errors from server', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ message: 'Specific dispute submission failure error message' }),
+      })
+    );
+
+    renderModal();
+    const textarea = screen.getByPlaceholderText(/describe the issue/i);
+    const submitBtn = screen.getByRole('button', { name: /submit dispute/i });
+
+    fireEvent.change(textarea, { target: { value: 'Bad reason' } });
+    fireEvent.click(submitBtn);
+
+    // Wait for error alert
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeTruthy();
+      expect(screen.getByText('Specific dispute submission failure error message')).toBeTruthy();
+    });
+  });
+
+  it('handles network error during submission', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network offline')));
+
+    renderModal();
+    const textarea = screen.getByPlaceholderText(/describe the issue/i);
+    const submitBtn = screen.getByRole('button', { name: /submit dispute/i });
+
+    fireEvent.change(textarea, { target: { value: 'Network offline reason' } });
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeTruthy();
+      expect(screen.getByText('Network error. Check your connection and try again.')).toBeTruthy();
+    });
+  });
+
+  it('calls onClose when close button or cancel is clicked', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+
+    // Click Close modal button (X)
+    fireEvent.click(screen.getByRole('button', { name: 'Close dispute modal' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    // Click Cancel button
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('locks body scroll while open', () => {
+    renderModal();
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+});

--- a/src/components/modals/CommitmentDisputeModal.tsx
+++ b/src/components/modals/CommitmentDisputeModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useState } from 'react';
 import { AlertTriangle, Loader2, X } from 'lucide-react';
+import { Dialog } from '@/components/ui/Dialog';
 
 type DisputeStatus = 'idle' | 'submitting' | 'success' | 'error';
 
@@ -11,15 +12,6 @@ interface CommitmentDisputeModalProps {
   onClose: () => void;
 }
 
-const focusableSelector = [
-  'button:not([disabled])',
-  'a[href]',
-  'input:not([disabled])',
-  'select:not([disabled])',
-  'textarea:not([disabled])',
-  '[tabindex]:not([tabindex="-1"])',
-].join(',');
-
 export default function CommitmentDisputeModal({
   isOpen,
   commitmentId,
@@ -27,8 +19,6 @@ export default function CommitmentDisputeModal({
 }: CommitmentDisputeModalProps) {
   const titleId = useId();
   const descriptionId = useId();
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const previousFocusRef = useRef<HTMLElement | null>(null);
   const [status, setStatus] = useState<DisputeStatus>('idle');
   const [reason, setReason] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
@@ -36,24 +26,9 @@ export default function CommitmentDisputeModal({
   useEffect(() => {
     if (!isOpen) return;
 
-    previousFocusRef.current = document.activeElement as HTMLElement | null;
     setStatus('idle');
     setReason('');
     setErrorMessage('');
-
-    const focusDialog = () => {
-      dialogRef.current?.focus();
-    };
-
-    if (typeof window.requestAnimationFrame === 'function') {
-      window.requestAnimationFrame(focusDialog);
-    } else {
-      window.setTimeout(focusDialog, 0);
-    }
-
-    return () => {
-      previousFocusRef.current?.focus?.();
-    };
   }, [isOpen]);
 
   const handleSubmit = useCallback(async () => {
@@ -87,140 +62,106 @@ export default function CommitmentDisputeModal({
     }
   }, [commitmentId, reason]);
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'Escape' && status !== 'submitting') {
-      onClose();
-      return;
-    }
-
-    if (event.key !== 'Tab') return;
-
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    const focusableElements = Array.from(
-      dialog.querySelectorAll<HTMLElement>(focusableSelector)
-    );
-
-    if (focusableElements.length === 0) return;
-
-    const first = focusableElements[0];
-    const last = focusableElements[focusableElements.length - 1];
-
-    if (event.shiftKey && document.activeElement === first) {
-      event.preventDefault();
-      last.focus();
-    } else if (!event.shiftKey && document.activeElement === last) {
-      event.preventDefault();
-      first.focus();
-    }
-  };
-
-  if (!isOpen) return null;
-
   const isSubmitting = status === 'submitting';
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-6">
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        aria-describedby={descriptionId}
-        tabIndex={-1}
-        onKeyDown={handleKeyDown}
-        className="w-full max-w-[520px] rounded-[18px] border border-[#FF8A0433] bg-[#0A0A0A] p-6 text-white shadow-[0_24px_70px_rgba(0,0,0,0.55)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC]"
-      >
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex items-center gap-4">
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-[#FF8A04]/30 bg-[#FF8A04]/10">
-              <AlertTriangle className="h-6 w-6 text-[#FF8A04]" aria-hidden="true" />
-            </div>
-            <div>
-              <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#FF8A04]">
-                Report an issue
-              </p>
-              <h2 id={titleId} className="mt-1 text-2xl font-semibold leading-tight">
-                Dispute commitment
-              </h2>
-            </div>
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      closeOnEscape={status !== 'submitting'}
+      labelledById={titleId}
+      describedById={descriptionId}
+      className="w-full max-w-[520px] rounded-[18px] border border-[#FF8A0433] bg-[#0A0A0A] p-6 text-white shadow-[0_24px_70px_rgba(0,0,0,0.55)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC]"
+      backdropClassName="bg-black/70 px-4 py-6"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-center gap-4">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-[#FF8A04]/30 bg-[#FF8A04]/10">
+            <AlertTriangle className="h-6 w-6 text-[#FF8A04]" aria-hidden="true" />
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={isSubmitting}
-            aria-label="Close dispute modal"
-            className="rounded-full border border-white/10 p-2 text-white/70 transition-colors hover:border-white/30 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC] disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <X size={18} />
-          </button>
-        </div>
-
-        <p id={descriptionId} className="mt-4 text-sm leading-6 text-white/70">
-          Submit a formal dispute for commitment <span className="font-mono text-[#0FF0FC]">{commitmentId}</span>.
-          This action will be recorded on-chain.
-        </p>
-
-        <div className="mt-6">
-          <label htmlFor="dispute-reason" className="block text-sm font-medium text-white/80 mb-2">
-            Reason for dispute
-          </label>
-          <textarea
-            id="dispute-reason"
-            value={reason}
-            onChange={(e) => setReason(e.target.value)}
-            disabled={isSubmitting}
-            rows={4}
-            placeholder="Describe the issue with this commitment..."
-            className="w-full rounded-[14px] border border-white/10 bg-[#050505] px-4 py-3 text-white placeholder:text-white/30 resize-none focus:outline-none focus-visible:ring-2 focus-visible:ring-[#FF8A04] disabled:cursor-not-allowed disabled:opacity-50"
-            autoComplete="off"
-          />
-          <p className="mt-2 text-[12px] text-white/40">
-            The reason must be at least 1 character and at most 500 characters.
-          </p>
-        </div>
-
-        {status === 'success' ? (
-          <div
-            role="status"
-            className="mt-5 flex gap-3 rounded-[14px] border border-[#22C55E33] bg-[#22C55E12] px-4 py-3 text-sm leading-6 text-[#BBF7D0]"
-          >
-            <AlertTriangle className="mt-0.5 shrink-0" size={18} />
-            <span>Dispute submitted. The commitment is now under review.</span>
+          <div>
+            <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#FF8A04]">
+              Report an issue
+            </p>
+            <h2 id={titleId} className="mt-1 text-2xl font-semibold leading-tight">
+              Dispute commitment
+            </h2>
           </div>
-        ) : errorMessage ? (
-          <div
-            role="alert"
-            className="mt-5 flex gap-3 rounded-[14px] border border-[#F9737333] bg-[#F9737312] px-4 py-3 text-sm leading-6 text-[#FECACA]"
-          >
-            <AlertTriangle className="mt-0.5 shrink-0" size={18} />
-            <span>{errorMessage}</span>
-          </div>
-        ) : null}
-
-        <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={isSubmitting}
-            className="rounded-[14px] border border-white/10 px-5 py-3 text-sm font-semibold text-white/80 transition-colors hover:border-white/30 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC] disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {status === 'success' ? 'Close' : 'Cancel'}
-          </button>
-          {status !== 'success' && (
-            <button
-              type="button"
-              onClick={handleSubmit}
-              disabled={isSubmitting || !reason.trim()}
-              className="inline-flex items-center justify-center gap-2 rounded-[14px] border border-[#FF8A0466] bg-[#FF8A041A] px-5 py-3 text-sm font-semibold text-white shadow-[0_0_18px_rgba(255,138,4,0.22)] transition-all hover:bg-[#FF8A0426] hover:shadow-[0_0_24px_rgba(255,138,4,0.34)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#FF8A04] disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {isSubmitting ? <Loader2 className="animate-spin" size={18} /> : <AlertTriangle size={18} />}
-              {isSubmitting ? 'Submitting dispute' : 'Submit dispute'}
-            </button>
-          )}
         </div>
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={isSubmitting}
+          aria-label="Close dispute modal"
+          className="rounded-full border border-white/10 p-2 text-white/70 transition-colors hover:border-white/30 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <X size={18} />
+        </button>
       </div>
-    </div>
+
+      <p id={descriptionId} className="mt-4 text-sm leading-6 text-white/70">
+        Submit a formal dispute for commitment <span className="font-mono text-[#0FF0FC]">{commitmentId}</span>.
+        This action will be recorded on-chain.
+      </p>
+
+      <div className="mt-6">
+        <label htmlFor="dispute-reason" className="block text-sm font-medium text-white/80 mb-2">
+          Reason for dispute
+        </label>
+        <textarea
+          id="dispute-reason"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          disabled={isSubmitting}
+          rows={4}
+          placeholder="Describe the issue with this commitment..."
+          className="w-full rounded-[14px] border border-white/10 bg-[#050505] px-4 py-3 text-white placeholder:text-white/30 resize-none focus:outline-none focus-visible:ring-2 focus-visible:ring-[#FF8A04] disabled:cursor-not-allowed disabled:opacity-50"
+          autoComplete="off"
+        />
+        <p className="mt-2 text-[12px] text-white/40">
+          The reason must be at least 1 character and at most 500 characters.
+        </p>
+      </div>
+
+      {status === 'success' ? (
+        <div
+          role="status"
+          className="mt-5 flex gap-3 rounded-[14px] border border-[#22C55E33] bg-[#22C55E12] px-4 py-3 text-sm leading-6 text-[#BBF7D0]"
+        >
+          <AlertTriangle className="mt-0.5 shrink-0" size={18} />
+          <span>Dispute submitted. The commitment is now under review.</span>
+        </div>
+      ) : errorMessage ? (
+        <div
+          role="alert"
+          className="mt-5 flex gap-3 rounded-[14px] border border-[#F9737333] bg-[#F9737312] px-4 py-3 text-sm leading-6 text-[#FECACA]"
+        >
+          <AlertTriangle className="mt-0.5 shrink-0" size={18} />
+          <span>{errorMessage}</span>
+        </div>
+      ) : null}
+
+      <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={isSubmitting}
+          className="rounded-[14px] border border-white/10 px-5 py-3 text-sm font-semibold text-white/80 transition-colors hover:border-white/30 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {status === 'success' ? 'Close' : 'Cancel'}
+        </button>
+        {status !== 'success' && (
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={isSubmitting || !reason.trim()}
+            className="inline-flex items-center justify-center gap-2 rounded-[14px] border border-[#FF8A0466] bg-[#FF8A041A] px-5 py-3 text-sm font-semibold text-white shadow-[0_0_18px_rgba(255,138,4,0.22)] transition-all hover:bg-[#FF8A0426] hover:shadow-[0_0_24px_rgba(255,138,4,0.34)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#FF8A04] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isSubmitting ? <Loader2 className="animate-spin" size={18} /> : <AlertTriangle size={18} />}
+            {isSubmitting ? 'Submitting dispute' : 'Submit dispute'}
+          </button>
+        )}
+      </div>
+    </Dialog>
   );
 }


### PR DESCRIPTION
closes #815

# Description

This Pull Request centralizes focus trapping, Escape-to-close handling, and body scroll-locking in the shared `Dialog` primitive (`src/components/ui/Dialog.tsx`). It migrates modals to use this primitive, cleans up manual, redundant implementations, and introduces comprehensive tests.

## Key Changes

1. **Modal Migration to `Dialog`**:
   - **`CommitmentDisputeModal`**: Refactored to compose its markup within the `<Dialog>` primitive. Removed manual keydown listener, tab-focus cycling loop, backdrop/scroll lock management, and window animation frame focus loops. Passed `closeOnEscape={status !== 'submitting'}` to keep the modal from closing during submit.
   - **`CommitmentCreatedModal`**: Refactored to use `<Dialog>`. Fixed a runtime reference bug where `mounted` and `setMounted` were used but never declared. Removed custom backdrop click, keydown handlers, body scroll manipulation, and window timers.

2. **Test Fixes and Coverage**:
   - **`CommitmentDisputeModal.test.tsx`**: Added a new React Testing Library (RTL) suite asserting correct rendering, submit state transitions (disabling submit when reason is empty/whitespace), success/error message feedback, close callbacks, and background scroll-lock behavior.
   - **`CommitmentCreatedModal.test.tsx`**: Fixed the retry test case. Since the component returns to the idle state upon clicking "Retry funding", it requires clicking the "Fund escrow now" button to initiate a new fetch request. Added this step to align the test with the component's UX.

3. **Documentation**:
   - Extended `docs/MODAL_SYSTEM.md` to document `CommitmentDisputeModal` as a migrated component and highlighted the standardized accessibility guarantees provided by `Dialog` (focus trapping, initial focus, focus restoration, scroll lock, and sibling element inertness).
