### PR TITLE
feat: add web-vitals field reporting hook and performance budget

### DIFF
--- a/docs/PERFORMANCE_BUDGET.md
+++ b/docs/PERFORMANCE_BUDGET.md
@@ -1,0 +1,98 @@
+# Performance Budget & Web-Vitals Reporting
+
+CommitLabs tracks performance in two complementary ways:
+
+- **Lab** — [Lighthouse CI](performance/LIGHTHOUSE.md) (`lighthouserc.json`) runs
+  synthetic audits on PRs for key routes.
+- **Field** — a web-vitals reporting hook captures **real-user** Core Web Vitals
+  (LCP / CLS / INP) and forwards them to a pluggable sink.
+
+This document defines the budget both should be held to and how the field
+reporting pipeline works.
+
+## Budget (Core Web Vitals)
+
+Field targets use Google's "good" thresholds, encoded in `WEB_VITALS_BUDGET` in
+[`src/lib/perf/webVitals.ts`](../src/lib/perf/webVitals.ts):
+
+| Metric | Budget ("good") | Meaning |
+| ------ | --------------- | ------- |
+| **LCP** (Largest Contentful Paint) | ≤ 2500 ms | Main content rendered |
+| **INP** (Interaction to Next Paint) | ≤ 200 ms | Responsiveness to input |
+| **CLS** (Cumulative Layout Shift) | ≤ 0.1 | Visual stability |
+
+### Key routes
+
+The budget applies to all routes, with these as the tracked priorities (the same
+set Lighthouse CI collects):
+
+| Route | Why it matters |
+| ----- | -------------- |
+| `/` | Landing — first impression, mostly unauthenticated traffic |
+| `/marketplace` | Data-heavy listing grid (search, sort, cards) |
+| `/commitments` | Authenticated dashboard with charts |
+
+> **Lab vs field:** the Lighthouse assertions in `lighthouserc.json` are
+> intentionally looser than the field "good" thresholds (e.g. LCP warns at
+> 4000 ms in lab) because lab runs include cold-start and CI-runner overhead.
+> Treat the field budget above as the user-facing goal and Lighthouse as a
+> regression guard.
+
+## Field reporting pipeline
+
+```
+Browser → next/web-vitals useReportWebVitals
+        → WebVitalsReporter  (src/components/perf/WebVitalsReporter.tsx)
+        → reportWebVital()   (src/lib/perf/webVitals.ts)  ← sanitises to a PII-free record
+        → sink               (no-op by default; opt-in via setWebVitalsSink)
+```
+
+- [`WebVitalsReporter`](../src/components/perf/WebVitalsReporter.tsx) is a tiny
+  client component mounted in [`src/app/layout.tsx`](../src/app/layout.tsx); it
+  renders nothing.
+- [`reportWebVital`](../src/lib/perf/webVitals.ts) normalises each metric to a
+  `WebVitalRecord` — **only** `name`, `value`, and optional `rating`, `id`,
+  `navigationType`. Extra library fields (`entries`, `attribution`, DOM targets)
+  are **dropped**, so no element selectors or user data leave the page. It never
+  throws.
+
+### Privacy
+
+- **No PII.** Records carry only the metric name/value and non-identifying
+  metadata. The `id` is the measurement library's opaque per-metric id, not a
+  user id.
+- **Off by default.** The sink is a no-op until an operator opts in, so no
+  telemetry is collected or transmitted out of the box.
+
+### Enabling a sink
+
+Register a destination once, on the client, before/at app start:
+
+```ts
+import { setWebVitalsSink } from '@/lib/perf/webVitals'
+
+setWebVitalsSink((record) => {
+  // e.g. navigator.sendBeacon('/api/vitals', JSON.stringify(record))
+  // keep it cheap and non-throwing
+})
+```
+
+Use [`isWithinBudget(name, value)`](../src/lib/perf/webVitals.ts) in a sink to
+flag or sample out-of-budget samples.
+
+## Testing
+
+[`src/lib/perf/__tests__/webVitals.test.ts`](../src/lib/perf/__tests__/webVitals.test.ts)
+asserts: no-op by default, sanitized forwarding to a registered sink, unknown
+names / non-finite values dropped, extra PII-like fields not forwarded, the sink
+throwing never propagates, and budget evaluation via `isWithinBudget`.
+
+## Investigating a regression
+
+1. Identify which metric/route regressed (field sink data or Lighthouse CI).
+2. For **LCP**: check the largest above-the-fold element, image sizing/priority,
+   and font loading. See [performance/LAZY_HEALTH_CHARTS.md](performance/LAZY_HEALTH_CHARTS.md)
+   and [performance/GRID_RENDER.md](performance/GRID_RENDER.md).
+3. For **CLS**: reserve space for images/embeds and async content.
+4. For **INP**: reduce long tasks / heavy synchronous work on interaction; lazy
+   load heavy dependencies (framer-motion, recharts, stellar-sdk).

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@ Welcome to the CommitLabs documentation index. This document serves as a single 
 - **[testing/TRUST_BADGE_TESTS.md](testing/TRUST_BADGE_TESTS.md)** — Verification details for seller trust level badges.
 
 ## ♿ Accessibility & Performance
