### PR TITLE
chore: add external-link security policy, lint guard, and policy tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,14 @@
         "varsIgnorePattern": "^_",
         "caughtErrorsIgnorePattern": "^_"
       }
+    ],
+    "react/jsx-no-target-blank": [
+      "error",
+      {
+        "allowReferrer": false,
+        "enforceDynamicLinks": "always",
+        "warnOnSpreadAttributes": true
+      }
     ]
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ Welcome to the CommitLabs documentation index. This document serves as a single 
 - **[hero-section-design.md](hero-section-design.md)** — Call-to-action layout, copy patterns, and spacing specifications for the home hero block.
 
 ## 🔒 Security, Audit & Threats
+- **[security/EXTERNAL_LINKS.md](security/EXTERNAL_LINKS.md)** — External-link & subresource policy: required `rel` on `target=_blank`, the ESLint guard, the allow-listed hosts, and the safe explorer-link helper.
 - **[audit/AUDIT.md](audit/AUDIT.md)** — Dead code search, TODO registry, and linting status audit documentation.
 - **[backend-security-checklist.md](backend-security-checklist.md)** — API route protection, payload limits, sanitization, and compliance guidelines.
 - **[backend-threat-model.md](backend-threat-model.md)** — Analysis of security vectors, Stellar transaction replay attacks, and state vulnerabilities.

