### PR TITLE
chore: add typecheck script and a reporting typecheck CI workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,45 @@
+# .github/workflows/typecheck.yml
+# Runs `tsc --noEmit` on PRs/pushes for fast, isolated type feedback.
+#
+# Reporting (non-blocking) for now: `next.config.js` sets
+# `typescript.ignoreBuildErrors: true`, so the build does not type-check, and
+# there is an existing type-error backlog. This job surfaces type errors without
+# blocking PRs. Once the backlog is at zero, remove `continue-on-error` to make
+# it a required gate. See docs/CI.md.
+
+name: Typecheck
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  typecheck:
+    name: tsc --noEmit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Non-blocking while the type-error backlog is burned down.
+      # Flip to a hard failure (drop continue-on-error) once `npm run typecheck`
+      # is clean. Uses the same tsconfig.json as the build to avoid drift.
+      - name: Typecheck
+        run: npm run typecheck
+        continue-on-error: true

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,55 @@
+# Continuous Integration
+
+This document describes the CI workflows in `.github/workflows/` and how to run
+their checks locally.
+
+## Workflows
+
+| Workflow | File | Purpose | Blocking? |
+| -------- | ---- | ------- | --------- |
+| Coverage Check | `coverage.yml` | Vitest with coverage thresholds | Yes |
+| Lighthouse | `lighthouse.yml` | Lab performance/a11y/SEO audits | Warn |
+| CodeQL | `codeql.yml` | Security static analysis | Yes |
+| Contracts | `contracts.yml` | Soroban contract checks | Yes |
+| **Typecheck** | `typecheck.yml` | `tsc --noEmit` type feedback | **Reporting (non-blocking) — see below** |
+
+## Typecheck gate
+
+```bash
+npm run typecheck   # tsc --noEmit, using the project tsconfig.json
+```
+
+The `typecheck` script runs `tsc --noEmit` against the **same `tsconfig.json`
+the build uses**, so there is no config drift. It gives fast, isolated type
+feedback locally and in CI without producing build output.
+
+### Why it is currently non-blocking
+
+Two things make a hard type gate impossible to turn on today:
+
+1. **The build does not type-check.** `next.config.js` sets
+   `typescript.ignoreBuildErrors: true` (and `eslint.ignoreDuringBuilds: true`),
+   so `next build` never fails on type errors. Types have therefore been
+   effectively unenforced.
+2. **There is an existing type-error backlog**, almost entirely in test files
+   (missing test-runner globals, drifted helper signatures, stale import paths),
+   plus a smaller set in application source.
+
+So `typecheck.yml` runs `npm run typecheck` with `continue-on-error: true`: it
+**reports** the current type-error surface on every PR/push but does not block
+merges yet.
+
+### Making it blocking
+
+The intended path to a real gate:
+
+1. Burn the backlog down to zero (`npm run typecheck` clean). Tackling the test
+   files first removes the bulk of it; consider a dedicated test `tsconfig` that
+   pulls in the Vitest globals so test files type-check the way they run.
+2. Remove `continue-on-error: true` from the `Typecheck` step in
+   `typecheck.yml`.
+3. Optionally also set `typescript.ignoreBuildErrors: false` in `next.config.js`
+   so the build enforces types too.
+
+Until step 1 is done, please avoid adding **new** type errors — the reporting
+job makes them visible in the PR checks.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Welcome to the CommitLabs documentation index. This document serves as a single 
 ## 📖 Overview & General Guides
 - **[README.md](../README.md)** (Root) — Main project overview, features, configuration guide, and quick start instructions.
 - **[DEVELOPER_GUIDE.md](../DEVELOPER_GUIDE.md)** (Root) — Coding standards, TypeScript conventions, styling practices, package management, and testing workflows.
+- **[CI.md](CI.md)** — CI workflows (coverage, Lighthouse, CodeQL, contracts, typecheck) and how to run their checks locally.
 - **[GLOSSARY.md](GLOSSARY.md)** — Explanations of core business domain terms (e.g., Safe, Balanced, Aggressive commitments, drawdowns).
 - **[todo/TODO.md](todo/TODO.md)** — Tracked checklist for self-hosting fonts performance feature.
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage",


### PR DESCRIPTION
## Summary

Closes #1006.

Adds a `typecheck` npm script and a CI workflow giving fast, isolated `tsc --noEmit` feedback.

- `package.json` — `"typecheck": "tsc --noEmit"` (uses the build's `tsconfig.json`, so **no config drift**).
- `.github/workflows/typecheck.yml` — runs `npm run typecheck` on PRs/pushes (Node 20, `npm ci`), matching the existing workflows' shape.
- `docs/CI.md` — documents all CI workflows and the path to making typecheck a required gate.

## Why the job is non-blocking (reporting) for now

I verified the actual state before wiring this up, and the issue's premise ("type errors only surface during `next build`") doesn't hold:

- **The build doesn't type-check at all** — `next.config.js` sets `typescript.ignoreBuildErrors: true` (and `eslint.ignoreDuringBuilds: true`). Types have been effectively unenforced.
- **`tsc --noEmit` currently reports ~730 errors** — ~648 in test files (missing Vitest globals, drifted helper signatures, stale import paths) and ~82 across 26 application files.

A hard gate would therefore be permanently red. So the workflow runs with `continue-on-error: true`: it **surfaces** the type-error count on every PR without blocking merges, and `docs/CI.md` documents the steps to flip it to blocking once the backlog reaches zero (this mirrors the report-first approach intended for the knip/madge jobs).

## Findings (not fixed here, to keep this PR scoped to CI tooling)

While verifying, I found two files with genuine **syntax** errors (not just type errors), currently masked by `ignoreBuildErrors`:
- `src/app/commitments/overview/page.tsx` — a stray brace closes the `try` before `catch` (bad-merge artifact).
- `src/components/MarketplaceHeader/MarketplaceHeader.tsx` — a duplicated destructuring + `useState` block (bad merge). Its test file `tests/components/MarketplaceHeader/MarketplaceHeader.test.tsx` is similarly duplicated.

I have clean fixes for both but kept them out of this tooling PR — happy to open a focused bug-fix PR for them.

## Testing

`npm run typecheck` runs locally and in CI; output is the current type-error report (non-blocking by design). No application code changed in this PR.