### PR TITLE
docs: add architecture-decision-records directory, template, and seed ADR

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Welcome to the CommitLabs documentation index. This document serves as a single 
 - **[todo/TODO.md](todo/TODO.md)** — Tracked checklist for self-hosting fonts performance feature.
 
 ## 🏗 Architecture & Design Systems
+- **[adr/README.md](adr/README.md)** — Architecture Decision Records: the *why* behind cross-cutting decisions, plus the template and process for adding new ones.
 - **[ARCHITECTURE.md](../ARCHITECTURE.md)** (Root) — Global system design, modules, and soroban contract data flow.
 - **[FRONTEND_ARCHITECTURE.md](FRONTEND_ARCHITECTURE.md)** — Page routes mapping to React components and API routes, including wallet/auth state design.
 - **[MODAL_SYSTEM.md](MODAL_SYSTEM.md)** — Architecture of the modal managers, custom context triggers, and backdrop animations.

--- a/docs/adr/0001-wallet-signature-authentication.md
+++ b/docs/adr/0001-wallet-signature-authentication.md
@@ -1,0 +1,94 @@
+# ADR-0001: Wallet-signature authentication with cookie-backed sessions
+
+- **Status:** Accepted
+- **Date:** 2026-06-28
+- **Deciders:** CommitLabs frontend maintainers
+- **Related:** [`docs/WALLET_AUTH.md`](../WALLET_AUTH.md),
+  [`docs/ROUTE_AUTH_GUARD.md`](../ROUTE_AUTH_GUARD.md),
+  [`docs/FRONTEND_ARCHITECTURE.md`](../FRONTEND_ARCHITECTURE.md),
+  `src/hooks/useWallet.ts`
+
+## Context
+
+CommitLabs is a Stellar/Soroban dApp: a user's identity *is* their Stellar
+account, and every state-changing action ultimately maps to an on-chain
+transaction signed by that account. The product therefore has no separate
+username/password concept and no first-party credential store to protect.
+
+We still need a server-side notion of "who is calling" so that backend route
+handlers can authorize requests, and we need that identity to be:
+
+- proven by control of the Stellar secret key, not merely asserted;
+- resistant to replay across sessions and across domains; and
+- safe to persist in the browser without ever exposing key material.
+
+The wallet (Freighter) holds the secret key and never reveals it; it will only
+return a *signature* over a message. Any auth design has to be built on that
+primitive.
+
+## Decision
+
+We will authenticate users with a **nonce-based wallet-signature handshake** and
+persist the resulting session in a **cookie**, implemented in
+`src/hooks/useWallet.ts`:
+
+1. **Nonce** — the client sends the public address to `POST /api/auth/nonce`.
+   The server returns a single-use, time-boxed challenge string built from the
+   `[CommitLabs Auth V2]` template, which embeds the domain, nonce, issued-at,
+   and expiry.
+2. **Sign** — the client asks Freighter to `signMessage(message, { address })`.
+   The user reviews the domain and nonce in the extension and approves.
+3. **Verify** — the client posts `{ address, signature, message }` to
+   `POST /api/auth/verify`. The server validates the template and domain, checks
+   expiry, verifies the Ed25519 signature against the address, consumes the nonce
+   (delete-on-use), and returns a `sessionToken`.
+
+The `sessionToken` is then written to a `session` cookie
+(`path=/; SameSite=Lax; Secure`) so backend route handlers can enforce
+cookie-based session verification on subsequent requests. Route-level access
+control is layered on top of this on the client by `RequireWallet`
+(see [`ROUTE_AUTH_GUARD.md`](../ROUTE_AUTH_GUARD.md)), which gates `/create`,
+`/settings`, and `/commitments` while leaving public routes open.
+
+Two invariants are part of this decision:
+
+- **No key material at rest.** Raw signatures and nonces are kept in memory only
+  and are never written to storage or logs.
+- **Address binding.** The authenticated address is recorded
+  (`commitlabs.authAddress`); if Freighter switches accounts or disconnects, the
+  session token, storage keys, and cookie are cleared immediately so a stale
+  session cannot authorize actions for a different account.
+
+## Alternatives considered
+
+- **Email/password or OAuth.** Rejected: it introduces a credential store and an
+  identity that is divorced from the on-chain account that actually authorizes
+  transactions, adding attack surface for no product benefit.
+- **Pure client-side "is a wallet connected?" check, no server session.**
+  Rejected: connection state is trivially spoofable and gives the backend no
+  verifiable caller identity, so it cannot protect server route handlers. We keep
+  a client guard (`RequireWallet`) for UX, but it is explicitly *not* the
+  security boundary.
+- **Signature without a server nonce** (e.g. signing a static or client-chosen
+  message). Rejected: a server-issued, single-use, expiring nonce is what makes
+  the handshake replay-resistant and domain-bound.
+- **Store the session token only in `localStorage`.** Rejected as the sole
+  mechanism: backend route handlers read a cookie, so a `Secure`, `SameSite=Lax`
+  cookie is required. (Tokens are additionally mirrored to `localStorage`/
+  `sessionStorage` for backward compatibility with older page exports.)
+
+## Consequences
+
+- **Positive:** identity is cryptographically proven by the same key that signs
+  transactions; there is no first-party password to leak; sessions are
+  replay-resistant (single-use, expiring, domain-bound nonce) and
+  account-switch-safe.
+- **Negative / trade-offs:** authentication depends on the Freighter extension
+  being installed and available, and on `@stellar/freighter-api`; the session
+  token now lives in several places (cookie, `localStorage`, `sessionStorage`),
+  so any change to the session model must update all of them and the
+  account-switch teardown path. `SameSite=Lax` is a deliberate balance between
+  CSRF resistance and normal navigation, not the strictest possible setting.
+- **Neutral:** the auth message template is explicitly versioned
+  (`[CommitLabs Auth V2]`), so a future format change is expected to bump the
+  version rather than mutate the existing template.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,62 @@
+# Architecture Decision Records (ADRs)
+
+This directory captures **Architecture Decision Records** — short documents that
+record significant, cross-cutting technical decisions and, most importantly, the
+context and reasoning behind them.
+
+The rest of `docs/` explains *how* a given feature works today. ADRs explain
+*why* the project arrived at a particular approach, what alternatives were
+weighed, and what trade-offs were accepted. That history is easy to lose once
+the original contributors move on, which is exactly what ADRs are meant to
+prevent.
+
+## What belongs in an ADR
+
+Write an ADR when a decision:
+
+- affects more than one feature or module (auth, caching, rate limiting, state
+  management, the wallet/contract boundary, build/deploy tooling);
+- is expensive or disruptive to reverse later;
+- a future contributor would reasonably ask "why was it done this way?" about; or
+- was contested, i.e. there were credible alternatives.
+
+You do **not** need an ADR for routine, localized changes (a new component, a
+copy tweak, a bug fix). Those are adequately covered by the code and the
+feature docs.
+
+## Index
+
+| ADR | Title | Status |
+| --- | ----- | ------ |
+| [0001](0001-wallet-signature-authentication.md) | Wallet-signature authentication with cookie-backed sessions | Accepted |
+
+## Statuses
+
+An ADR moves through a small lifecycle. Set the status in the front of each
+record:
+
+- **Proposed** — under discussion, not yet agreed.
+- **Accepted** — agreed and in effect.
+- **Deprecated** — no longer recommended, but still present in parts of the code.
+- **Superseded by [ADR-XXXX](xxxx-title.md)** — replaced by a later decision.
+
+Records are immutable once **Accepted**: rather than rewriting history, add a new
+ADR that supersedes the old one and update the old record's status to point at
+it.
+
+## How to add a new ADR
+
+1. Copy [`template.md`](template.md) to `NNNN-short-title.md`, where `NNNN` is the
+   next free zero-padded number (the next one is `0002`).
+2. Use a short, lower-case, hyphenated title that matches the filename.
+3. Fill in **Context**, **Decision**, and **Consequences**. Keep it concise —
+   one page is usually enough. Link to relevant feature docs in `docs/` and to
+   the code paths the decision governs.
+4. Add a row to the [Index](#index) above.
+5. Open a pull request. Treat the ADR as part of the change it describes, or as a
+   standalone PR when documenting an existing decision retroactively.
+
+## Further reading
+
+ADRs here follow the lightweight format popularized by Michael Nygard in
+["Documenting Architecture Decisions"](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,37 @@
+# ADR-NNNN: Short decision title
+
+- **Status:** Proposed | Accepted | Deprecated | Superseded by [ADR-XXXX](xxxx-title.md)
+- **Date:** YYYY-MM-DD
+- **Deciders:** names or roles involved in the decision
+- **Related:** links to relevant `docs/` pages, issues, or PRs
+
+## Context
+
+What is the problem or force that requires a decision? Describe the technical,
+product, or operational background a reader needs in order to understand why a
+decision was necessary. State the constraints (existing stack, security needs,
+the wallet/contract boundary, performance budgets) and any assumptions.
+
+## Decision
+
+State the decision in plain, active language: "We will …".
+
+Be specific about what is in scope and what is explicitly out of scope. Reference
+the concrete code paths or modules that implement the decision so future readers
+can find them.
+
+## Alternatives considered
+
+List the realistic options that were weighed and why each was not chosen. This is
+the part that prevents the same debate from being re-run later.
+
+- **Option A** — why rejected.
+- **Option B** — why rejected.
+
+## Consequences
+
+What becomes easier and what becomes harder as a result of this decision?
+
+- **Positive:** benefits gained.
+- **Negative / trade-offs:** costs accepted, new constraints, follow-up work.
+- **Neutral:** notable but value-neutral effects.


### PR DESCRIPTION
## Summary

Closes #1022.

Adds an Architecture Decision Records (ADR) area under `docs/adr/` so cross-cutting decisions have a recorded *why*, not just feature-level *how* docs.

- `docs/adr/README.md` — ADR index, what qualifies as an ADR, the status lifecycle, and a step-by-step process for adding new ones.
- `docs/adr/template.md` — reusable template (Context / Decision / Alternatives considered / Consequences).
- `docs/adr/0001-wallet-signature-authentication.md` — seed ADR documenting an existing decision.
- `docs/README.md` — links the ADR directory from the Architecture section of the docs index.

## Note on the seed ADR

The issue suggested seeding with a *cookie-session auth* ADR. In the actual codebase the authentication decision is a **Freighter wallet-signature handshake** (nonce → sign → verify → `sessionToken`) that is *then* persisted in a `Secure; SameSite=Lax` `session` cookie for backend route handlers. I wrote ADR-0001 to reflect that real decision — covering the nonce/handshake, the cookie-backed session, account-switch teardown, and the alternatives that were rejected — so the seed record is accurate rather than hypothetical. Sourced from `docs/WALLET_AUTH.md`, `docs/ROUTE_AUTH_GUARD.md`, and `src/hooks/useWallet.ts`.

## Testing

Documentation-only change (new Markdown under `docs/`, plus one link in the docs index). No source or build files touched; all intra-doc links verified to resolve.