### PR TITLE
fix: repair the broken production build (next build now succeeds)

### DIFF
--- a/src/app/commitments/overview/page.tsx
+++ b/src/app/commitments/overview/page.tsx
@@ -13,12 +13,10 @@ export default function CommitmentOverviewPage() {
     async function loadCommitments() {
       try {
         const data = await apiGet<{ data: Commitment[] }>('/api/commitments');
-        setCommitments(data.data);
-          if (data && Array.isArray(data.data)) {
-            setCommitments(data.data);
-          } else if (Array.isArray(data)) {
-            setCommitments(data);
-          }
+        if (data && Array.isArray(data.data)) {
+          setCommitments(data.data);
+        } else if (Array.isArray(data)) {
+          setCommitments(data);
         }
       } catch (err) {
         console.error("Failed to load commitments", err);

--- a/src/app/commitments/page.tsx
+++ b/src/app/commitments/page.tsx
@@ -11,6 +11,7 @@ import CommitmentEarlyExitModal from '@/components/CommitmentEarlyExitModal/Comm
 import ExportCommitmentsModal from '@/components/export/ExportCommitmentsModal'
 import ListForSaleModal from '@/components/modals/ListForSaleModal'
 import { useWallet } from '@/hooks/useWallet'
+import { useToast } from '@/components/toast/ToastProvider'
 import { Commitment, CommitmentStats } from '@/types/commitment'
 import { listCommitments } from '@/lib/backend/mocks/contracts'
 import { fetchProtocolConstants, ProtocolConstants } from '@/utils/protocol'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ const SolutionSection = dynamic(() => import('@/components/SolutionSection'), {
   loading: () => <Skeleton className="w-full h-64" />,
   ssr: false,
 });
-const CoreConceptsSection = dynamic(() => import('@/components/landing-page/sections/CoreConceptsSection'), {
+const CoreConceptsSection = dynamic(() => import('@/components/landing-page/sections/CoreConceptsSection').then((m) => m.CoreConceptsSection), {
   loading: () => <Skeleton className="w-full h-64" />,
   ssr: false,
 });
@@ -25,7 +25,7 @@ const ImpactSection = dynamic(() => import('@/components/ImpactSection'), {
   loading: () => <Skeleton className="w-full h-64" />,
   ssr: false,
 });
-const ExperienceSection = dynamic(() => import('@/components/landing-page/sections/ExperienceSection'), {
+const ExperienceSection = dynamic(() => import('@/components/landing-page/sections/ExperienceSection').then((m) => m.ExperienceSection), {
   loading: () => <Skeleton className="w-full h-64" />,
   ssr: false,
 });

--- a/src/components/MarketplaceHeader/MarketplaceHeader.tsx
+++ b/src/components/MarketplaceHeader/MarketplaceHeader.tsx
@@ -80,11 +80,6 @@ export function MarketplaceHeader({
   backHref = '/',
   createHref = '/create',
   searchQuery: controlledQuery,
-}: MarketplaceHeaderProps) {
-  const [stats, setStats] = useState<MarketplaceStats | null>(null);
-  const [statsError, setStatsError] = useState<string | null>(null);
-  const [sortValue, setSortValue] = useState<SortValue>('popular');
-  const [query, setQuery] = useState(controlledQuery ?? '');
   ownerAddress,
   onResultSelect,
 }: MarketplaceHeaderProps) {

--- a/src/lib/backend/validation.ts
+++ b/src/lib/backend/validation.ts
@@ -58,6 +58,13 @@ const amountSchema = z.union([z.string(), z.number()]).transform((val) => {
   return num;
 });
 
+const addressSchema = z
+  .string()
+  .trim()
+  .refine((addr) => StrKey.isValidEd25519PublicKey(addr), {
+    message: "Must be a valid Stellar address (G... format).",
+  });
+
 const paginationSchema = z
   .object({
     page: z


### PR DESCRIPTION
## Summary

`next build` is currently **broken on master** — production deploys cannot succeed. `next.config.js` sets `typescript.ignoreBuildErrors: true` / `eslint.ignoreDuringBuilds: true`, which hid type/lint problems, but these are **parse/eval/prerender** failures that those flags do **not** suppress. This PR fixes them so the build completes end-to-end.

Found and fixed by running `next build` repeatedly until green:

1. **`src/lib/backend/validation.ts`** — `addressSchema` was referenced by the `*Old` schemas and re-exported as `stellarAddressSchema`, but **never declared** (only `addressSchema2` existed). Module evaluation threw → `Export 'addressSchema' is not defined`. Added the missing definition (same logic as `addressSchema2`, defined before first use).
2. **`src/app/commitments/overview/page.tsx`** — a stray brace + duplicate `setCommitments` closed the `try` before `catch` (`'catch' or 'finally' expected`). Bad-merge artifact.
3. **`src/components/MarketplaceHeader/MarketplaceHeader.tsx`** — a duplicated destructuring + `useState` block from a bad merge (parse error).
4. **`src/app/page.tsx`** — `CoreConceptsSection` and `ExperienceSection` are **named** exports but were `dynamic(() => import(...))`-ed as defaults, so prerendering the landing page rendered a module namespace → `Unsupported Server Component type: Module`. Mapped each to its named export.
5. **`src/app/commitments/page.tsx`** — `useToast()` was used but never imported → `ReferenceError: useToast is not defined` at prerender. Added the import from `@/components/toast/ToastProvider`.

## Verification

```
next build  →  ✓ exit 0   (all 39 pages + API routes built)
```
(run with `SESSION_SECRET` / `SOROBAN_RPC_URL_ALLOWLIST` set, which the env validator requires in production — CI/Vercel already provide these).

`tests/lib/backend/validation.test.ts` goes from **unloadable** on master (the undefined `addressSchema` throws on import) to **141/143 passing**. The 2 remaining failures are a pre-existing `validateAmount` bug (throws a generic `Error` instead of `ValidationError`) — unrelated to this change.

## Out of scope (pre-existing, non-blocking — flagged for follow-up)

The build now also emits non-fatal "Attempted import error" **warnings** for exports that don't exist; these don't break the build but would 500 the affected routes at runtime, and are worth a separate fix:
- `AUTH_COOKIE_NAME`, `COOKIE_OPTIONS` — not exported from `@/lib/backend/auth` (used by `api/auth/logout`).
- `transferOwnership` — not exported from `@/lib/backend/services/contracts` (used by `api/marketplace/listings/[id]/purchase`).

Also unblocks the typecheck (#1078) and size-limit (#1081) gates, which need a green build.