### PR TITLE
feat: wire ErrorBoundary into client error-monitoring seam and document the adapter contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,7 @@ Welcome to the CommitLabs documentation index. This document serves as a single 
 - **[performance/STARFIELD.md](performance/STARFIELD.md)** — Canvas rendering optimizations for animated background components.
 
 ## 📡 API & Backend Storage
+- **[observability/ERROR_MONITORING.md](observability/ERROR_MONITORING.md)** — Pluggable client error-reporting seam: record shape, call sites, the adapter contract, and redaction.
 - **[backend-api-reference.md](backend-api-reference.md)** — Detailed definitions of REST API routes, parameter validations, schemas, and return formats.
 - **[backend-changelog.md](backend-changelog.md)** — Version logs tracking updates and contract changes to endpoints.
 - **[backend-cors-policy.md](backend-cors-policy.md)** — CORS whitelist configs and cross-origin handling.

--- a/docs/observability/ERROR_MONITORING.md
+++ b/docs/observability/ERROR_MONITORING.md
@@ -1,0 +1,98 @@
+# Client Error Monitoring Seam
+
+CommitLabs reports client-side errors through a small, **pluggable seam** rather
+than a hard dependency on any vendor. By default it emits to the console; an
+operator wires a real sink (Sentry, Datadog, a backend ingest endpoint, …) once,
+at startup, without changing any component code.
+
+Implementation: [`src/lib/observability/reportError.ts`](../../src/lib/observability/reportError.ts)
+(unit tests in [`src/lib/observability/__tests__/reportError.test.ts`](../../src/lib/observability/__tests__/reportError.test.ts)).
+
+## What gets reported
+
+Errors are turned into a redaction-safe, serialisable record:
+
+```ts
+interface ClientErrorRecord {
+  message: string            // redacted (see Redaction below)
+  digest: string | undefined // Next.js error digest, when present
+  route: string              // pathname where the error occurred
+  timestamp: string          // ISO-8601 UTC
+  stack?: string             // present only when NODE_ENV !== 'production'
+}
+```
+
+## Call sites
+
+Both client error surfaces already forward into the seam:
+
+| Source | What it catches | Route passed |
+| ------ | --------------- | ------------ |
+| [`src/app/error.tsx`](../../src/app/error.tsx) | Errors from the App Router route segment (the Next.js `error.tsx` boundary) | `window.location.pathname` |
+| [`src/components/ErrorBoundary.tsx`](../../src/components/ErrorBoundary.tsx) | Render/lifecycle errors in any subtree wrapped by `ErrorBoundary` / `withErrorBoundary` | `window.location.pathname` (or `''` if unavailable) |
+
+Application code should not call `reportError` ad hoc; let these boundaries do
+it. Wrap risky subtrees in `ErrorBoundary` instead of adding bespoke try/catch
+reporting.
+
+## The adapter contract
+
+A monitoring adapter is just a transport function:
+
+```ts
+type ErrorTransport = (record: ClientErrorRecord) => void
+```
+
+Register it **once**, before the app renders, with `setErrorTransport`. An
+adapter must:
+
+- be **synchronous and non-throwing** — never let reporting break the app; wrap
+  any network/SDK call in your own try/catch and swallow failures;
+- treat `ClientErrorRecord` as already-redacted and **not** re-derive sensitive
+  data from it;
+- be cheap — it runs on the error path, which may already be degraded.
+
+### Default behaviour (no adapter)
+
+If `setErrorTransport` is never called, the default transport logs the record via
+`console.error('[reportError]', record)`. There is no network traffic and no
+PII egress by default — reporting is opt-in.
+
+### Example: wiring an adapter
+
+```ts
+// e.g. in a top-level client provider, run once on mount
+import { setErrorTransport } from '@/lib/observability/reportError'
+
+setErrorTransport((record) => {
+  try {
+    // Sentry.captureMessage(record.message, { extra: record })
+    // or: navigator.sendBeacon('/api/client-errors', JSON.stringify(record))
+  } catch {
+    // never rethrow from the transport
+  }
+})
+```
+
+## Redaction
+
+`reportError` redacts the error `message` before building the record: substrings
+of the form `key=value` / `key: value` whose key is in the sensitive set
+(`token`, `authorization`, `password`, `secret`, `key`, `privatekey`,
+`publickey`, `mnemonic`, `seed`, `auth`, `bearer`, `apikey`, `api_key`,
+`session`, `cookie`, `csrf`, `signature`, `nonce`) are replaced with
+`key=[REDACTED]`.
+
+Stack traces are included only outside production. This matches the backend
+logging posture documented in
+[`LOGGING_SCHEMA.md`](LOGGING_SCHEMA.md); as there, redaction is **key-based**,
+so avoid putting raw secrets into error messages.
+
+## Testing
+
+- The seam itself: `reportError.test.ts` covers the record shape, redaction, the
+  production stack-omission, and that a registered transport receives the record
+  (and the default is safe when none is set).
+- The boundary wiring: `ErrorBoundary.test.tsx` asserts a thrown child error is
+  forwarded to a registered transport, and that nothing is reported on the happy
+  path.

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -3,6 +3,7 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import ErrorLayout from './ErrorLayout';
 import ErrorButton from './ErrorButton';
