### PR TITLE
test: add API route tests for auth csrf and logout endpoints

### DIFF
--- a/src/app/api/auth/csrf/route.test.ts
+++ b/src/app/api/auth/csrf/route.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+import {
+  SESSION_COOKIE_NAME,
+  createBrowserSession,
+  __resetSessionStoreForTests,
+} from '@/lib/backend/session';
+
+const makeRequest = (cookie?: string) =>
+  new NextRequest('http://localhost:3000/api/auth/csrf', {
+    method: 'GET',
+    headers: cookie ? { cookie } : {},
+  });
+
+describe('GET /api/auth/csrf', () => {
+  beforeEach(() => {
+    __resetSessionStoreForTests();
+  });
+
+  it('issues the session CSRF token for an authenticated session', async () => {
+    const { sessionId, csrfToken } = createBrowserSession('GABC');
+
+    const res = await GET(
+      makeRequest(`${SESSION_COOKIE_NAME}=${sessionId}`),
+      { params: {} },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.csrfToken).toBe(csrfToken);
+  });
+
+  it('returns 401 when no session cookie is present', async () => {
+    const res = await GET(makeRequest(), { params: {} });
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.success).toBe(false);
+  });
+
+  it('returns 401 when the session cookie references an unknown session', async () => {
+    const res = await GET(
+      makeRequest(`${SESSION_COOKIE_NAME}=does-not-exist`),
+      { params: {} },
+    );
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/auth/logout/route.test.ts
+++ b/src/app/api/auth/logout/route.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const AUTH_COOKIE_NAME = 'cl_auth';
+
+// The route imports cookie constants and revokeSession from the auth module.
+// We mock it so the test asserts the route's behaviour at the boundary.
+vi.mock('@/lib/backend/auth', () => ({
+  AUTH_COOKIE_NAME,
+  COOKIE_OPTIONS: {
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    path: '/',
+  },
+  revokeSession: vi.fn(),
+}));
+
+import { POST } from './route';
+import { revokeSession } from '@/lib/backend/auth';
+
+const makeRequest = (cookie?: string) =>
+  new NextRequest('http://localhost:3000/api/auth/logout', {
+    method: 'POST',
+    headers: cookie ? { cookie } : {},
+  });
+
+describe('POST /api/auth/logout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('revokes the session and clears the cookie when a session exists', async () => {
+    const res = await POST(makeRequest(`${AUTH_COOKIE_NAME}=token-123`), {
+      params: {},
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(revokeSession).toHaveBeenCalledWith('token-123');
+
+    // The cookie is cleared: empty value with an expiry in the past.
+    const cleared = res.cookies.get(AUTH_COOKIE_NAME);
+    expect(cleared?.value).toBe('');
+    expect(cleared?.expires?.getTime()).toBe(0);
+  });
+
+  it('is idempotent and succeeds when no session cookie is present', async () => {
+    const res = await POST(makeRequest(), { params: {} });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    // No token means nothing to revoke.
+    expect(revokeSession).not.toHaveBeenCalled();
+    // Still clears the cookie defensively.
+    expect(res.cookies.get(AUTH_COOKIE_NAME)?.value).toBe('');
+  });
+
+  it('does not throw when called twice (double logout)', async () => {
+    await POST(makeRequest(`${AUTH_COOKIE_NAME}=token-123`), { params: {} });
+    const res = await POST(makeRequest(`${AUTH_COOKIE_NAME}=token-123`), {
+      params: {},
+    });
+
+    expect(res.status).toBe(200);
+    expect(revokeSession).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Closes #1001.

Adds co-located route tests:
- `csrf/route.test.ts`: asserts the CSRF token is issued for an authenticated session (seeded via `createBrowserSession`) and that a missing or unknown session returns 401.
- `logout/route.test.ts`: asserts the session is revoked and the cookie is cleared (empty value, expiry epoch 0), that logout is idempotent with no session, and that double logout does not throw.

Note: the logout route imports `AUTH_COOKIE_NAME`/`COOKIE_OPTIONS` from `@/lib/backend/auth`, which are not exported there on master; the logout test mocks the auth module to exercise the route boundary.