### PR TITLE
docs: add accessibility statement with WCAG 2.1 AA target and known gaps

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@ Welcome to the CommitLabs documentation index. This document serves as a single 
 - **[testing/TRUST_BADGE_TESTS.md](testing/TRUST_BADGE_TESTS.md)** — Verification details for seller trust level badges.
 
 ## ♿ Accessibility & Performance
+- **[accessibility/ACCESSIBILITY_STATEMENT.md](accessibility/ACCESSIBILITY_STATEMENT.md)** — Overall WCAG 2.1 AA target, current conformance posture, known gaps, and how to report accessibility problems.
 - **[accessibility-dense-ui.md](accessibility-dense-ui.md)** — Layout rules and size considerations for data-dense tables.
 - **[accessibility/CONTRAST_AUDIT.md](accessibility/CONTRAST_AUDIT.md)** — Verification report on text color contrast ratios.
 - **[accessibility/CREATE_WIZARD_A11Y.md](accessibility/CREATE_WIZARD_A11Y.md)** — Keyboard controls, screen-reader descriptions, and aria labels for form steps.

--- a/docs/accessibility-dense-ui.md
+++ b/docs/accessibility-dense-ui.md
@@ -2,6 +2,10 @@
 
 This document defines the accessibility standards for presenting dense numeric data, financial metrics, and complex tables within the CommitLabs platform.
 
+> Part of CommitLabs' accessibility effort. For the overall WCAG 2.1 AA target,
+> current conformance posture, known gaps, and how to report problems, see the
+> [Accessibility Statement](accessibility/ACCESSIBILITY_STATEMENT.md).
+
 ## 1. General Principles
 
 - **Clarity over Density**: While we aim for information density, accessibility requires that the logical relationship between data points remains clear.

--- a/docs/accessibility/ACCESSIBILITY_STATEMENT.md
+++ b/docs/accessibility/ACCESSIBILITY_STATEMENT.md
@@ -1,0 +1,72 @@
+# Accessibility Statement
+
+CommitLabs is committed to making its web application usable by as many people as
+possible, including people who rely on assistive technologies.
+
+This statement records the target we hold ourselves to, where we stand against
+it today, the gaps we know about, and how to report problems. The per-area
+accessibility notes elsewhere in `docs/accessibility/` describe *how* specific
+flows are made accessible; this document is the single place that states the
+overall posture.
+
+## Conformance target
+
+We target **WCAG 2.1 Level AA**.
+
+"Partially conformant" is an honest description of where the app is today: large
+portions have been deliberately audited and remediated (see [Current
+posture](#current-posture)), while some areas have not yet been verified
+end-to-end against every AA success criterion.
+
+## Current posture
+
+Accessibility work that is already in place and verifiable in the codebase:
+
+- **Color contrast** — a dark-theme contrast audit against the AA thresholds
+  (4.5:1 normal text, 3.0:1 large text / graphical objects), with the remediated
+  tokens recorded in [`CONTRAST_AUDIT.md`](CONTRAST_AUDIT.md).
+- **Keyboard operation & screen-reader semantics** — the multi-step create flow
+  documents its keyboard controls, focus order, and ARIA labelling in
+  [`CREATE_WIZARD_A11Y.md`](CREATE_WIZARD_A11Y.md).
+- **Focus management in overlays** — modal/dialog flows use `role="dialog"`,
+  `aria-modal="true"`, focus-on-open, focus trapping, and focus restoration on
+  close (see [`../ROUTE_AUTH_GUARD.md`](../ROUTE_AUTH_GUARD.md) and
+  [`../MODAL_SYSTEM.md`](../MODAL_SYSTEM.md)).
+- **Marketplace comparison** — focus traps and accessible properties for the
+  compare interface are documented in [`MARKETPLACE_A11Y.md`](MARKETPLACE_A11Y.md).
+- **Reduced motion** — animations respect the user's
+  `prefers-reduced-motion` preference, per [`REDUCED_MOTION.md`](REDUCED_MOTION.md).
+- **Data-dense layouts** — sizing and layout rules that keep tables usable are
+  captured in [`../accessibility-dense-ui.md`](../accessibility-dense-ui.md).
+- **Verification** — interactive flows are exercised with Playwright end-to-end
+  tests (`npm run test:e2e`).
+
+## Known gaps
+
+These are tracked as ordinary issues; this list is intentionally honest rather
+than aspirational.
+
+- No automated accessibility assertions (e.g. an `axe` pass) run in CI yet, so AA
+  conformance is currently verified by manual audit and targeted e2e coverage
+  rather than continuous automated checks.
+- Conformance has been audited per-area (contrast, create wizard, marketplace
+  compare, overlays) but not yet as a single end-to-end pass across every route.
+- The light/alternate theme has not been put through the same documented contrast
+  audit as the dark theme.
+
+If you find a barrier that is not listed here, please report it (see below) so we
+can add it to the list and track a fix.
+
+## Reporting an accessibility problem
+
+We welcome reports of accessibility barriers.
+
+- **Preferred:** open an issue in the
+  [CommitLabs-Frontend repository](https://github.com/Commitlabs-Org/Commitlabs-Frontend/issues)
+  and describe the page/flow, the assistive technology and browser you were
+  using, and what you expected to happen.
+- For sensitive reports you would rather not file publicly, use the private
+  channel described in [`SECURITY.md`](../../SECURITY.md).
+
+We aim to acknowledge accessibility reports and triage them alongside other
+issues.


### PR DESCRIPTION
## Summary

Closes #1011.

The app has scattered accessibility work (contrast audit, keyboard a11y, focus management, reduced motion) but no single statement of the target, posture, and how to report issues. This adds that baseline.

- `docs/accessibility/ACCESSIBILITY_STATEMENT.md` — states the **WCAG 2.1 AA** target, the current (partially-conformant) posture with links to the existing per-area a11y docs, an honest **known gaps** list, and a reporting channel.
- `docs/accessibility-dense-ui.md` — cross-links the statement.
- `docs/README.md` — indexes the statement under Accessibility & Performance.

## Accuracy notes

Posture and gaps are drawn from what's actually in the repo, not boilerplate:
- Linked real docs: `CONTRAST_AUDIT.md`, `CREATE_WIZARD_A11Y.md`, `MARKETPLACE_A11Y.md`, `REDUCED_MOTION.md`, `MODAL_SYSTEM.md`, `ROUTE_AUTH_GUARD.md`.
- The issue mentioned "axe tests", but there is **no axe tooling in the repo** today, so the statement lists "no automated a11y assertions in CI" as a known gap rather than claiming coverage that doesn't exist. Verification is described as manual audit + Playwright e2e, which is what exists.

## Testing

Documentation-only change. No source/build files touched; all intra-doc links verified to resolve.