### PR TITLE
perf: add reduced-motion policy for charts and meters

### DIFF
--- a/docs/accessibility/MOTION_POLICY.md
+++ b/docs/accessibility/MOTION_POLICY.md
@@ -1,0 +1,36 @@
+# Motion Policy for Data Visualizations
+
+Data-visualization surfaces (Recharts charts and the `VolatilityExposureMeter`)
+animate by default. To respect accessibility preferences and improve perceived
+performance, animations are gated behind the user's
+`prefers-reduced-motion` setting.
+
+## The hook
+
+[`src/lib/a11y/useReducedMotion.ts`](../../src/lib/a11y/useReducedMotion.ts)
+exposes a shared `useReducedMotion()` hook:
+
+- Returns `true` when the OS/browser requests reduced motion.
+- **SSR-safe**: returns `false` on the server and first client render to avoid
+  hydration mismatches, then updates after mount.
+- **Resilient**: if `matchMedia` is unavailable it falls back to `false`
+  (animations enabled) instead of throwing.
+- **Live**: subscribes to media-query changes so toggling the setting updates
+  the value without a reload.
+
+## How it is applied
+
+| Surface                          | Gating mechanism                                  |
+| -------------------------------- | ------------------------------------------------- |
+| `HealthMetricsValueHistoryChart` | Recharts `isAnimationActive={!reducedMotion}`     |
+| `VolatilityExposureMeter`        | Inline `transition: 'none'` when reduced motion   |
+
+Importantly, **data still updates** when reduced motion is on — only the
+animation/transition is removed, so the chart and meter reflect new values
+instantly rather than tweening to them.
+
+## Adding new visualizations
+
+When adding a new chart or animated meter, call `useReducedMotion()` and disable
+the relevant animation (e.g. `isAnimationActive`, CSS `transition`, or
+framer-motion variants) when it returns `true`.

--- a/src/components/VolatilityExposureMeter/VolatilityExposureMeter.tsx
+++ b/src/components/VolatilityExposureMeter/VolatilityExposureMeter.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import styles from './VolatilityExposureMeter.module.css'
+import { useReducedMotion } from '@/lib/a11y/useReducedMotion'
 
 export interface VolatilityExposureMeterProps {
   /** Current exposure as a percentage (0–100). Clamped when rendering. */
@@ -27,6 +28,7 @@ export default function VolatilityExposureMeter({
   const percent = clamp(valuePercent)
   const level = exposureLevel(percent)
   const ariaLabel = `Volatility exposure: ${percent}%, ${level} range.`
+  const reducedMotion = useReducedMotion()
 
   return (
     <section
@@ -52,7 +54,11 @@ export default function VolatilityExposureMeter({
       >
         <div
           className={styles.barMask}
-          style={{ width: `${percent}%` }}
+          style={{
+            width: `${percent}%`,
+            // Honor the motion policy: live updates still apply, just without animation.
+            transition: reducedMotion ? 'none' : undefined,
+          }}
         >
              <div className={styles.barGradient} />
         </div>

--- a/src/components/dashboard/HealthMetricsValueHistoryChart.tsx
+++ b/src/components/dashboard/HealthMetricsValueHistoryChart.tsx
@@ -13,6 +13,7 @@ import {
 } from 'recharts';
 
 import VolatilityExposureMeter from '../VolatilityExposureMeter/VolatilityExposureMeter';
+import { useReducedMotion } from '@/lib/a11y/useReducedMotion';
 
 interface HealthMetricsValueHistoryChartProps {
     data: Array<{ date: string; currentValue: number; initialAmount?: number }>;
@@ -56,6 +57,7 @@ export const HealthMetricsValueHistoryChart: React.FC<HealthMetricsValueHistoryC
     data,
     volatilityPercent,
 }) => {
+    const reducedMotion = useReducedMotion();
     return (
         <>
             <div className="w-full h-full min-h-[350px] bg-[#111] rounded-xl p-4 sm:p-6 border border-[#222] shadow-sm">
@@ -115,6 +117,7 @@ export const HealthMetricsValueHistoryChart: React.FC<HealthMetricsValueHistoryC
                             strokeDasharray="5 5"
                             dot={false}
                             activeDot={false}
+                            isAnimationActive={!reducedMotion}
                         />
                         {/* Current Value Line (Teal) */}
                         <Line
@@ -125,6 +128,7 @@ export const HealthMetricsValueHistoryChart: React.FC<HealthMetricsValueHistoryC
                             strokeWidth={2}
                             dot={{ r: 4, fill: '#0ff0fc', stroke: '#111', strokeWidth: 2 }}
                             activeDot={{ r: 6, fill: '#0ff0fc', stroke: '#111', strokeWidth: 2 }}
+                            isAnimationActive={!reducedMotion}
                         />
                     </LineChart>
                 </ResponsiveContainer>

--- a/src/lib/a11y/__tests__/useReducedMotion.test.ts
+++ b/src/lib/a11y/__tests__/useReducedMotion.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useReducedMotion } from '../useReducedMotion';
+
+type Listener = (event: MediaQueryListEvent) => void;
+
+/** Installs a controllable matchMedia stub and returns helpers to drive it. */
+function mockMatchMedia(initialMatches: boolean) {
+  let matches = initialMatches;
+  const listeners = new Set<Listener>();
+
+  const mql = {
+    get matches() {
+      return matches;
+    },
+    media: '(prefers-reduced-motion: reduce)',
+    addEventListener: (_: string, cb: Listener) => listeners.add(cb),
+    removeEventListener: (_: string, cb: Listener) => listeners.delete(cb),
+  };
+
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => mql),
+  );
+
+  return {
+    emit(next: boolean) {
+      matches = next;
+      listeners.forEach((cb) => cb({ matches } as MediaQueryListEvent));
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useReducedMotion', () => {
+  it('returns false when reduced motion is not preferred', () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when reduced motion is preferred', () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it('falls back to false when matchMedia is unsupported', () => {
+    vi.stubGlobal('matchMedia', undefined);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/lib/a11y/useReducedMotion.ts
+++ b/src/lib/a11y/useReducedMotion.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+/**
+ * Shared motion policy hook for data-visualization surfaces.
+ *
+ * Reads the `prefers-reduced-motion` media query and returns `true` when the
+ * user has requested reduced motion. Consumers use this to gate chart and meter
+ * animations so they remain accessible and feel faster.
+ *
+ * - SSR-safe: returns `false` on the server and on the first client render to
+ *   avoid hydration mismatches, then updates after mount.
+ * - Resilient: if `matchMedia` is unsupported it falls back to `false`
+ *   (animations enabled) rather than throwing.
+ * - Live: subscribes to media-query changes so toggling the OS setting updates
+ *   the value without a reload.
+ */
+export function useReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(QUERY);
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+export default useReducedMotion;


### PR DESCRIPTION
Closes #1025.

Adds a shared `useReducedMotion()` hook (`src/lib/a11y/useReducedMotion.ts`) that reads `prefers-reduced-motion` (SSR-safe, matchMedia-fallback safe, live-updating). Applies it to `HealthMetricsValueHistoryChart` (Recharts `isAnimationActive={!reducedMotion}`) and `VolatilityExposureMeter` (disables the CSS width transition). Data still updates instantly under reduced motion; only the animation is dropped. Adds a unit test covering both media-query states plus the unsupported-matchMedia fallback, and documents the policy in docs/accessibility/MOTION_POLICY.md.