### PR TITLE
feat: live market stats banner in marketplace header

### DIFF
--- a/docs/MARKETPLACE_STATS_BANNER.md
+++ b/docs/MARKETPLACE_STATS_BANNER.md
@@ -1,0 +1,46 @@
+# Marketplace Stats Banner
+
+## Overview
+
+The `MarketStatsBanner` is a React component that displays real-time, market-wide statistics at the top of the Marketplace. Its primary goal is to **orient buyers with market-wide context before they filter** listings.
+
+It fetches data directly from the `/api/marketplace/stats` endpoint and visually represents it using our standard `KPICard` component.
+
+## Implementation Details
+
+- **Location**: `src/components/MarketplaceHeader/MarketStatsBanner.tsx`
+- **Data Source**: `/api/marketplace/stats`
+
+### KPI Chips Displayed
+Based on the current API structure, the following KPI chips are displayed:
+1. **Total Listings**: (`activeListings`) 
+2. **Average APY**: (`averageYield`)
+3. **Median Price**: (`medianPrice`)
+
+*Note: The original requirements mentioned displaying "24h volume" and "active sellers". However, these fields are not currently exposed by the `MarketplaceStats` backend interface, so the component strictly uses the real available fields to prevent fabricated data.*
+
+## Features & States
+
+- **Loading State**: Displays skeleton-loading `KPICard` chips while the data is fetched, ensuring a layout-stable experience.
+- **Success State**: Uses the `format="count/percentage/currency"` props of `KPICard` for locale-aware and accessible number formatting.
+- **Error State**: Degrades gracefully. If the fetch fails, it replaces the chips with a subtle, inline error message and a "Retry" button. It avoids bringing down or breaking the larger header structure.
+- **Responsive**: Adapts layout to wrap chips gracefully on mobile using flexbox styling.
+- **Accessibility**: Includes `aria-live="polite"` and proper ARIA labels so screen readers are updated when the market stats finish loading or fail.
+
+## Usage
+
+The component is entirely self-contained and manages its own data-fetching and state. It is injected into the `MarketplaceHeader`:
+
+```tsx
+import { MarketStatsBanner } from './MarketStatsBanner';
+
+export function MarketplaceHeader() {
+  return (
+    <header>
+      {/* ...other header content... */}
+      <MarketStatsBanner />
+      {/* ...other header content... */}
+    </header>
+  );
+}
+```

--- a/src/components/MarketplaceHeader/MarketStatsBanner.module.css
+++ b/src/components/MarketplaceHeader/MarketStatsBanner.module.css
@@ -1,0 +1,31 @@
+.root {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+  width: 100%;
+}
+
+.errorContainer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-error, #ef4444);
+  padding: 0.5rem 0;
+}
+
+.retryButton {
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  opacity: 0.8;
+}
+
+.retryButton:hover {
+  opacity: 1;
+}

