### PR TITLE
Add app shell skip link

### DIFF
--- a/docs/APP_SHELL_SIDEBAR.md
+++ b/docs/APP_SHELL_SIDEBAR.md
@@ -138,6 +138,7 @@ The sidebar follows the CommitLabs design system:
 
 ### Keyboard Navigation
 
+- **Skip to main content**: First tab stop moves focus directly to the main region
 - **Tab**: Navigate through navigation items
 - **Escape**: Close mobile drawer
 - **Enter/Space**: Activate navigation links
@@ -151,6 +152,8 @@ The sidebar follows the CommitLabs design system:
 
 ### Focus Management
 
+- App shell routes expose a visually-hidden skip link before the sidebar and a
+  focusable `#main-content` landmark target
 - Focus trap active in mobile drawer
 - First focusable element receives focus when drawer opens
 - Focus returns to trigger button when drawer closes

--- a/docs/SKIP_LINK.md
+++ b/docs/SKIP_LINK.md
@@ -1,0 +1,43 @@
+# Skip Link
+
+CommitLabs app-shell routes include a `Skip to main content` link before the
+sidebar navigation. Keyboard and screen-reader users can use it to bypass the
+persistent `AppSidebar` and move directly to the page content.
+
+## Usage
+
+`AppShellLayout` renders the skip link automatically for every route wrapped by
+the shell:
+
+```tsx
+import { AppShellLayout } from '@/components/shell/AppShellLayout'
+
+export default function CommitmentsPage() {
+  return (
+    <AppShellLayout>
+      <h1>My Commitments</h1>
+    </AppShellLayout>
+  )
+}
+```
+
+The layout assigns `id="main-content"` and `tabIndex={-1}` to the `<main>`
+landmark so the link has a stable target and scripts or assistive technology can
+move focus there.
+
+## Accessibility Behavior
+
+- The skip link is the first focusable control in `AppShellLayout`.
+- It stays visually hidden for pointer users and becomes visible when focused.
+- It links to the main landmark without changing the page layout.
+- It respects `prefers-reduced-motion: reduce` by disabling its focus
+  transition.
+
+## Validation
+
+Use keyboard navigation on any app-shell route:
+
+1. Press `Tab` once after page load.
+2. Confirm `Skip to main content` is visible.
+3. Press `Enter`.
+4. Confirm focus moves to the main content region before the sidebar links.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -199,6 +199,36 @@ body {
   min-height: 100vh;
 }
 
+.skip-link {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  z-index: 1000;
+  transform: translateY(calc(-100% - 2rem));
+  border: 1px solid var(--focus-ring-color);
+  border-radius: 0.5rem;
+  background: var(--surface-card);
+  color: var(--text-primary);
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: var(--focus-ring-shadow);
+  transition: transform 120ms ease;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  transform: translateY(0);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skip-link {
+    transition: none;
+  }
+}
+
 *:focus-visible {
   outline-offset: var(--focus-ring-offset);
 }

--- a/src/components/shell/AppShellLayout.test.tsx
+++ b/src/components/shell/AppShellLayout.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { AppShellLayout } from './AppShellLayout'
+
+vi.mock('./AppSidebar', () => ({
+  AppSidebar: () => (
+    <nav aria-label="Main navigation">
+      <a href="/marketplace">Marketplace</a>
+    </nav>
+  ),
+}))
+
+describe('AppShellLayout skip link', () => {
+  it('renders the skip link before sidebar navigation as the first focus target', () => {
+    const { container } = render(
+      <AppShellLayout>
+        <h1>Dashboard</h1>
+      </AppShellLayout>,
+    )
+
+    const skipLink = screen.getByRole('link', { name: /skip to main content/i })
+    const navigation = screen.getByRole('navigation', { name: /main navigation/i })
+    const shell = container.firstElementChild
+
+    expect(skipLink).toHaveAttribute('href', '#main-content')
+    expect(shell?.firstElementChild).toBe(skipLink)
+    expect(skipLink.compareDocumentPosition(navigation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('marks the main landmark as the skip target and keeps it programmatically focusable', () => {
+    render(
+      <AppShellLayout>
+        <h1>Dashboard</h1>
+      </AppShellLayout>,
+    )
+
+    const main = screen.getByRole('main')
+
+    expect(main).toHaveAttribute('id', 'main-content')
+    expect(main).toHaveAttribute('tabindex', '-1')
+    expect(main).toHaveClass('focus:outline-none')
+  })
+
+  it('moves focus to the main landmark when the skip link target is activated', () => {
+    render(
+      <AppShellLayout>
+        <h1>Dashboard</h1>
+      </AppShellLayout>,
+    )
+
+    const skipLink = screen.getByRole('link', { name: /skip to main content/i })
+    const main = screen.getByRole('main')
+
+    main.scrollIntoView = vi.fn()
+
+    fireEvent.click(skipLink)
+
+    expect(main).toHaveFocus()
+    expect(main.scrollIntoView).toHaveBeenCalled()
+  })
+})

--- a/src/components/shell/AppShellLayout.tsx
+++ b/src/components/shell/AppShellLayout.tsx
@@ -8,10 +8,29 @@ export interface AppShellLayoutProps {
 }
 
 export const AppShellLayout: React.FC<AppShellLayoutProps> = ({ children }) => {
+  const handleSkipToMain = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    const mainContent = document.getElementById('main-content')
+
+    if (!mainContent) {
+      return
+    }
+
+    event.preventDefault()
+    mainContent.focus()
+    mainContent.scrollIntoView()
+  }
+
   return (
     <div className="flex min-h-screen bg-[#0a0a0a]">
+      <a className="skip-link" href="#main-content" onClick={handleSkipToMain}>
+        Skip to main content
+      </a>
       <AppSidebar />
-      <main className="flex-1 md:ml-[240px] transition-[margin] duration-300">
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="flex-1 md:ml-[240px] transition-[margin] duration-300 focus:outline-none"
+      >
         {children}
       </main>
     </div>


### PR DESCRIPTION
## Summary
- add a first-focus skip link before the persistent AppSidebar
- make the main landmark a stable `#main-content` target and focus it when the skip link is activated
- add regression coverage and document the keyboard behavior

Closes #920

## Tests
- `pnpm test src/components/shell/AppShellLayout.test.tsx --run`
- `git diff --check`

## Notes
- `pnpm typecheck` currently fails on pre-existing syntax errors in `src/app/commitments/overview/page.tsx`.
- `pnpm lint` currently fails on existing repository-wide lint issues, including the same parse error in `src/app/commitments/overview/page.tsx`.
- The Vercel status requires team authorization for fork deployments; no code failure is reported there.