### PR TITLE
chore: add CODEOWNERS for area-based review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# CODEOWNERS
+#
+# This file routes review requests to the right maintainers based on the
+# area of the codebase a change touches. The last matching pattern wins, so
+# more specific patterns are placed below the broad fallback.
+#
+# See docs/CODEOWNERS.md for how ownership maps to review expectations.
+
+# Fallback owner for anything not matched by a more specific rule below.
+*                       @Commitlabs-Org/maintainers
+
+# Frontend: app router, UI components and styles
+/src/app/               @Commitlabs-Org/frontend
+/src/components/        @Commitlabs-Org/frontend
+/src/styles/            @Commitlabs-Org/frontend
+
+# API / backend library layer
+/src/app/api/           @Commitlabs-Org/backend
+/src/lib/backend/       @Commitlabs-Org/backend
+
+# Smart contracts
+/contracts/             @Commitlabs-Org/contracts
+
+# Documentation
+/docs/                  @Commitlabs-Org/docs
+*.md                    @Commitlabs-Org/docs

--- a/docs/CODEOWNERS.md
+++ b/docs/CODEOWNERS.md
@@ -1,0 +1,29 @@
+# Code Ownership & Review Routing
+
+This repository uses a [`.github/CODEOWNERS`](../.github/CODEOWNERS) file so that
+review requests are automatically routed to the maintainers responsible for the
+area a pull request touches.
+
+## How it works
+
+- When a PR changes files matching a pattern in `CODEOWNERS`, GitHub
+  automatically requests a review from the listed owner(s).
+- The **last matching pattern wins**. A broad fallback (`*`) is declared first,
+  and more specific area patterns are declared below it.
+
+## Ownership map
+
+| Area            | Paths                                        | Owner                            |
+| --------------- | -------------------------------------------- | -------------------------------- |
+| Fallback        | everything                                   | `@Commitlabs-Org/maintainers`    |
+| Frontend        | `src/app/`, `src/components/`, `src/styles/` | `@Commitlabs-Org/frontend`       |
+| API / backend   | `src/app/api/`, `src/lib/backend/`           | `@Commitlabs-Org/backend`        |
+| Contracts       | `contracts/`                                 | `@Commitlabs-Org/contracts`      |
+| Documentation   | `docs/`, `*.md`                              | `@Commitlabs-Org/docs`           |
+
+## Review expectations
+
+- At least one code owner approval is expected before merge for the matched area.
+- Docs-only changes route to the docs owners and do not require frontend/backend
+  sign-off.
+- If a change spans multiple areas, all matching owners are requested.


### PR DESCRIPTION
Closes #1015.

Adds a `.github/CODEOWNERS` mapping the frontend (app/components/styles), API/backend layer, contracts, and docs to area owners, with a broad `*` fallback so there are no gaps. The last-match-wins ordering keeps specific area rules above the fallback. Also adds `docs/CODEOWNERS.md` documenting how ownership maps to review expectations.