### PR TITLE
feat: offline/online status banner with reconnect confirmation

### DIFF
--- a/docs/CONNECTION_STATUS.md
+++ b/docs/CONNECTION_STATUS.md
@@ -1,0 +1,19 @@
+# Connection status and queued actions
+
+The app now surfaces connectivity state at the shell level so users can see when the browser has lost network access and when the connection is restored.
+
+## What changed
+
+- A global connection banner appears when the browser goes offline and shows a reconnect confirmation when the app comes back online.
+- The banner uses an accessible status region and avoids motion for users who prefer reduced motion.
+- The create-commitment review step disables submission while offline and shows a short warning so users do not start a write action that cannot complete.
+
+## Behavior
+
+- The banner listens to `navigator.onLine` plus the browser `online` and `offline` events.
+- When the app is offline, a persistent banner explains that queued actions will be held until the connection is restored.
+- When connectivity returns, the banner switches to a confirmation state and then dismisses automatically.
+
+## Testing
+
+The new hook and banner behavior are covered by dedicated tests under the relevant hook and shell test directories.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,13 @@
 import type { Metadata } from 'next'
 import './globals.css'
-import ScrollToTopButton from "@/components/landing-page/ui/ScrollToTop"
-import { ThemeProvider } from "@/components/theme/ThemeProvider"
-import { ToastProvider } from "@/components/toast/ToastProvider"
-import { CommandPaletteProvider } from "@/components/CommandPalette"
-import { NetworkMismatchBanner } from "@/components/wallet/NetworkMismatchBanner"
+import ScrollToTopButton from '@/components/landing-page/ui/ScrollToTop'
+import { ThemeProvider } from '@/components/theme/ThemeProvider'
+import { ToastProvider } from '@/components/toast/ToastProvider'
+import { CommandPaletteProvider } from '@/components/CommandPalette'
+import { NetworkMismatchBanner } from '@/components/wallet/NetworkMismatchBanner'
 import { Inter, Roboto_Mono } from 'next/font/google'
-import { MotionProvider } from "@/components/MotionProvider"
+import { MotionProvider } from '@/components/MotionProvider'
+import { AppShellConnectionStatus } from '@/components/shell/AppShellConnectionStatus'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -77,24 +78,24 @@ export default function RootLayout({
     <html
       lang="en"
       suppressHydrationWarning
-      className={["scroll-smooth", inter.variable, robotoMono.variable].join(' ')}
+      className={['scroll-smooth', inter.variable, robotoMono.variable].join(' ')}
     >
       <head>
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify({
-              "@context": "https://schema.org",
-              "@type": "WebSite",
-              "name": "CommitLabs",
-              "description": "Transform passive liquidity into enforceable, attestable, and composable on-chain commitments",
-              "url": "https://commitlabs.com",
-              "publisher": {
-                "@type": "Organization",
-                "name": "CommitLabs",
-                "url": "https://commitlabs.com"
-              }
-            })
+              '@context': 'https://schema.org',
+              '@type': 'WebSite',
+              name: 'CommitLabs',
+              description: 'Transform passive liquidity into enforceable, attestable, and composable on-chain commitments',
+              url: 'https://commitlabs.com',
+              publisher: {
+                '@type': 'Organization',
+                name: 'CommitLabs',
+                url: 'https://commitlabs.com',
+              },
+            }),
           }}
         />
       </head>
@@ -102,16 +103,15 @@ export default function RootLayout({
         <a href="#main-content" className="skip-link">Skip to main content</a>
         <ThemeProvider>
           <MotionProvider>
-          <ToastProvider>
-            <NetworkMismatchBanner />
-            {children}
-            <ScrollToTopButton />
-            <CommandPaletteProvider />
-          </ToastProvider>
+            <ToastProvider>
+              <NetworkMismatchBanner />
+              <AppShellConnectionStatus>{children}</AppShellConnectionStatus>
+              <ScrollToTopButton />
+              <CommandPaletteProvider />
+            </ToastProvider>
           </MotionProvider>
         </ThemeProvider>
       </body>
     </html>
   )
 }
