### PR TITLE
chore: add Dependabot for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "area-frontend"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      # Reduce PR noise: batch all minor/patch bumps into one PR.
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Majors are handled manually to avoid surprise breaking changes.
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  # GitHub Actions used by workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -1,0 +1,30 @@
+# Dependency Updates
+
+Dependency updates are automated with [Dependabot](../.github/dependabot.yml).
+
+## What is covered
+
+| Ecosystem        | Directory | Schedule        |
+| ---------------- | --------- | --------------- |
+| `npm`            | `/`       | Weekly (Monday) |
+| `github-actions` | `/`       | Weekly (Monday) |
+
+## Cadence and grouping
+
+- Dependabot runs **weekly** on Monday morning.
+- **Minor and patch** updates are **grouped** into a single PR per ecosystem to
+  reduce review noise.
+- **Major** version bumps for npm are **ignored** by automation and must be
+  performed deliberately, since they may include breaking changes.
+- Pinned GitHub Actions are still updated (Dependabot rewrites the pinned ref).
+
+## Triage policy
+
+1. **Grouped minor/patch PRs**: review the changelog summary, confirm CI is
+   green (lint, tests, audit), then merge.
+2. **Security updates**: prioritize over routine updates; merge as soon as CI
+   passes.
+3. **Major updates**: open a tracking issue, read the upgrade/migration guide,
+   and schedule the work separately from routine maintenance.
+4. If a PR breaks CI, comment `@dependabot rebase` after a fix lands, or close it
+   with a note if the bump is intentionally deferred.


### PR DESCRIPTION
Closes #1007.

Adds `.github/dependabot.yml` covering the npm and github-actions ecosystems on a weekly schedule. Minor/patch updates are grouped to reduce PR noise, major npm bumps are ignored so they are handled deliberately, and conventional commit prefixes are applied. Adds `docs/DEPENDENCY_UPDATES.md` documenting the cadence and triage policy.