### PR TITLE
[codex] Add error helper message mapping tests

### DIFF
--- a/src/utils/__tests__/errorHelpers.test.ts
+++ b/src/utils/__tests__/errorHelpers.test.ts
@@ -98,7 +98,7 @@ describe("badGatewayError", () => {
     expect(result.error.code).toBe(502);
     expect(result.error.type).toBe("BAD_GATEWAY");
     expect(result.error.message).toBe(
-      "A upstream service returned an invalid response. Please try again later."
+      "An upstream service returned an invalid response. Please try again later."
     );
   });
 
@@ -209,6 +209,54 @@ describe("resolveServerError", () => {
     const result = resolveServerError(502, "bad upstream");
     expect(result.error.details).toBe("bad upstream");
   });
+
+  it.each([
+    [
+      502,
+      "BAD_GATEWAY",
+      "An upstream service returned an invalid response. Please try again later.",
+    ],
+    [
+      503,
+      "SERVICE_UNAVAILABLE",
+      "The service is temporarily unavailable. Please try again later.",
+    ],
+    [504, "GATEWAY_TIMEOUT", "The request timed out. Please try again."],
+    [
+      599,
+      "INTERNAL_SERVER_ERROR",
+      "An unexpected error occurred. Please try again later.",
+    ],
+  ])(
+    "maps status %i to the expected user-facing %s message",
+    (statusCode, errorType, message) => {
+      const result = resolveServerError(statusCode);
+
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe(
+        statusCode === 599 ? 500 : statusCode
+      );
+      expect(result.error.type).toBe(errorType);
+      expect(result.error.message).toBe(message);
+    }
+  );
+
+  it.each([502, 503, 504, 599])(
+    "does not leak sensitive internals in production for status %i",
+    (statusCode) => {
+      process.env.NODE_ENV = "production";
+      const internalDetails =
+        "postgres://admin:secret@db.internal stacktrace token=abc123";
+      const result = resolveServerError(statusCode, internalDetails);
+      const serializedResponse = JSON.stringify(result);
+
+      expect(result.error.details).toBeUndefined();
+      expect(serializedResponse).not.toContain("postgres://");
+      expect(serializedResponse).not.toContain("secret");
+      expect(serializedResponse).not.toContain("stacktrace");
+      expect(serializedResponse).not.toContain("abc123");
+    }
+  );
 });
 
 // ── getErrorHeaders ───────────────────────────────────────────────────────────

--- a/src/utils/errorHelpers.ts
+++ b/src/utils/errorHelpers.ts
@@ -47,7 +47,7 @@ export function badGatewayError(details?: string): ApiErrorResponse {
         error: {
         code: 502,
         type: "BAD_GATEWAY",
-        message: "A upstream service returned an invalid response. Please try again later.",
+        message: "An upstream service returned an invalid response. Please try again later.",
         ...(details && process.env.NODE_ENV === "development" ? { details } : {}),
         },
     };


### PR DESCRIPTION
## Description
Adds focused unit coverage for `src/utils/errorHelpers.ts` so the client-facing server error contract is locked down.

This PR covers:
- known 5xx status mappings for 502, 503, and 504
- generic fallback behavior for unknown 5xx statuses
- production responses omitting sensitive internal diagnostic details
- a small user-facing grammar fix for the 502 upstream service message

Closes #987

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
Please review the [Developer Guide](https://github.com/Commitlabs-Org/Commitlabs-Frontend/blob/master/DEVELOPER_GUIDE.md) before checking the items below:

- [x] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas. No new comments were needed for these straightforward tests.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files). Not applicable; this is test coverage for an existing utility.
- [x] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`). Not run; targeted utility tests pass.
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics. `pnpm lint` currently fails on existing unrelated lint errors across the repository; the two files changed in this PR pass ESLint directly.
- [x] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes. Not applicable; no UI changes.

## Tests
- `pnpm exec vitest run src/utils/__tests__/errorHelpers.test.ts` (37 tests passed)
- `pnpm exec eslint src/utils/errorHelpers.ts src/utils/__tests__/errorHelpers.test.ts`

## Visual Changes (if applicable)
N/A - no visual changes.

## Join the Discussion
Need help or want to chat? Join our [CommitLabs Discord](https://discord.gg/WV7tdYkJk) server.