-

--- a/src/components/CreateCommitmentStepReview.tsx
+++ b/src/components/CreateCommitmentStepReview.tsx
@@ -14,6 +14,7 @@ import {
 import WizardStepper from "./WizardStepper";
 import styles from "./CreateCommitmentStepReview.module.css";
 import { useWallet } from "@/hooks/useWallet";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
 import ValidationSummary, { ValidationErrorItem } from "./create/ValidationSummary";
 
 interface CreateCommitmentStepReviewProps {
@@ -55,6 +56,7 @@ export default function CreateCommitmentStepReview({
   const [acceptedTerms, setAcceptedTerms] = useState(false);
   const [acknowledgedRisks, setAcknowledgedRisks] = useState(false);
   const { connected, address, connect } = useWallet();
+  const { isOnline } = useOnlineStatus();
   const [validationErrors, setValidationErrors] = useState<ValidationErrorItem[]>([]);
   const [isValidating, setIsValidating] = useState(false);
 
@@ -196,7 +198,7 @@ export default function CreateCommitmentStepReview({
     }
   };
 
-  const canSubmit = acceptedTerms && acknowledgedRisks && !isSubmitting && validationErrors.length === 0;
+  const canSubmit = acceptedTerms && acknowledgedRisks && !isSubmitting && validationErrors.length === 0 && isOnline;
 
   const getIconAndStyle = () => {
     const l = typeLabel.toLowerCase();
@@ -512,6 +514,11 @@ export default function CreateCommitmentStepReview({
         {/* Footer */}
         <div className={styles.footer}>
           {submitError && <p className={styles.submitError} role="alert">{submitError}</p>}
+          {!isOnline && (
+            <p className={styles.submitError} role="status">
+              You are offline. Reconnect to submit this commitment.
+            </p>
+          )}
           <button
             onClick={onSubmit}
             disabled={!canSubmit}

--- a/src/components/shell/AppShellConnectionStatus.tsx
+++ b/src/components/shell/AppShellConnectionStatus.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { type ReactNode } from 'react';
+
+import { ConnectionStatusBanner } from '@/components/shell/ConnectionStatusBanner';
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
+
+interface AppShellConnectionStatusProps {
+  children: ReactNode;
+}
+
+export function AppShellConnectionStatus({ children }: AppShellConnectionStatusProps) {
+  const { isOnline } = useOnlineStatus();
+
+  return (
+    <>
+      <ConnectionStatusBanner isOnline={isOnline} />
+      {children}
+    </>
+  );
+}

--- a/src/components/shell/ConnectionStatusBanner.tsx
+++ b/src/components/shell/ConnectionStatusBanner.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { WifiOff, Wifi } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+interface ConnectionStatusBannerProps {
+  isOnline: boolean;
+}
+
+export function ConnectionStatusBanner({ isOnline }: ConnectionStatusBannerProps) {
+  const [showReconnect, setShowReconnect] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const wasOffline = useRef(false);
+  const prefersReducedMotion = useRef(false);
+
+  useEffect(() => {
+    prefersReducedMotion.current = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+  }, []);
+
+  // Track offline transitions and reset state
+  useEffect(() => {
+    if (!isOnline) {
+      wasOffline.current = true;
+      setShowReconnect(false);
+      setDismissed(false);
+    }
+  }, [isOnline]);
+
+  // Show reconnect confirmation when coming back online from a real offline state
+  useEffect(() => {
+    if (!isOnline || !wasOffline.current) return;
+
+    wasOffline.current = false;
+    setShowReconnect(true);
+
+    if (prefersReducedMotion.current) return;
+
+    const timeout = window.setTimeout(() => {
+      setShowReconnect(false);
+    }, 2400);
+
+    return () => window.clearTimeout(timeout);
+  }, [isOnline]);
+
+  const isOffline = !isOnline;
+
+  // Visibility: offline & not dismissed, or online & showing reconnect
+  const shouldShow = (isOffline && !dismissed) || (isOnline && showReconnect);
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  const title = isOffline ? 'You are offline' : 'Back online';
+  const description = isOffline
+    ? 'Queued actions will resume once the connection is restored.'
+    : 'Your connection is restored. You can continue with queued actions.';
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="border-b border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-950 backdrop-blur motion-reduce:backdrop-blur-none supports-[backdrop-filter]:bg-amber-500/15 dark:text-amber-100"
+    >
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-3">
+        <div className="flex items-start gap-2">
+          {isOffline ? (
+            <WifiOff size={18} className="mt-0.5 shrink-0" aria-hidden="true" />
+          ) : (
+            <Wifi size={18} className="mt-0.5 shrink-0" aria-hidden="true" />
+          )}
+          <div>
+            <p className="font-semibold">{title}</p>
+            <p className="text-xs opacity-90">{description}</p>
+          </div>
+        </div>
+        {isOffline && (
+          <button
+            type="button"
+            onClick={() => setDismissed(true)}
+            className="rounded-md border border-amber-600/40 px-2.5 py-1 text-xs font-medium hover:bg-amber-600/10"
+          >
+            Dismiss
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/shell/__tests__/ConnectionStatusBanner.test.tsx
+++ b/src/components/shell/__tests__/ConnectionStatusBanner.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ConnectionStatusBanner } from '../ConnectionStatusBanner';
+
+describe('ConnectionStatusBanner', () => {
+  const setOnline = (value: boolean) => {
+    Object.defineProperty(window.navigator, 'onLine', {
+      configurable: true,
+      value,
+    });
+  };
+
+  beforeEach(() => {
+    setOnline(true);
+  });
+
+  afterEach(() => {
+    setOnline(true);
+  });
+
+  it('renders nothing when online on initial mount', () => {
+    const { container } = render(<ConnectionStatusBanner isOnline={true} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders an offline banner with an accessible status role', () => {
+    render(<ConnectionStatusBanner isOnline={false} />);
+
+    expect(screen.getByRole('status')).toHaveTextContent(/offline/i);
+    expect(screen.getAllByText(/queued actions/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders the offline banner on initial offline load', () => {
+    render(<ConnectionStatusBanner isOnline={false} />);
+
+    expect(screen.getByRole('status')).toHaveTextContent(/you are offline/i);
+  });
+
+  it('shows a reconnect confirmation when the app comes back online after being offline', () => {
+    const { rerender } = render(<ConnectionStatusBanner isOnline={false} />);
+
+    // Simulate window online event to update navigator.onLine
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+
+    rerender(<ConnectionStatusBanner isOnline={true} />);
+
+    expect(screen.getByRole('status')).toHaveTextContent(/back online/i);
+  });
+
+  it('does not show reconnect on initial online mount (no prior offline state)', () => {
+    const { container } = render(<ConnectionStatusBanner isOnline={true} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hides the offline banner when dismissed', () => {
+    const { container, rerender } = render(
+      <ConnectionStatusBanner isOnline={false} />,
+    );
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+
+    rerender(<ConnectionStatusBanner isOnline={false} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows reconnect after coming back online even if previously dismissed', () => {
+    const { container, rerender } = render(
+      <ConnectionStatusBanner isOnline={false} />,
+    );
+
+    // Dismiss while offline
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    rerender(<ConnectionStatusBanner isOnline={false} />);
+    expect(container.firstChild).toBeNull();
+
+    // Come back online
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+    rerender(<ConnectionStatusBanner isOnline={true} />);
+
+    expect(screen.getByRole('status')).toHaveTextContent(/back online/i);
+  });
+});

--- a/src/components/shell/index.ts
+++ b/src/components/shell/index.ts
@@ -1,4 +1,6 @@
 export { AppSidebar } from './AppSidebar'
 export type { AppSidebarProps } from './AppSidebar'
+export { AppShellConnectionStatus } from './AppShellConnectionStatus'
 export { AppShellLayout } from './AppShellLayout'
 export type { AppShellLayoutProps } from './AppShellLayout'
+export { ConnectionStatusBanner } from './ConnectionStatusBanner'

--- a/src/hooks/__tests__/useOnlineStatus.test.ts
+++ b/src/hooks/__tests__/useOnlineStatus.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useOnlineStatus } from '../useOnlineStatus';
+
+describe('useOnlineStatus', () => {
+  const setOnline = (value: boolean) => {
+    Object.defineProperty(window.navigator, 'onLine', {
+      configurable: true,
+      value,
+    });
+  };
+
+  beforeEach(() => {
+    setOnline(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses navigator.onLine for the initial state', () => {
+    setOnline(false);
+
+    const { result } = renderHook(() => useOnlineStatus());
+
+    expect(result.current.isOnline).toBe(false);
+  });
+
+  it('updates when the browser emits online and offline events', () => {
+    const { result } = renderHook(() => useOnlineStatus());
+
+    expect(result.current.isOnline).toBe(true);
+
+    act(() => {
+      setOnline(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    expect(result.current.isOnline).toBe(false);
+
+    act(() => {
+      setOnline(true);
+      window.dispatchEvent(new Event('online'));
+    });
+
+    expect(result.current.isOnline).toBe(true);
+  });
+
+  it('falls back to online when navigator.onLine is unavailable', () => {
+    Object.defineProperty(window.navigator, 'onLine', {
+      configurable: true,
+      value: undefined,
+    });
+
+    const { result } = renderHook(() => useOnlineStatus());
+
+    expect(result.current.isOnline).toBe(true);
+  });
+});

--- a/src/hooks/useOnlineStatus.ts
+++ b/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+export function useOnlineStatus() {
+  const [isOnline, setIsOnline] = useState(() => {
+    if (typeof window === 'undefined' || typeof window.navigator === 'undefined') {
+      return true;
+    }
+
+    return typeof window.navigator.onLine === 'boolean' ? window.navigator.onLine : true;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return { isOnline };
+}


### PR DESCRIPTION
## Summary

Adds an ambient offline/connection-status indicator that surfaces browser connectivity state at the shell level. Users now see a persistent banner when the browser goes offline and a brief "Back online" confirmation when the connection is restored.

## Changes

- **New hook** `src/hooks/useOnlineStatus.ts` — listens to `navigator.onLine` and `online`/`offline` events, SSR-safe
- **New component** `src/components/shell/ConnectionStatusBanner.tsx` — accessible banner (`role="status"`, `aria-live="polite"`) with self-contained dismiss state, reconnection confirmation, and `prefers-reduced-motion` support
- **New wrapper** `src/components/shell/AppShellConnectionStatus.tsx` — mounts the banner in the app shell
- **Modified** `src/app/layout.tsx` — wraps children with `AppShellConnectionStatus`
- **Modified** `src/components/CreateCommitmentStepReview.tsx` — disables the submit button and shows a warning when offline
- **Tests** `src/hooks/__tests__/useOnlineStatus.test.ts` (3 tests) and `src/components/shell/__tests__/ConnectionStatusBanner.test.tsx` (7 tests) — covers initial states, transitions, dismiss, and reconnect after dismiss
- **Docs** `docs/CONNECTION_STATUS.md` — documents the feature behavior

## Requirements met

- Listen to `navigator.onLine` and online/offline events
- Persistent offline banner with dismiss
- Auto-dismissing "Back online" confirmation
- Disables primary write actions while offline
- Accessible `role="status"` region
- Respects `prefers-reduced-motion` (skips auto-dismiss timer, disables backdrop blur)

closes #712