### PR TITLE
perf: add route-level loading boundaries with skeletons

### DIFF
--- a/src/app/__tests__/loading.test.tsx
+++ b/src/app/__tests__/loading.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+import MarketplaceLoading from '@/app/marketplace/loading';
+import CommitmentsLoading from '@/app/commitments/loading';
+import CommitmentDetailLoading from '@/app/commitments/[id]/loading';
+import CreateLoading from '@/app/create/loading';
+
+afterEach(() => cleanup());
+
+describe('route-level loading boundaries', () => {
+  it('marketplace loading renders a skeleton status region', () => {
+    const { container } = render(<MarketplaceLoading />);
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+  });
+
+  it('commitments loading renders a skeleton status region', () => {
+    const { container } = render(<CommitmentsLoading />);
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+  });
+
+  it('commitment detail loading renders a skeleton status region', () => {
+    const { container } = render(<CommitmentDetailLoading />);
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+  });
+
+  it('create loading renders a skeleton status region', () => {
+    const { container } = render(<CreateLoading />);
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+  });
+});

--- a/src/app/commitments/[id]/loading.tsx
+++ b/src/app/commitments/[id]/loading.tsx
@@ -1,0 +1,23 @@
+import {
+  CommitmentCardSkeleton,
+  CommitmentStatsSkeleton,
+  HealthChartSkeleton,
+} from '@/components/Skeleton';
+
+/**
+ * Route-level loading boundary for the commitment detail segment.
+ * Nested under /commitments, this boundary takes precedence for /commitments/[id].
+ */
+export default function Loading() {
+  return (
+    <div
+      className="px-6 py-8 max-w-5xl mx-auto flex flex-col gap-8"
+      role="status"
+      aria-label="Loading commitment"
+    >
+      <CommitmentStatsSkeleton />
+      <HealthChartSkeleton />
+      <CommitmentCardSkeleton />
+    </div>
+  );
+}

--- a/src/app/commitments/loading.tsx
+++ b/src/app/commitments/loading.tsx
@@ -1,0 +1,13 @@
+import MyCommitmentsGridSkeleton from '@/components/MyCommitmentsGridSkeleton';
+
+/**
+ * Route-level loading boundary for the commitments list segment.
+ * Streams a skeleton while the page is being rendered.
+ */
+export default function Loading() {
+  return (
+    <div className="px-6 py-8 max-w-7xl mx-auto">
+      <MyCommitmentsGridSkeleton />
+    </div>
+  );
+}

--- a/src/app/create/loading.tsx
+++ b/src/app/create/loading.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from '@/components/Skeleton';
+
+/**
+ * Route-level loading boundary for the create-commitment segment.
+ * Streams a lightweight form skeleton while the page is being rendered.
+ */
+export default function Loading() {
+  return (
+    <div
+      className="px-6 py-8 max-w-2xl mx-auto flex flex-col gap-6"
+      role="status"
+      aria-label="Loading create commitment"
+    >
+      <Skeleton className="h-8 w-1/2" />
+      <Skeleton className="h-12 w-full" />
+      <Skeleton className="h-12 w-full" />
+      <Skeleton className="h-12 w-full" />
+      <Skeleton className="h-10 w-32" />
+    </div>
+  );
+}

--- a/src/app/marketplace/loading.tsx
+++ b/src/app/marketplace/loading.tsx
@@ -1,0 +1,13 @@
+import { MarketplaceGridSkeleton } from '@/components/MarketplaceGridSkeleton';
+
+/**
+ * Route-level loading boundary for the marketplace segment.
+ * Streams a skeleton while the page is being rendered.
+ */
+export default function Loading() {
+  return (
+    <div className="px-6 py-8 max-w-7xl mx-auto">
+      <MarketplaceGridSkeleton />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #1017.

Adds `loading.tsx` boundaries for the marketplace, commitments, create, and commitment-detail (`commitments/[id]`) segments so navigation streams a skeleton instead of a blank screen. Each reuses existing skeleton components (`MarketplaceGridSkeleton`, `MyCommitmentsGridSkeleton`, base `Skeleton`) for consistency; the nested `[id]` boundary takes precedence over the list boundary. Adds `src/app/__tests__/loading.test.tsx` asserting each boundary renders a status region.