### PR TITLE
chore: add npm audit and dependency-review CI gate

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,50 @@
+# .github/workflows/security-audit.yml
+# Scans dependencies for known vulnerabilities on PRs and pushes.
+#   - npm audit: fails the build on high/critical advisories in production deps.
+#   - dependency-review: flags risky dependency changes introduced by a PR.
+
+name: Security Audit
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  npm-audit:
+    name: npm audit (prod deps)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Requires a lockfile so the audit is reproducible.
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    # Dependency review only runs on pull requests.
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/docs/backend-security-checklist.md
+++ b/docs/backend-security-checklist.md
@@ -159,6 +159,29 @@ npm audit
 
 ---
 
+## Dependency Audit Gate
+
+Pull requests are scanned for known-vulnerable dependencies by the
+[`security-audit`](../.github/workflows/security-audit.yml) workflow:
+
+- **`npm audit --omit=dev --audit-level=high`** fails CI when a **high or
+  critical** advisory affects a **production** dependency. Dev-only advisories
+  do not block the build.
+- **`dependency-review-action`** runs on PRs and flags dependency changes that
+  introduce advisories at `high` severity or above. It requires a committed
+  lockfile to diff against.
+
+### Triaging / waiving findings
+
+1. Prefer upgrading to a patched version (`npm update <pkg>` or bump the range).
+2. If no fix exists and the advisory is not exploitable in our usage, document
+   the rationale in the PR and track it as a follow-up issue.
+3. As a last resort, scope a temporary waiver narrowly (e.g. raise the
+   `audit-level` only for the affected job) and link the tracking issue so it is
+   revisited.
+
+---
+
 ## Severity Guide
 
 Use this when flagging issues during review:


### PR DESCRIPTION
Closes #1008.

Adds `.github/workflows/security-audit.yml` with two jobs: `npm audit --omit=dev --audit-level=high` (fails CI on high/critical advisories in production deps, leaving dev-only advisories non-blocking) and `dependency-review-action` on PRs to flag risky dependency changes. Extends `docs/backend-security-checklist.md` with the audit gate and a triage/waiver process.