### PR TITLE
chore: add Husky pre-commit hook running lint and typecheck

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/docs/CONTRIBUTING_HOOKS.md
+++ b/docs/CONTRIBUTING_HOOKS.md
@@ -1,0 +1,39 @@
+# Git Hooks
+
+This repository uses [Husky](https://typicode.github.io/husky/) and
+[lint-staged](https://github.com/lint-staged/lint-staged) to catch issues
+before they reach CI, keeping the feedback loop short for contributors.
+
+## How it works
+
+Hooks are installed automatically after `npm install` (or `pnpm install`) via
+the `prepare` script, which runs `husky`.
+
+### pre-commit
+
+The [`.husky/pre-commit`](../.husky/pre-commit) hook runs `lint-staged`, which
+operates **only on staged files** so commits stay fast. For staged
+`*.{ts,tsx,js,jsx}` files it:
+
+1. Runs `eslint --fix` to auto-fix and report lint errors.
+2. Runs `tsc --noEmit` for a typecheck.
+
+If lint or the typecheck fails, the commit is aborted so the problem is fixed
+locally rather than in CI.
+
+## Bypassing the hook
+
+In an emergency you can skip the hook with:
+
+```bash
+git commit --no-verify -m "wip: ..."
+```
+
+Use this sparingly — CI still runs the full lint, typecheck, and test suite, so
+bypassing locally only defers the feedback.
+
+## Notes
+
+- The hook is intentionally lightweight and never runs the full test suite.
+- CI does not re-run these hooks; it runs the equivalent checks directly, so
+  there is no redundant work.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,15 @@
     "test:coverage": "vitest --coverage",
     "test:contracts:deploy": "node contracts/scripts/deploy-testnet.smoke.mjs",
     "seed:mock": "tsx scripts/seed-backend-mock.ts",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "typecheck": "tsc --noEmit",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": [
+      "eslint --fix",
+      "bash -c 'tsc --noEmit'"
+    ]
   },
   "dependencies": {
 
@@ -47,7 +55,9 @@
     "eslint": "^8.0.0",
     "eslint-config-next": "^14.0.0",
     "happy-dom": "^20.7.0",
+    "husky": "^9.1.7",
     "ioredis": "^5.11.0",
+    "lint-staged": "^15.2.10",
     "jsdom": "^29.1.1",
     "node-fetch": "^3.3.2",
     "tsx": "^4.21.0",


### PR DESCRIPTION
Closes #1004.

Adds Husky + lint-staged so a fast pre-commit hook runs ESLint (`--fix`) and a `tsc --noEmit` typecheck on staged `*.{ts,tsx,js,jsx}` files only. Adds the `prepare` script (installs hooks on `npm install`), a `typecheck` script, the lint-staged config, and `.husky/pre-commit`. Documents the workflow and the `--no-verify` bypass in docs/CONTRIBUTING_HOOKS.md.