### PR TITLE
docs: add CHANGELOG and documented release/versioning process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to the CommitLabs frontend are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+See [`docs/RELEASE_PROCESS.md`](docs/RELEASE_PROCESS.md) for how entries are added
+and how releases are cut. For breaking **backend** API changes that affect this
+frontend, see [`docs/backend-changelog.md`](docs/backend-changelog.md).
+
+## [Unreleased]
+
+### Added
+
+- `CHANGELOG.md` and a documented release/versioning process
+  (`docs/RELEASE_PROCESS.md`).
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+[Unreleased]: https://github.com/Commitlabs-Org/Commitlabs-Frontend/commits/master

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ Welcome to the CommitLabs documentation index. This document serves as a single 
 ## 📖 Overview & General Guides
 - **[README.md](../README.md)** (Root) — Main project overview, features, configuration guide, and quick start instructions.
 - **[DEVELOPER_GUIDE.md](../DEVELOPER_GUIDE.md)** (Root) — Coding standards, TypeScript conventions, styling practices, package management, and testing workflows.
+- **[CHANGELOG.md](../CHANGELOG.md)** (Root) — Keep-a-Changelog record of notable frontend changes.
+- **[RELEASE_PROCESS.md](RELEASE_PROCESS.md)** — Semantic versioning, how changelog entries are added, and how releases are cut.
 - **[GLOSSARY.md](GLOSSARY.md)** — Explanations of core business domain terms (e.g., Safe, Balanced, Aggressive commitments, drawdowns).
 - **[todo/TODO.md](todo/TODO.md)** — Tracked checklist for self-hosting fonts performance feature.
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,65 @@
+# Release & Versioning Process
+
+This document describes how the CommitLabs frontend is versioned, how changelog
+entries are recorded, and how a release is cut. It is intentionally lightweight
+and meant to grow with the project.
+
+## Versioning
+
+The frontend follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html),
+`MAJOR.MINOR.PATCH`, tracked in the `version` field of [`package.json`](../package.json):
+
+- **MAJOR** — incompatible, user-visible changes (e.g. a removed route, a
+  breaking change to a persisted local format, or a required wallet/API change
+  that invalidates existing sessions).
+- **MINOR** — new functionality added in a backward-compatible way.
+- **PATCH** — backward-compatible bug fixes and internal changes.
+
+The project is currently pre-1.0 (`0.x`). While in `0.x`, the public surface is
+still stabilizing: minor bumps may include breaking changes, and patch bumps are
+used for fixes. The first stable line is `1.0.0`.
+
+## The changelog
+
+All notable changes are recorded in the root [`CHANGELOG.md`](../CHANGELOG.md),
+using the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+### Adding an entry
+
+- Add a bullet to the **`[Unreleased]`** section **in the same PR** as the change.
+- Put it under the right group: `Added`, `Changed`, `Deprecated`, `Removed`,
+  `Fixed`, or `Security`.
+- Write for a reader of the app, not the diff: describe the user-facing or
+  contributor-facing effect, and link the PR or issue where useful.
+- Skip purely internal noise (formatting, comment-only changes) unless it affects
+  contributors.
+
+A breaking change to a **backend** API that this frontend depends on is tracked
+separately in [`docs/backend-changelog.md`](backend-changelog.md); link to that
+entry from the `CHANGELOG.md` line when the two are related.
+
+## Cutting a release
+
+1. Decide the next version from the nature of the `[Unreleased]` entries (see
+   [Versioning](#versioning)).
+2. In `CHANGELOG.md`, rename `[Unreleased]` to the new version with today's date,
+   e.g. `## [0.2.0] - 2026-07-01`, and add a fresh empty `[Unreleased]` section
+   above it.
+3. Update the comparison links at the bottom of `CHANGELOG.md` so `[Unreleased]`
+   compares the new tag to `HEAD` and the new version compares to the previous tag.
+4. Bump `version` in `package.json` to match.
+5. Merge the release PR, then tag the merge commit:
+   ```bash
+   git tag -a v0.2.0 -m "v0.2.0"
+   git push origin v0.2.0
+   ```
+6. Create a GitHub Release from the tag, pasting that version's changelog section
+   as the release notes.
+
+## Checklist
+
+- [ ] `[Unreleased]` entry added in the same PR as the change.
+- [ ] Entry filed under the correct Keep-a-Changelog group.
+- [ ] Related backend breaking change linked to `docs/backend-changelog.md` if any.
+- [ ] On release: version moved out of `[Unreleased]`, `package.json` bumped, tag
+      pushed, GitHub Release created.

--- a/docs/backend-changelog.md
+++ b/docs/backend-changelog.md
@@ -2,6 +2,10 @@
 
 This document tracks **breaking backend API changes** that may impact this frontend. Keep entries brief, actionable, and linked to implementation artifacts.
 
+> For frontend-facing changes (features, fixes, releases) see the root
+> [`CHANGELOG.md`](../CHANGELOG.md) and the [release process](RELEASE_PROCESS.md).
+> This file is scoped to backend API breaking changes only.
+
 ## Purpose
 
 - Provide a single source of truth for backend API breaking changes.


### PR DESCRIPTION
## Summary

Closes #1024.

Adds a top-level changelog and a documented release process for the frontend, which previously had only a backend-API changelog.

- `CHANGELOG.md` — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with an `[Unreleased]` section and the standard Added/Changed/Deprecated/Removed/Fixed/Security groups.
- `docs/RELEASE_PROCESS.md` — semantic versioning policy (incl. the current `0.x` pre-1.0 caveat tied to `package.json`), how to add changelog entries, a step-by-step release/tag procedure, and a checklist.
- `docs/backend-changelog.md` — cross-links the new frontend changelog/release process and clarifies its own scope (backend breaking changes only).
- `docs/README.md` — indexes both new docs under Overview & General Guides.

## Testing

Documentation-only change. No source or build files touched; all intra-doc links verified to resolve and version references match `package.json` (`0.1.0`).