### PR TITLE
chore: add commitlint config and Conventional Commits enforcement

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no-install commitlint --edit "$1"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,35 @@
+/**
+ * Commitlint configuration enforcing Conventional Commits.
+ * See docs/COMMIT_CONVENTION.md for accepted types and scopes.
+ */
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Allowed commit types (scope is optional).
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'docs',
+        'style',
+        'refactor',
+        'perf',
+        'test',
+        'build',
+        'ci',
+        'chore',
+        'revert',
+      ],
+    ],
+    // Keep the subject readable; do not block long bodies.
+    'header-max-length': [2, 'always', 100],
+    'body-max-line-length': [0, 'always', Infinity],
+  },
+  // Allow merge/revert commits and dependabot to bypass the rules.
+  ignores: [
+    (message) => /^Merge /.test(message),
+    (message) => /^Revert /.test(message),
+  ],
+};

--- a/docs/COMMIT_CONVENTION.md
+++ b/docs/COMMIT_CONVENTION.md
@@ -1,0 +1,52 @@
+# Commit Convention
+
+This repository follows [Conventional Commits](https://www.conventionalcommits.org/)
+and enforces it with [commitlint](https://commitlint.js.org/) via a `commit-msg`
+git hook ([`.husky/commit-msg`](../.husky/commit-msg)). A consistent history keeps
+the log scannable and enables future changelog automation.
+
+## Format
+
+```
+<type>(<optional scope>): <subject>
+
+<optional body>
+
+<optional footer>
+```
+
+- The **header** (`type(scope): subject`) is limited to 100 characters.
+- The **scope** is optional (e.g. `feat(marketplace): ...`).
+- The **body** may wrap across multiple lines with no length limit.
+
+## Accepted types
+
+| Type       | Use for                                                        |
+| ---------- | ------------------------------------------------------------- |
+| `feat`     | A new feature                                                 |
+| `fix`      | A bug fix                                                     |
+| `docs`     | Documentation-only changes                                    |
+| `style`    | Formatting/whitespace, no logic change                       |
+| `refactor` | Code change that neither fixes a bug nor adds a feature       |
+| `perf`     | A performance improvement                                     |
+| `test`     | Adding or correcting tests                                    |
+| `build`    | Build system or dependency changes                           |
+| `ci`       | CI configuration and scripts                                  |
+| `chore`    | Routine maintenance that doesn't fit the above               |
+| `revert`   | Reverting a previous commit                                   |
+
+## Examples
+
+```
+feat(commitments): add early-exit flow to detail page
+fix(api): return 429 with Retry-After on rate limit
+docs: document commit convention
+```
+
+## Notes
+
+- Merge and revert commits are allowed through the linter automatically.
+- If a commit is rejected, the error message names the failing rule; fix the
+  message and recommit.
+- In an emergency you can bypass the hook with `git commit --no-verify`, but CI
+  may still validate commit messages.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:coverage": "vitest --coverage",
     "test:contracts:deploy": "node contracts/scripts/deploy-testnet.smoke.mjs",
     "seed:mock": "tsx scripts/seed-backend-mock.ts",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "prepare": "husky"
   },
   "dependencies": {
 
@@ -34,6 +35,8 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@commitlint/cli": "^19.6.1",
+    "@commitlint/config-conventional": "^19.6.0",
     "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -47,6 +50,7 @@
     "eslint": "^8.0.0",
     "eslint-config-next": "^14.0.0",
     "happy-dom": "^20.7.0",
+    "husky": "^9.1.7",
     "ioredis": "^5.11.0",
     "jsdom": "^29.1.1",
     "node-fetch": "^3.3.2",


### PR DESCRIPTION
Closes #1005.

Adds commitlint with the conventional config and a Husky `commit-msg` hook. `commitlint.config.js` defines the accepted type-enum, allows long bodies, and ignores merge/revert commits. Adds the `@commitlint/cli`, `@commitlint/config-conventional`, and `husky` devDeps plus a `prepare` script. Documents accepted types and scopes with examples in docs/COMMIT_CONVENTION.md.