### PR TITLE
feat: add web app manifest and PWA metadata for installability

### DIFF
--- a/docs/SEO_METADATA.md
+++ b/docs/SEO_METADATA.md
@@ -5,6 +5,13 @@
 CommitLabs uses **Next.js 14 App Router metadata API** for per-route SEO metadata (title,
 description, Open Graph, and Twitter cards).
 
+> **Web App Manifest:** installability metadata (name, icons, theme color) is served
+> by the App Router metadata route [`src/app/manifest.ts`](../src/app/manifest.ts) at
+> `/manifest.webmanifest`. Its `theme_color`/`background_color` track the
+> `--surface-base` design token (`#0a0a0a`), and its icon (`public/icon.svg`) is a
+> neutral placeholder intended to be replaced by final brand artwork. See the
+> [Web App Manifest](#web-app-manifest) section below.
+
 Since route pages that require client-side interactivity use `'use client'` (and therefore
 cannot export `metadata` directly), each such route **must have a sibling `layout.tsx`**
 that is a **server component** and exports the metadata.
@@ -161,3 +168,32 @@ This ensures that search engine crawlers receive up‑to‑date rules and a site
   are absent, entries have valid structure, and there are no duplicates.
 - When a new public route is added, the **drift detection test** will fail until
   `PUBLIC_ROUTES` in the test file is updated.
+
+## Web App Manifest
+
+The web app manifest makes CommitLabs installable as a PWA with consistent
+naming, icons, and colors across platforms. It is implemented as an App Router
+metadata route — [`src/app/manifest.ts`](../src/app/manifest.ts) — which Next.js
+serves at `/manifest.webmanifest` and links automatically from the document head.
+
+Key fields:
+
+- `name` / `short_name` / `description` — mirror the site metadata in
+  `src/app/layout.tsx`.
+- `start_url` `'/'` and `scope` `'/'` — the app launches at and is scoped to the
+  site root.
+- `display: 'standalone'` — installed app runs without browser chrome.
+- `theme_color` / `background_color` — `#0a0a0a`, kept in sync with the
+  `--surface-base` design token in `src/app/globals.css`.
+- `icons` — reference `public/icon.svg` (scalable, `purpose: any` and
+  `maskable`). This SVG is a **neutral placeholder**; replace it with final brand
+  artwork (and add raster `192x192` / `512x512` PNGs if broader launcher support
+  is required) without changing the manifest contract.
+
+### Testing
+
+[`src/app/__tests__/manifest.test.ts`](../src/app/__tests__/manifest.test.ts)
+asserts the required installability fields, that the colors match the design
+token, that a maskable icon is declared, and that **every referenced icon asset
+actually exists** in `public/` — so a manifest that points at a missing icon
+fails CI.

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="CommitLabs">
+  <rect width="512" height="512" rx="112" fill="#0a0a0a"/>
+  <rect x="20" y="20" width="472" height="472" rx="96" fill="none" stroke="#1f2937" stroke-width="8"/>
+  <text x="256" y="318" text-anchor="middle" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="220" font-weight="700" fill="#f8fafc">CL</text>
+</svg>

--- a/src/app/__tests__/manifest.test.ts
+++ b/src/app/__tests__/manifest.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import manifest from '../manifest'
+
+describe('web app manifest', () => {
+  const m = manifest()
+
+  it('exposes required installability fields', () => {
+    expect(m.name).toBeTruthy()
+    expect(m.short_name).toBeTruthy()
+    expect(m.description).toBeTruthy()
+    expect(m.start_url).toBe('/')
+    expect(m.scope).toBe('/')
+    expect(m.display).toBe('standalone')
+  })
+
+  it('uses the design-token surface color for theme and background', () => {
+    expect(m.theme_color).toBe('#0a0a0a')
+    expect(m.background_color).toBe('#0a0a0a')
+  })
+
+  it('declares at least one icon and every icon asset exists in public/', () => {
+    expect(Array.isArray(m.icons)).toBe(true)
+    expect(m.icons!.length).toBeGreaterThan(0)
+
+    for (const icon of m.icons!) {
+      expect(icon.src.startsWith('/')).toBe(true)
+      const filePath = join(process.cwd(), 'public', icon.src.replace(/^\//, ''))
+      expect(existsSync(filePath), `missing icon asset: public${icon.src}`).toBe(true)
+    }
+  })
+
+  it('declares a maskable icon for adaptive launchers', () => {
+    const purposes = (m.icons ?? []).map((i) => i.purpose)
+    expect(purposes).toContain('maskable')
+  })
+})

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,39 @@
+import type { MetadataRoute } from 'next'
+
+/**
+ * Web App Manifest (App Router metadata route).
+ *
+ * Served at `/manifest.webmanifest` and makes the app installable as a PWA with
+ * a consistent name, icons, and colors across platforms. This adds metadata
+ * only — it does not change runtime behaviour.
+ *
+ * `theme_color`/`background_color` are kept in sync with the design token
+ * `--surface-base` (`#0a0a0a`) defined in `src/app/globals.css`.
+ */
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'CommitLabs - Liquidity as a Commitment',
+    short_name: 'CommitLabs',
+    description:
+      'Transform passive liquidity into enforceable, attestable, and composable on-chain commitments',
+    start_url: '/',
+    scope: '/',
+    display: 'standalone',
+    background_color: '#0a0a0a',
+    theme_color: '#0a0a0a',
+    icons: [
+      {
+        src: '/icon.svg',
+        type: 'image/svg+xml',
+        sizes: 'any',
+        purpose: 'any',
+      },
+      {
+        src: '/icon.svg',
+        type: 'image/svg+xml',
+        sizes: 'any',
+        purpose: 'maskable',
+      },
+    ],
+  }
+}


### PR DESCRIPTION
## Summary

Closes #1018.

Makes the app installable by adding a typed App Router manifest route plus icon metadata. Metadata-only — no behavioural change.

- `src/app/manifest.ts` — `MetadataRoute.Manifest` served at `/manifest.webmanifest`: `name`/`short_name`/`description` mirroring `layout.tsx`, `start_url`/`scope` = `/`, `display: standalone`, and `theme_color`/`background_color` = `#0a0a0a` (the `--surface-base` design token in `globals.css`).
- `public/icon.svg` — a scalable icon referenced as both `any` and `maskable`.
- `src/app/__tests__/manifest.test.ts` — asserts the installability fields, color↔token match, a maskable icon, and that **every referenced icon asset exists on disk**.
- `docs/SEO_METADATA.md` — documents the manifest and cross-links it.

## Note on the icon

The repo had **no** PWA icon assets (only `public/plus.png`), so rather than reference a non-existent path I added a neutral `icon.svg` placeholder (dark surface + "CL" monogram). It's explicitly documented as a placeholder for final brand artwork; the manifest contract won't change when real icons land. (Aside: `layout.tsx` references `/og-image.jpg`, which is also missing from `public/` — flagging as a separate pre-existing issue, not touched here.)

## Testing

```
vitest run src/app/__tests__/manifest.test.ts
✓ 4 passed
```