+import { reportError } from '@/lib/observability/reportError';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -51,6 +52,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     // Log error to console (client-side pattern)
     console.error('[ErrorBoundary] Caught an error:', error);
     console.error('[ErrorBoundary] Error info:', errorInfo);
+
+    // Forward to the pluggable error-monitoring seam. The default transport is
+    // a no-op-ish console sink; operators can swap in Sentry/Datadog/etc. via
+    // `setErrorTransport` without touching this component. See
+    // docs/observability/ERROR_MONITORING.md.
+    const route =
+      typeof window !== 'undefined' ? window.location.pathname : '';
+    reportError(error, route);
 
     // Call custom error handler if provided
     if (this.props.onError) {

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -3,9 +3,13 @@
  */
 
 import React, { Component, ErrorInfo, ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { ErrorBoundary, withErrorBoundary } from '@/components/ErrorBoundary';
+import {
+  setErrorTransport,
+  type ClientErrorRecord,
+} from '@/lib/observability/reportError';
 
 // Component that throws an error
 class ThrowingComponent extends Component<{ shouldThrow?: boolean }> {
@@ -206,5 +210,47 @@ describe('withErrorBoundary HOC', () => {
     });
 
     expect(SafeComponent.displayName).toBe('withErrorBoundary(Component)');
+  });
+});
+
+describe('ErrorBoundary — error-monitoring seam', () => {
+  afterEach(() => {
+    // Restore the default (console) transport so other suites are unaffected.
+    setErrorTransport((r) => console.error('[reportError]', r));
+  });
+
+  it('forwards caught errors to the reportError seam', () => {
+    const captured: ClientErrorRecord[] = [];
+    setErrorTransport((r) => captured.push(r));
+
+    const originalError = console.error;
+    console.error = vi.fn();
+    try {
+      render(
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow={true} />
+        </ErrorBoundary>,
+      );
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].message).toContain('Test error from ThrowingComponent');
+    expect(typeof captured[0].timestamp).toBe('string');
+    expect(typeof captured[0].route).toBe('string');
+  });
+
+  it('does not report when no error is thrown', () => {
+    const captured: ClientErrorRecord[] = [];
+    setErrorTransport((r) => captured.push(r));
+
+    render(
+      <ErrorBoundary>
+        <div>Healthy child</div>
+      </ErrorBoundary>,
+    );
+
+    expect(captured).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Closes #1019.

A pluggable error-reporting seam already exists at `src/lib/observability/reportError.ts` (with `setErrorTransport`, a redaction-safe `ClientErrorRecord`, and a no-op-by-default console transport), and the route-level `src/app/error.tsx` already calls it. The gap was that `ErrorBoundary` only `console.error`-ed. This closes that gap and documents the contract.

- `src/components/ErrorBoundary.tsx` — `componentDidCatch` now forwards into `reportError(error, route)` (SSR-safe route lookup), so component-tree errors are reported through the same seam as route errors.
- `src/components/__tests__/ErrorBoundary.test.tsx` — new cases: a thrown child error is forwarded to a registered transport; nothing is reported on the happy path.
- `docs/observability/ERROR_MONITORING.md` — documents the record shape, both call sites, the adapter contract (sync, non-throwing, no PII re-derivation), the no-op default, a wiring example, and redaction.

## Deviation from the issue (intentional)

The issue suggested creating `src/lib/monitoring/reportError.ts`. That seam **already exists** at `src/lib/observability/reportError.ts` with full unit tests, so I reused it instead of adding a duplicate module — and spent the effort on the missing wiring + documentation.

## Testing

```
vitest run src/components/__tests__/ErrorBoundary.test.tsx src/lib/observability/__tests__/reportError.test.ts
✓ 35 passed
```