+- **[PERFORMANCE_BUDGET.md](PERFORMANCE_BUDGET.md)** — Core Web Vitals budget (LCP/CLS/INP), the field web-vitals reporting pipeline, and regression triage.
 - **[accessibility-dense-ui.md](accessibility-dense-ui.md)** — Layout rules and size considerations for data-dense tables.
 - **[accessibility/CONTRAST_AUDIT.md](accessibility/CONTRAST_AUDIT.md)** — Verification report on text color contrast ratios.
 - **[accessibility/CREATE_WIZARD_A11Y.md](accessibility/CREATE_WIZARD_A11Y.md)** — Keyboard controls, screen-reader descriptions, and aria labels for form steps.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { CommandPaletteProvider } from "@/components/CommandPalette"
 import { NetworkMismatchBanner } from "@/components/wallet/NetworkMismatchBanner"
 import { Inter, Roboto_Mono } from 'next/font/google'
 import { MotionProvider } from "@/components/MotionProvider"
+import { WebVitalsReporter } from "@/components/perf/WebVitalsReporter"
 
 const inter = Inter({
   subsets: ['latin'],
@@ -99,6 +100,7 @@ export default function RootLayout({
         />
       </head>
       <body>
+        <WebVitalsReporter />
         <a href="#main-content" className="skip-link">Skip to main content</a>
         <ThemeProvider>
           <MotionProvider>

--- a/src/components/perf/WebVitalsReporter.tsx
+++ b/src/components/perf/WebVitalsReporter.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useReportWebVitals } from 'next/web-vitals'
+import { reportWebVital } from '@/lib/perf/webVitals'
+
+/**
+ * Mounts the Next.js web-vitals listener and forwards each metric to the
+ * pluggable reporter in `@/lib/perf/webVitals`. Renders nothing.
+ *
+ * The reporter's sink is a no-op by default, so this is inert until an operator
+ * opts in via `setWebVitalsSink`. See docs/PERFORMANCE_BUDGET.md.
+ */
+export function WebVitalsReporter() {
+  useReportWebVitals((metric) => {
+    reportWebVital(metric)
+  })
+
+  return null
+}

--- a/src/lib/perf/__tests__/webVitals.test.ts
+++ b/src/lib/perf/__tests__/webVitals.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  reportWebVital,
+  setWebVitalsSink,
+  isWithinBudget,
+  WEB_VITALS_BUDGET,
+  type WebVitalRecord,
+} from '../webVitals'
+
+afterEach(() => {
+  setWebVitalsSink() // reset to the no-op default
+})
+
+describe('webVitals reporter', () => {
+  it('is a no-op by default (no sink, no throw)', () => {
+    expect(() =>
+      reportWebVital({ name: 'LCP', value: 1200, id: 'v1' }),
+    ).not.toThrow()
+  })
+
+  it('forwards a sanitized record to a registered sink', () => {
+    const captured: WebVitalRecord[] = []
+    setWebVitalsSink((r) => captured.push(r))
+
+    reportWebVital({
+      name: 'LCP',
+      value: 1800.4,
+      rating: 'good',
+      id: 'metric-1',
+      navigationType: 'navigate',
+    })
+
+    expect(captured).toHaveLength(1)
+    expect(captured[0]).toEqual({
+      name: 'LCP',
+      value: 1800.4,
+      rating: 'good',
+      id: 'metric-1',
+      navigationType: 'navigate',
+    })
+  })
+
+  it('drops unknown metric names and non-finite values', () => {
+    const captured: WebVitalRecord[] = []
+    setWebVitalsSink((r) => captured.push(r))
+
+    reportWebVital({ name: 'NOT_A_METRIC', value: 1 })
+    reportWebVital({ name: 'CLS', value: Number.NaN })
+    reportWebVital({ name: 'LCP', value: Infinity })
+
+    expect(captured).toHaveLength(0)
+  })
+
+  it('does not forward PII-like extra fields from the raw metric', () => {
+    const captured: WebVitalRecord[] = []
+    setWebVitalsSink((r) => captured.push(r))
+
+    // Simulate a raw metric carrying extra fields (entries/attribution/etc.)
+    reportWebVital({
+      name: 'INP',
+      value: 90,
+      id: 'x',
+      // @ts-expect-error — extra fields must be ignored, not forwarded
+      entries: [{ name: 'click', target: 'button#secret' }],
+      attribution: { element: 'div.user-data' },
+    })
+
+    expect(captured).toHaveLength(1)
+    expect(Object.keys(captured[0]).sort()).toEqual(['id', 'name', 'value'])
+    expect('entries' in captured[0]).toBe(false)
+    expect('attribution' in captured[0]).toBe(false)
+  })
+
+  it('never throws even if the sink throws', () => {
+    setWebVitalsSink(() => {
+      throw new Error('sink boom')
+    })
+    expect(() => reportWebVital({ name: 'CLS', value: 0.05 })).not.toThrow()
+  })
+
+  it('evaluates values against the documented budget', () => {
+    expect(isWithinBudget('LCP', WEB_VITALS_BUDGET.LCP)).toBe(true)
+    expect(isWithinBudget('LCP', WEB_VITALS_BUDGET.LCP + 1)).toBe(false)
+    expect(isWithinBudget('CLS', 0.05)).toBe(true)
+    expect(isWithinBudget('CLS', 0.2)).toBe(false)
+    // Metrics without a budget are treated as within budget.
+    expect(isWithinBudget('TTFB', 99999)).toBe(true)
+  })
+})

--- a/src/lib/perf/webVitals.ts
+++ b/src/lib/perf/webVitals.ts
@@ -1,0 +1,100 @@
+/**
+ * Field web-vitals reporting.
+ *
+ * Captures Core Web Vitals from real users and forwards a **minimal, PII-free**
+ * record to a pluggable sink. The sink is a no-op by default, so nothing is
+ * collected or sent until an operator opts in via `setWebVitalsSink`.
+ *
+ * This module is framework-agnostic and SSR-safe (no `window`/`document` access
+ * at import or call time). The Next.js wiring lives in
+ * `src/components/perf/WebVitalsReporter.tsx`.
+ *
+ * @see docs/PERFORMANCE_BUDGET.md
+ */
+
+/** Core Web Vitals (plus a few supporting metrics Next reports). */
+export type WebVitalName = 'LCP' | 'CLS' | 'INP' | 'FCP' | 'TTFB' | 'FID'
+
+/** A sanitized, serialisable metric record. Contains no PII. */
+export interface WebVitalRecord {
+  /** Metric short name, e.g. `LCP`. */
+  name: WebVitalName
+  /** Metric value (ms, except CLS which is unitless). */
+  value: number
+  /** Google rating bucket, when provided by the source. */
+  rating?: 'good' | 'needs-improvement' | 'poor'
+  /** Opaque per-metric id from the measurement library (not user-identifying). */
+  id?: string
+  /** Navigation type, e.g. `navigate`, `reload`, `back-forward`. */
+  navigationType?: string
+}
+
+/**
+ * Performance budget for key Core Web Vitals, aligned with Google's "good"
+ * thresholds. Documented per-route in docs/PERFORMANCE_BUDGET.md.
+ */
+export const WEB_VITALS_BUDGET = {
+  /** Largest Contentful Paint — milliseconds. */
+  LCP: 2500,
+  /** Interaction to Next Paint — milliseconds. */
+  INP: 200,
+  /** Cumulative Layout Shift — unitless. */
+  CLS: 0.1,
+} as const
+
+export type WebVitalsSink = (record: WebVitalRecord) => void
+
+/** Default sink: a no-op. Nothing is collected until an operator opts in. */
+const noopSink: WebVitalsSink = () => {}
+
+let sink: WebVitalsSink = noopSink
+
+/**
+ * Register the destination for web-vitals records (e.g. an analytics beacon).
+ * Pass nothing to reset back to the no-op default.
+ */
+export function setWebVitalsSink(next?: WebVitalsSink): void {
+  sink = next ?? noopSink
+}
+
+/** Shape accepted from `next/web-vitals` / the `web-vitals` library. */
+interface RawMetric {
+  name: string
+  value: number
+  rating?: string
+  id?: string
+  navigationType?: string
+  // intentionally ignore any other fields (entries, attribution, etc.)
+}
+
+const KNOWN_NAMES = new Set<WebVitalName>(['LCP', 'CLS', 'INP', 'FCP', 'TTFB', 'FID'])
+
+/**
+ * Normalise a raw metric to a PII-free {@link WebVitalRecord} and forward it to
+ * the configured sink. Unknown metric names and non-finite values are dropped.
+ * Never throws — reporting must not affect the page.
+ */
+export function reportWebVital(metric: RawMetric): void {
+  try {
+    if (!metric || !KNOWN_NAMES.has(metric.name as WebVitalName)) return
+    if (typeof metric.value !== 'number' || !Number.isFinite(metric.value)) return
+
+    const record: WebVitalRecord = {
+      name: metric.name as WebVitalName,
+      value: metric.value,
+      ...(metric.rating ? { rating: metric.rating as WebVitalRecord['rating'] } : {}),
+      ...(metric.id ? { id: metric.id } : {}),
+      ...(metric.navigationType ? { navigationType: metric.navigationType } : {}),
+    }
+
+    sink(record)
+  } catch {
+    // Swallow — telemetry must never break the app.
+  }
+}
+
+/** Whether a metric value is within the documented budget (if one exists). */
+export function isWithinBudget(name: WebVitalName, value: number): boolean {
+  const budget = (WEB_VITALS_BUDGET as Record<string, number>)[name]
+  return budget === undefined ? true : value <= budget
+}


### PR DESCRIPTION
## Summary

Closes #1016.

Adds real-user (field) Core Web Vitals capture to complement the existing Lighthouse (lab) CI, plus a documented budget.

- `src/lib/perf/webVitals.ts` — `reportWebVital` normalises each metric to a **PII-free** `WebVitalRecord` (`name`, `value`, optional `rating`/`id`/`navigationType`); raw `entries`/`attribution`/DOM targets are dropped. The sink is a **no-op by default** (opt-in via `setWebVitalsSink`), SSR-safe, and never throws. Exports `WEB_VITALS_BUDGET` (LCP ≤ 2500, INP ≤ 200, CLS ≤ 0.1) and `isWithinBudget`.
- `src/components/perf/WebVitalsReporter.tsx` — minimal `'use client'` wrapper using `next/web-vitals` `useReportWebVitals` (no new dependency); mounted in `src/app/layout.tsx`.
- `src/lib/perf/__tests__/webVitals.test.ts` — 6 tests.
- `docs/PERFORMANCE_BUDGET.md` — budget, pipeline diagram, privacy stance, lab-vs-field note, and regression triage.

## Notes

- Uses the built-in `next/web-vitals` hook, so **no new dependency**.
- A client wrapper component was needed because `useReportWebVitals` is a hook and `layout.tsx` is a server component — kept to a render-nothing component.

## Testing

```
vitest run src/lib/perf/__tests__/webVitals.test.ts
✓ 6 passed
```