--- a/docs/security/EXTERNAL_LINKS.md
+++ b/docs/security/EXTERNAL_LINKS.md
@@ -1,0 +1,91 @@
+# External Link & Subresource Security Policy
+
+CommitLabs renders links to external sites (the Stellar block explorer, wallet,
+social, and docs). Unsafe external links create two concrete risks:
+
+- **Tab-nabbing** — a `target="_blank"` link without `rel="noopener"` gives the
+  opened page access to `window.opener`, which it can use to redirect the
+  original tab to a phishing page.
+- **Referrer leakage / open redirect** — sending the full referrer to third
+  parties, or building an explorer URL from unvalidated input that lets an
+  attacker point the link at an arbitrary host.
+
+This policy and its automated guards keep those closed.
+
+## Rules
+
+1. **Every `target="_blank"` anchor must carry `rel="noopener noreferrer"`.**
+   This is enforced by lint (see [Lint guard](#lint-guard)) — it is not optional
+   and not a matter of review vigilance.
+2. **Build explorer links through the helper, never by hand.** Use
+   [`buildExplorerUrl` / `openExplorerUrl`](../../src/utils/explorerLinks.ts);
+   do not interpolate user/chain data into an explorer URL string. The helper
+   validates the identifier and pins the host, so untrusted input cannot change
+   where the link points.
+3. **Programmatic opens use safe window features.** `openExplorerUrl` calls
+   `window.open(url, '_blank', 'noopener,noreferrer')`.
+4. **Only link to known hosts.** New external destinations should come from the
+   allow-list below; adding a host is a deliberate change, reviewed as such.
+
+## Allowed external hosts
+
+| Host | Used for |
+| ---- | -------- |
+| `stellar.expert` | Block explorer (accounts, contracts, transactions, assets) — via `explorerLinks.ts` |
+| `stellar.org` / `rpc-mainnet.stellar.org` | Stellar org pages and RPC |
+| `www.freighter.app` | Freighter wallet install/help |
+| `discord.gg` | Community / "Report issue" |
+| `github.com` | Source repository |
+| `twitter.com` | Social |
+| `commitlabs.com` | First-party canonical/OG URLs |
+
+Adding a host here should be paired with the reason and the component that uses
+it.
+
+## Lint guard
+
+`react/jsx-no-target-blank` is enabled as an **error** in
+[`.eslintrc.json`](../../.eslintrc.json):
+
+```json
+"react/jsx-no-target-blank": [
+  "error",
+  { "allowReferrer": false, "enforceDynamicLinks": "always", "warnOnSpreadAttributes": true }
+]
+```
+
+This fails CI (`npm run lint`) on any `target="_blank"` anchor — including ones
+with a dynamic `href` or a spread `{...props}` — that lacks
+`rel="noopener noreferrer"`.
+
+## The explorer link helper
+
+[`src/utils/explorerLinks.ts`](../../src/utils/explorerLinks.ts) is the single
+safe path for explorer links:
+
+- validates the identifier against per-kind patterns (`account` `G…`,
+  `contract` `C…`, `tx` 64-hex, `token`) and rejects anything that does not
+  match — so a value cannot smuggle in a scheme, host, or path traversal;
+- constructs the URL against a fixed `https://stellar.expert` origin, so the host
+  can never be attacker-controlled;
+- returns `null` for invalid input (`buildExplorerUrl`) / does nothing and
+  returns `false` (`openExplorerUrl`), so callers fail closed.
+
+## Adding a new external link safely
+
+- **In JSX:** `<a href="…" target="_blank" rel="noopener noreferrer">`. The lint
+  rule will reject it otherwise.
+- **To the explorer:** call `buildExplorerUrl(kind, id, network)` /
+  `openExplorerUrl(...)` — never hand-build the URL.
+- **New host:** add it to [Allowed external hosts](#allowed-external-hosts) in
+  the same PR.
+
+## Testing
+
+- [`src/utils/__tests__/explorerLinks.policy.test.ts`](../../src/utils/__tests__/explorerLinks.policy.test.ts)
+  asserts the policy invariants: built URLs stay on the allow-listed host over
+  `https`, malicious identifiers (other host/scheme, path traversal, embedded
+  credentials, trailing junk) are rejected, and `openExplorerUrl` opens with
+  `noopener,noreferrer` (and opens nothing for rejected input).
+- [`src/utils/__tests__/explorerLinks.test.ts`](../../src/utils/__tests__/explorerLinks.test.ts)
+  covers the functional behaviour.

--- a/src/utils/__tests__/explorerLinks.policy.test.ts
+++ b/src/utils/__tests__/explorerLinks.policy.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+
+/**
+ * External-link security policy coverage for the explorer link helpers.
+ *
+ * Complements explorerLinks.test.ts (functional behaviour) by asserting the
+ * security invariants documented in docs/security/EXTERNAL_LINKS.md:
+ *   1. Built URLs can only ever point at the allow-listed explorer host.
+ *   2. Untrusted identifiers cannot smuggle in another host, scheme, or path.
+ *   3. Programmatic opens use a safe, tab-nabbing-resistant window feature set.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { buildExplorerUrl, openExplorerUrl } from '../explorerLinks'
+
+const ALLOWED_HOST = 'stellar.expert'
+const validAccount = `G${'A'.repeat(55)}`
+const validTx = 'a'.repeat(64)
+
+describe('explorerLinks — external-link policy', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('only ever produces URLs on the allow-listed host', () => {
+    const url = buildExplorerUrl('account', validAccount)
+    expect(url).not.toBeNull()
+    expect(new URL(url!).host).toBe(ALLOWED_HOST)
+    expect(new URL(url!).protocol).toBe('https:')
+  })
+
+  it('rejects identifiers that try to smuggle in another host or scheme', () => {
+    const malicious = [
+      'https://evil.example.com',
+      '//evil.example.com',
+      'javascript:alert(1)',
+      `${validAccount}/../../evil`,
+      `${validAccount}@evil.example.com`,
+      `${validAccount} extra`,
+    ]
+    for (const id of malicious) {
+      expect(buildExplorerUrl('account', id), `should reject: ${id}`).toBeNull()
+    }
+  })
+
+  it('never emits an off-host URL even for otherwise valid-looking ids', () => {
+    // Any non-null result, across kinds, must stay on the allow-listed host.
+    const candidates: Array<[Parameters<typeof buildExplorerUrl>[0], string]> = [
+      ['account', validAccount],
+      ['tx', validTx],
+      ['contract', `C${'B'.repeat(55)}`],
+      ['token', 'USDC'],
+    ]
+    for (const [kind, id] of candidates) {
+      const url = buildExplorerUrl(kind, id)
+      if (url !== null) {
+        expect(new URL(url).host).toBe(ALLOWED_HOST)
+      }
+    }
+  })
+
+  it('opens external links with noopener and noreferrer to prevent tab-nabbing', () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+    const ok = openExplorerUrl('tx', validTx)
+
+    expect(ok).toBe(true)
+    expect(openSpy).toHaveBeenCalledTimes(1)
+    const [, target, features] = openSpy.mock.calls[0]
+    expect(target).toBe('_blank')
+    expect(features).toContain('noopener')
+    expect(features).toContain('noreferrer')
+  })
+
+  it('does not attempt to open anything for a rejected identifier', () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+    const ok = openExplorerUrl('account', 'not-a-valid-id')
+
+    expect(ok).toBe(false)
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Closes #1020.

Documents and enforces safe external-link handling (tab-nabbing / referrer-leak / open-redirect).

- `.eslintrc.json` — enables `react/jsx-no-target-blank` as an **error** (`enforceDynamicLinks: always`, `warnOnSpreadAttributes: true`), so every `target="_blank"` anchor must carry `rel="noopener noreferrer"`.
- `docs/security/EXTERNAL_LINKS.md` — the policy: required `rel`, the allow-listed hosts (derived from actual usage), the lint guard, and the safe `explorerLinks` helper (host-pinned + identifier-validated, fail-closed).
- `src/utils/__tests__/explorerLinks.policy.test.ts` — asserts built URLs stay on `stellar.expert` over https, malicious identifiers (other host/scheme, path traversal, embedded creds, trailing junk) are rejected, and `openExplorerUrl` uses `noopener,noreferrer` (and opens nothing for rejected input).

## Verification

- New rule introduces **zero** violations in `src` — confirmed via `next lint --dir src` (grep `jsx-no-target-blank` → 0). All 12 existing `target="_blank"` anchors already have `rel`.
- Tests:
  ```
  vitest run src/utils/__tests__/explorerLinks.policy.test.ts src/utils/__tests__/explorerLinks.test.ts
  ✓ 8 passed
  ```

> Heads-up unrelated to this PR: `npm run lint` is currently **red on master** (pre-existing `no-explicit-any` / `no-unused-vars` errors, plus a parse error in `src/app/commitments/overview/page.tsx`). This PR adds no new lint failures; the existing backlog is out of scope here.