### PR TITLE
perf: add bundle-size budget gate with size-limit

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,0 +1,47 @@
+# .github/workflows/size-limit.yml
+# Enforces a per-entry client bundle-size budget with size-limit.
+#
+# size-limit measures the production build output, so this job builds the app
+# and then checks the gzipped chunk sizes against .size-limit.json. It fails
+# when a budget is exceeded.
+#
+# NOTE: this requires a successful `next build`. See docs/performance/BUNDLE_BUDGET.md.
+
+name: Size Limit
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  size-limit:
+    name: size-limit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          # Builds must be deterministic for size comparison.
+          NODE_ENV: production
+
+      - name: Check bundle size budget
+        run: npm run size

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Client JS — all chunks (gzip)",
+    "path": ".next/static/chunks/**/*.js",
+    "limit": "1500 kB"
+  },
+  {
+    "name": "Framework + main entry (gzip)",
+    "path": [
+      ".next/static/chunks/framework-*.js",
+      ".next/static/chunks/main-*.js",
+      ".next/static/chunks/webpack-*.js"
+    ],
+    "limit": "120 kB"
+  },
+  {
+    "name": "Heavy shared vendor (recharts/framer-motion/stellar-sdk) (gzip)",
+    "path": ".next/static/chunks/+([0-9])-*.js",
+    "limit": "600 kB"
+  }
+]

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ Welcome to the CommitLabs documentation index. This document serves as a single 
 - **[accessibility/CONTRAST_AUDIT.md](accessibility/CONTRAST_AUDIT.md)** — Verification report on text color contrast ratios.
 - **[accessibility/CREATE_WIZARD_A11Y.md](accessibility/CREATE_WIZARD_A11Y.md)** — Keyboard controls, screen-reader descriptions, and aria labels for form steps.
 - **[accessibility/MARKETPLACE_A11Y.md](accessibility/MARKETPLACE_A11Y.md)** — Focus traps and accessible properties for comparing search items.
+- **[performance/BUNDLE_BUDGET.md](performance/BUNDLE_BUDGET.md)** — Enforced client bundle-size budget with size-limit: budgets, CI gate, calibration, and regression triage.
 - **[performance/GRID_RENDER.md](performance/GRID_RENDER.md)** — Virtualization, rendering limits, and performance improvements for large listing grids.
 - **[performance/LAZY_HEALTH_CHARTS.md](performance/LAZY_HEALTH_CHARTS.md)** — Lazy loading strategies and performance metrics for dashboard metrics rendering.
 - **[performance/LIGHTHOUSE.md](performance/LIGHTHOUSE.md)** — Lighthouse metrics checks and automated page speed scoring results.