--- a/src/components/MarketplaceHeader/MarketStatsBanner.test.tsx
+++ b/src/components/MarketplaceHeader/MarketStatsBanner.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MarketStatsBanner } from './MarketStatsBanner';
+import { apiGet } from '@/lib/apiClient';
+
+vi.mock('@/lib/apiClient', () => ({
+  apiGet: vi.fn(),
+}));
+
+describe('MarketStatsBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders loading state initially', async () => {
+    let resolvePromise: any;
+    const promise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+    vi.mocked(apiGet).mockReturnValue(promise as any);
+
+    render(<MarketStatsBanner />);
+
+    // Verify skeleton/loading indicators are present
+    expect(screen.getByLabelText('Loading market stats')).toBeInTheDocument();
+    expect(screen.getAllByText('Loading metrics...').length).toBeGreaterThan(0);
+    
+    // Resolve to avoid unhandled promises in tests
+    resolvePromise({ activeListings: 10, averageYield: 5, medianPrice: 100 });
+  });
+
+  it('renders success state with formatted KPI chips', async () => {
+    vi.mocked(apiGet).mockResolvedValue({
+      activeListings: 1542,
+      averageYield: 8.5,
+      medianPrice: 250,
+    });
+
+    render(<MarketStatsBanner />);
+
+    // Wait for the data to load and replace the loading state
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Loading market stats')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText('Market statistics')).toBeInTheDocument();
+    
+    // Check if the specific KPI labels are rendered
+    expect(screen.getByText('Total Listings')).toBeInTheDocument();
+    expect(screen.getByText('Average APY')).toBeInTheDocument();
+    expect(screen.getByText('Median Price')).toBeInTheDocument();
+    
+    // Check if values are rendered (relying on KPICard formatting count, currency, percentage)
+    // 1542 might be formatted as 1.5K or 1,542.
+    // 250 might be $250.00
+    // 8.5 might be 8.5%
+    expect(screen.getByText(/1542|1.5K/)).toBeInTheDocument();
+    expect(screen.getByText(/8.5%/)).toBeInTheDocument();
+    expect(screen.getByText(/\$250/)).toBeInTheDocument();
+  });
+
+  it('handles zero listings edge case correctly', async () => {
+    vi.mocked(apiGet).mockResolvedValue({
+      activeListings: 0,
+      averageYield: 0,
+      medianPrice: 0,
+    });
+
+    render(<MarketStatsBanner />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Market statistics')).toBeInTheDocument();
+    });
+
+    // Zero should still be rendered, not fall back to an empty string or error
+    expect(screen.getAllByText(/0|0.0|0%/).length).toBeGreaterThan(0);
+  });
+
+  it('degrades gracefully on fetch error and supports retry', async () => {
+    vi.mocked(apiGet).mockRejectedValue(new Error('Network timeout'));
+
+    render(<MarketStatsBanner />);
+
+    // Wait for the error UI
+    await waitFor(() => {
+      expect(screen.getByText('Market stats unavailable.')).toBeInTheDocument();
+    });
+
+    const retryButton = screen.getByRole('button', { name: /retry/i });
+    expect(retryButton).toBeInTheDocument();
+
+    // Mock a successful retry
+    vi.mocked(apiGet).mockResolvedValue({
+      activeListings: 5,
+      averageYield: 1.5,
+      medianPrice: 50,
+    });
+
+    fireEvent.click(retryButton);
+
+    // It should go back to loading, then success
+    await waitFor(() => {
+      expect(screen.getByLabelText('Market statistics')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Market stats unavailable.')).not.toBeInTheDocument();
+    expect(apiGet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/MarketplaceHeader/MarketStatsBanner.tsx
+++ b/src/components/MarketplaceHeader/MarketStatsBanner.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { KPICard } from '../KPICard';
+import { apiGet } from '@/lib/apiClient';
+import { AlertCircle } from 'lucide-react';
+import styles from './MarketStatsBanner.module.css';
+
+interface MarketplaceStats {
+  activeListings: number;
+  averageYield: number;
+  medianPrice: number;
+}
+
+/**
+ * MarketStatsBanner fetches and displays live marketplace context using KPICards.
+ * Goal: orient buyers with market-wide context before they filter.
+ */
+export function MarketStatsBanner() {
+  const [stats, setStats] = useState<MarketplaceStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStats = useCallback(async (cancelled: { value: boolean }) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await apiGet<MarketplaceStats>('/api/marketplace/stats');
+      if (!cancelled.value) {
+        setStats(data);
+      }
+    } catch (e) {
+      if (!cancelled.value) {
+        setError((e as Error).message || 'Failed to load stats');
+      }
+    } finally {
+      if (!cancelled.value) {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const cancelled = { value: false };
+    fetchStats(cancelled);
+    return () => {
+      cancelled.value = true;
+    };
+  }, [fetchStats]);
+
+  // Graceful error fallback
+  if (error) {
+    return (
+      <div className={styles.root} role="alert" aria-live="polite">
+        <div className={styles.errorContainer}>
+          <AlertCircle size={16} aria-hidden />
+          <span>Market stats unavailable.</span>
+          <button 
+            type="button"
+            onClick={() => fetchStats({ value: false })}
+            className={styles.retryButton}
+            aria-label="Retry loading market stats"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Loading state leveraging KPICard skeleton
+  if (isLoading) {
+    return (
+      <div className={styles.root} aria-busy="true" aria-label="Loading market stats">
+        <KPICard label="Total Listings" state="loading" size="small" />
+        <KPICard label="Average APY" state="loading" size="small" />
+        <KPICard label="Median Price" state="loading" size="small" />
+      </div>
+    );
+  }
+
+  // Success state matching actual API fields
+  return (
+    <div className={styles.root} aria-live="polite" aria-label="Market statistics">
+      <KPICard 
+        label="Total Listings" 
+        value={stats?.activeListings ?? 0} 
+        format="count" 
+        size="small" 
+        variant="teal" 
+      />
+      <KPICard 
+        label="Average APY" 
+        value={stats?.averageYield ?? 0} 
+        format="percentage" 
+        size="small" 
+        variant="blue" 
+      />
+      <KPICard 
+        label="Median Price" 
+        value={stats?.medianPrice ?? 0} 
+        format="currency" 
+        size="small" 
+        variant="green" 
+      />
+    </div>
+  );
+}

--- a/src/components/MarketplaceHeader/MarketplaceHeader.tsx
+++ b/src/components/MarketplaceHeader/MarketplaceHeader.tsx
@@ -12,6 +12,7 @@ import Image from 'next/image'
 import { AlertCircle, ArrowLeft, Loader2, Search } from 'lucide-react'
 import styles from './MarketplaceHeader.module.css';
 import { apiGet, apiFetch } from '@/lib/apiClient';
+import { MarketStatsBanner } from './MarketStatsBanner';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -28,12 +29,6 @@ export interface CommitmentSearchResult {
   currentValue: string
   createdAt: string
   expiresAt: string
-}
-
-interface MarketplaceStats {
-  activeListings: number
-  averageYield: number
-  medianPrice: number
 }
 
 const SORT_OPTIONS = [
@@ -83,9 +78,7 @@ export function MarketplaceHeader({
   ownerAddress,
   onResultSelect,
 }: MarketplaceHeaderProps) {
-  // ── Stats ──────────────────────────────────────────────────────────────────
-  const [stats, setStats] = useState<MarketplaceStats | null>(null)
-  const [statsError, setStatsError] = useState<string | null>(null)
+  // ── Sort ───────────────────────────────────────────────────────────────────
   const [sortValue, setSortValue] = useState<SortValue>('popular')
 
   // ── Typeahead ──────────────────────────────────────────────────────────────
@@ -100,23 +93,6 @@ export function MarketplaceHeader({
   const inputRef = useRef<HTMLInputElement>(null)
   const uid = useId()
   const listboxId = `${uid}-listbox`
-
-  // ── Fetch stats on mount ───────────────────────────────────────────────────
-  useEffect(() => {
-    let cancelled = false
-    const fetchStats = async () => {
-      try {
-        const data = await apiGet<MarketplaceStats>('/api/marketplace/stats');
-        if (!cancelled) setStats(data);
-      } catch (e) {
-        if (!cancelled) setStatsError((e as Error).message)
-      }
-    }
-    fetchStats()
-    return () => {
-      cancelled = true
-    }
-  }, [])
 
   // ── Debounced typeahead search ─────────────────────────────────────────────
   useEffect(() => {
@@ -322,16 +298,7 @@ export function MarketplaceHeader({
           </div>
 
           {/* ── Stats summary ── */}
-          {stats && (
-            <div className={styles.statsSummary} aria-live="polite">
-              <span className={styles.statItem}>Listings: {stats.activeListings}</span>
-              <span className={styles.statItem}>Avg Yield: {stats.averageYield}%</span>
-              <span className={styles.statItem}>Median Price: ${stats.medianPrice}</span>
-            </div>
-          )}
-          {statsError && (
-            <div className={styles.error}>Error: {statsError}</div>
-          )}
+          <MarketStatsBanner />
 
           {/* ── Sort control ── */}
           <div className={styles.sortControl}>


### PR DESCRIPTION
Close #704
## Summary
    Adds a live `MarketStatsBanner` to the `MarketplaceHeader` to orient buyers with market-wide context before they filter listings.

    ## What Changed
    - Created `MarketStatsBanner` component to fetch and display stats.
    - Wired the new banner into `MarketplaceHeader`, removing the old inline stats string and decoupled the data fetching logic.
    - Implemented robust loading (skeletons via `KPICard`) and graceful error states (inline subtle retry) to protect the header layout.
    - Added RTL test coverage for success, loading, zero-listings, and error edge cases.
    - Added `docs/MARKETPLACE_STATS_BANNER.md`.

    ## ⚠️ Note on API / Requirements Discrepancy
    The original issue requested that we render chips for "24h volume" and "active sellers". However, I discovered that the `MarketplaceStats` type returned by
  `/api/marketplace/stats` only exposes `activeListings`, `averageYield`, and `medianPrice`. 

    Rather than fabricating data or altering backend types outside the scope of this PR, I opted to assert real behavior and map the chips to the actual available fields (`Total
  Listings`, `Average APY`, `Median Price`).

    ## Acceptance Criteria Checklist
    - [x] Fetch `/api/marketplace/stats` and render KPI chips reusing the `KPICard` component.
    - [x] Loading uses the existing skeleton language.
    - [x] Errors degrade gracefully (hide or show a subtle retry).
    - [x] Numbers formatted with locale-aware separators (via `KPICard` formatters).
    - [x] Accessible and responsive (wraps on mobile).

    ## Security Note
    No client input is trusted for financial or identity data in this change. Data fetching handles failures defensively to avoid UI crashes.
