### PR TITLE
chore: add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,35 @@
+# EditorConfig is awesome: https://editorconfig.org
+# Top-most EditorConfig file
+root = true
+
+# Defaults for all files
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# TypeScript / JavaScript / React
+[*.{ts,tsx,js,jsx,mjs,cjs}]
+indent_style = space
+indent_size = 2
+
+# Styles
+[*.{css,scss}]
+indent_style = space
+indent_size = 2
+
+# Data / config
+[*.{json,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# Markdown: keep trailing whitespace (two trailing spaces = hard line break)
+[*.md]
+trim_trailing_whitespace = false
+
+# Makefiles require real tabs
+[Makefile]
+indent_style = tab

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,9 @@ Before diving into the code, please read through our [Developer Guide](./DEVELOP
 2. Ensure your fork is synced with the upstream `master` branch.
 3. Create a feature branch off of `master` using standard prefixes: `feat/<description>`, `fix/<description>`, `docs/<description>`, or `test/<description>`.
 
+## Editor Configuration
+This repository ships an [`.editorconfig`](./.editorconfig) at the root to keep whitespace, charset, and line endings consistent across editors. Most editors support it natively or via a plugin. It enforces UTF-8, LF line endings, 2-space indentation, a final newline, and trailing-whitespace trimming (Markdown excepted, so hard line breaks are preserved). These rules are aligned with the ESLint config to avoid formatting-only diffs.
+
 ## Pull Request Flow
 1. Commit your changes logically and with clear, descriptive commit messages.
 2. Push your feature branch to your fork.


### PR DESCRIPTION
Closes #1010.

Adds a root `.editorconfig` aligned with the existing 2-space code style: UTF-8 charset, LF line endings, final newline, and trailing-whitespace trimming. Covers TS/TSX/JS, CSS, JSON, and YAML; Markdown keeps trailing whitespace so hard line breaks are preserved. Rules are consistent with the ESLint config to avoid formatting-only diffs. Documented in CONTRIBUTING.md.