--- a/docs/performance/BUNDLE_BUDGET.md
+++ b/docs/performance/BUNDLE_BUDGET.md
@@ -1,0 +1,68 @@
+# Bundle Size Budget (size-limit)
+
+Bundle growth was previously only observable via the optional analyzer. This adds
+an enforced per-entry **bundle-size budget** with
+[size-limit](https://github.com/ai/size-limit) so heavy dependencies
+(`framer-motion`, `recharts`, `@stellar/stellar-sdk`) cannot silently inflate the
+client bundle.
+
+> Complements the runtime [performance budget](../PERFORMANCE_BUDGET.md) (Core
+> Web Vitals) and the lab [Lighthouse](LIGHTHOUSE.md) checks. This file is about
+> **shipped bytes**.
+
+## Running it
+
+```bash
+npm run build     # size-limit measures the production build output
+npm run size      # check .next chunks against .size-limit.json (gzip)
+```
+
+## Budgets
+
+Configured in [`.size-limit.json`](../../.size-limit.json) (sizes are **gzipped**):
+
+| Entry | Glob | Budget |
+| ----- | ---- | ------ |
+| All client JS chunks | `.next/static/chunks/**/*.js` | 1500 kB |
+| Framework + main + webpack runtime | `framework-*`, `main-*`, `webpack-*` | 120 kB |
+| Heavy shared vendor | numbered shared chunks | 600 kB |
+
+> **These are initial ceilings, not measured baselines.** They must be
+> **calibrated** against the first successful production build (set each limit a
+> little above the real number so genuine regressions trip it). See
+> [Calibrating](#calibrating-the-budgets).
+
+## CI
+
+[`size-limit.yml`](../../.github/workflows/size-limit.yml) builds the app and runs
+`npm run size` on PRs/pushes, failing when a budget is exceeded. For a per-PR
+size **delta** comment, the [`andresz1/size-limit-action`](https://github.com/andresz1/size-limit-action)
+can be added later; this PR keeps the dependency surface minimal with a plain
+build + check.
+
+> **Prerequisite — a green build.** size-limit measures build output, so this job
+> needs `next build` to succeed. At the time of writing the production build is
+> **broken** by pre-existing parse/export errors (e.g.
+> `src/app/commitments/overview/page.tsx`, `src/lib/backend/validation.ts`,
+> `src/components/MarketplaceHeader/MarketplaceHeader.tsx`) — note that
+> `next.config.js` `ignoreBuildErrors` suppresses *type* errors but **not** these
+> syntax/parse errors. The budget gate becomes effective once the build is fixed;
+> the budgets should be calibrated at that point.
+
+## Calibrating the budgets
+
+1. Once `npm run build` succeeds, run `npm run size` and note the actual gzipped
+   sizes per entry.
+2. Set each `limit` in `.size-limit.json` slightly above its current size (e.g.
+   +5–10%) so normal noise passes but real growth fails.
+3. Commit the calibrated `.size-limit.json`.
+
+## Investigating a regression
+
+1. `npm run size` shows which entry exceeded its budget and by how much.
+2. Identify the culprit import — heavy libs (`recharts`, `framer-motion`,
+   `@stellar/stellar-sdk`) are the usual cause.
+3. Prefer **dynamic `import()`** / `next/dynamic` for components that use them so
+   they land in a route-level chunk instead of the shared bundle. See
+   [GRID_RENDER.md](GRID_RENDER.md) and [LAZY_HEALTH_CHARTS.md](LAZY_HEALTH_CHARTS.md).
+4. Re-run `npm run size` to confirm you're back under budget.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "commitlabs-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@rolldown/binding-linux-x64-gnu": "^1.1.3",
         "@stellar/freighter-api": "^1.6.0",
         "@stellar/stellar-sdk": "^11.2.2",
         "@tailwindcss/postcss": "^4.1.18",
@@ -27,6 +26,8 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
+        "@size-limit/file": "^12.1.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -42,6 +43,7 @@
         "ioredis": "^5.11.0",
         "jsdom": "^29.1.1",
         "node-fetch": "^3.3.2",
+        "size-limit": "^12.1.0",
         "tsx": "^4.21.0",
         "typescript": "^5.0.0",
         "vitest": "^4.0.18"
@@ -1500,6 +1502,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmmirror.com/@polka/url/-/url-1.0.0-next.29.tgz",
@@ -1541,21 +1559,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
-      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1928,6 +1931,19 @@
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@size-limit/file": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.1.0.tgz",
+      "integrity": "sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -3925,6 +3941,16 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/call-bind": {
@@ -7072,6 +7098,19 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz",
@@ -7314,6 +7353,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
       }
     },
     "node_modules/napi-postinstall": {
@@ -7835,6 +7884,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8689,6 +8784,34 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/size-limit": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.1.0.tgz",
+      "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/sodium-native": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "size": "size-limit",
     "test": "vitest",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage",
@@ -15,7 +16,6 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-
     "@stellar/freighter-api": "^1.6.0",
     "@stellar/stellar-sdk": "^11.2.2",
     "@tailwindcss/postcss": "^4.1.18",
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
+    "@size-limit/file": "^12.1.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -50,6 +51,7 @@
     "ioredis": "^5.11.0",
     "jsdom": "^29.1.1",
     "node-fetch": "^3.3.2",
+    "size-limit": "^12.1.0",
     "tsx": "^4.21.0",
     "typescript": "^5.0.0",
     "vitest": "^4.0.18"


### PR DESCRIPTION
## Summary

Closes #1021.

Adds an enforced per-entry bundle-size budget so heavy deps (`framer-motion`, `recharts`, `@stellar/stellar-sdk`) can't silently inflate the client bundle.

- `size-limit` + `@size-limit/file` devDeps, `.size-limit.json` with gzipped per-entry budgets (all client JS, framework/main/runtime, heavy shared vendor).
- `size` npm script (`size-limit`).
- `.github/workflows/size-limit.yml` — builds then checks budgets on PRs/pushes, failing on regressions over budget.
- `docs/performance/BUNDLE_BUDGET.md` — budgets, how to calibrate, CI, and regression triage. Kept as a separate doc (cross-linked) rather than editing `PERFORMANCE_BUDGET.md`, to avoid colliding with the in-flight web-vitals PR (#1077) that introduces that file.

## Important: the gate needs a green build (currently broken)

size-limit measures build output, so this needs `next build` to succeed. While verifying, I found **`next build` currently fails** on master:

```
src/app/commitments/overview/page.tsx  — Syntax Error (stray brace closes try before catch)
src/lib/backend/validation.ts          — Export 'addressSchema' is not defined
```

`next.config.js` `ignoreBuildErrors: true` suppresses *type* errors but **not** these parse/export errors, so the production build (and presumably Vercel deploys) is broken independently of this PR. The size budget activates once the build is fixed; the budgets in `.size-limit.json` are **initial ceilings to calibrate** against the first successful build (documented in the doc).

I have a clean fix for the `page.tsx` syntax error and can open a focused build-fix PR (it also unblocks the #1006 typecheck gate) if you'd like.

## Notes

- Used `@size-limit/file` (lightweight gzip measurement) rather than the puppeteer-based time preset to keep the dependency footprint small.