### PR TITLE
Add real-time attestation streaming to RecentAttestationsPanel via the events route

### DIFF
--- a/docs/ATTESTATIONS_REALTIME.md
+++ b/docs/ATTESTATIONS_REALTIME.md
@@ -1,0 +1,108 @@
+# Real-Time Attestation Streaming
+
+## Overview
+
+`RecentAttestationsPanel` supports live attestation updates via Server-Sent Events (SSE). When a `commitmentId` prop is provided, the panel subscribes to `/api/commitments/[id]/events` and prepends new attestations to the list as they arrive — without a page reload.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `attestations` | `Attestation[]` | required | Static list rendered on initial load. |
+| `summary` | `{ complianceCount, warningCount, violationCount }` | required | Initial summary counts; merged with live arrivals. |
+| `onSelectAttestation` | `(id: string) => void` | required | Called when a row is clicked. |
+| `onViewAll` | `() => void` | required | Called when "View All" is clicked. |
+| `commitmentId` | `string \| null` | `null` | Commitment ID used to open the SSE stream. Pass `null` to disable streaming. |
+| `streamingEnabled` | `boolean` | `true` | Set to `false` to disable streaming while keeping `commitmentId` available. |
+
+## Usage Example
+
+```tsx
+import RecentAttestationsPanel from '@/components/RecentAttestationsPanel/RecentAttestationsPanel'
+
+export default function CommitmentPage({ commitment, attestations }) {
+  return (
+    <RecentAttestationsPanel
+      attestations={attestations}
+      summary={commitment.summary}
+      onSelectAttestation={(id) => console.log('selected', id)}
+      onViewAll={() => router.push('/attestations')}
+      commitmentId={commitment.id}
+      streamingEnabled={true}
+    />
+  )
+}
+```
+
+## `useAttestationStream` Hook
+
+The hook lives at `src/hooks/useAttestationStream.ts` and can be reused independently.
+
+```ts
+import { useAttestationStream } from '@/hooks/useAttestationStream'
+
+useAttestationStream({
+  commitmentId: 'abc-123',
+  onAttestation: (attestation) => console.log('new', attestation),
+  enabled: true,
+})
+```
+
+### Options
+
+| Option | Type | Description |
+|---|---|---|
+| `commitmentId` | `string \| null` | Commitment to subscribe to. |
+| `onAttestation` | `(a: Attestation) => void` | Callback fired for each received attestation event. |
+| `enabled` | `boolean` | When `false` the stream is not opened. |
+
+## Behaviour
+
+### Deduplication
+
+New arrivals are deduplicated against both the initial `attestations` prop and previously received live events (matched by `id`). Duplicate events are silently dropped.
+
+### Reconnection with Back-off
+
+On `EventSource` error the hook reconnects using exponential back-off:
+
+- Initial delay: **1 000 ms**
+- Multiplier: **×2** after each failure
+- Maximum delay: **30 000 ms**
+
+The stream is torn down on component unmount to prevent memory leaks.
+
+### Fallback
+
+When `EventSource` is unavailable (e.g. server-side render, unsupported browser) the hook exits silently and the panel renders the static `attestations` prop unchanged.
+
+### Accessibility
+
+A visually-hidden `role="status"` / `aria-live="polite"` live region announces each new attestation title. The announcement does not disrupt scroll position or move focus.
+
+## Events Route
+
+The server-side SSE endpoint is at `src/app/api/commitments/[id]/events/route.ts`. It emits the following events:
+
+| Event name | Payload |
+|---|---|
+| `snapshot` | Initial commitment status on connect. |
+| `status_change` | Emitted when commitment status transitions. |
+| `attestation` | New attestation object (matches the `Attestation` interface). |
+| `: keepalive` | SSE comment sent every ~20 s to keep the connection alive. |
+
+## Testing
+
+Tests are co-located with the component:
+
+```
+src/components/RecentAttestationsPanel/AttestationsRealtime.test.tsx
+```
+
+Run with:
+
+```bash
+pnpm vitest run src/components/RecentAttestationsPanel/AttestationsRealtime.test.tsx
+```
+
+Covered scenarios: initial render, SSE subscription URL, live prepend, deduplication, live region announcement, summary count update, EventSource unavailable fallback, reconnect with back-off, streaming disabled.

--- a/src/components/RecentAttestationsPanel/AttestationsRealtime.test.tsx
+++ b/src/components/RecentAttestationsPanel/AttestationsRealtime.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment happy-dom
+
+import React from 'react'
+import { render, screen, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import RecentAttestationsPanel, { type Attestation } from './RecentAttestationsPanel'
+
+// ---------------------------------------------------------------------------
+// Minimal EventSource mock
+// ---------------------------------------------------------------------------
+type EventHandler = (event: MessageEvent) => void
+
+class MockEventSource {
+  static instances: MockEventSource[] = []
+  url: string
+  listeners: Record<string, EventHandler[]> = {}
+  onerror: (() => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    MockEventSource.instances.push(this)
+  }
+
+  addEventListener(type: string, handler: EventHandler) {
+    if (!this.listeners[type]) this.listeners[type] = []
+    this.listeners[type].push(handler)
+  }
+
+  /** Helper used in tests to emit a named event */
+  emit(type: string, data: unknown) {
+    const handlers = this.listeners[type] ?? []
+    const event = { data: JSON.stringify(data) } as MessageEvent
+    handlers.forEach((h) => h(event))
+  }
+
+  close() {
+    MockEventSource.instances = MockEventSource.instances.filter((es) => es !== this)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+const baseAttestation: Attestation = {
+  id: 'att-1',
+  title: 'Health check passed',
+  description: 'All systems nominal',
+  txHash: '0xabcdef1234567890',
+  timestamp: new Date('2025-01-01T00:00:00Z').toISOString(),
+  severity: 'ok',
+}
+
+const baseSummary = { complianceCount: 1, warningCount: 0, violationCount: 0 }
+
+function renderPanel(overrides: Partial<React.ComponentProps<typeof RecentAttestationsPanel>> = {}) {
+  const defaults: React.ComponentProps<typeof RecentAttestationsPanel> = {
+    attestations: [baseAttestation],
+    summary: baseSummary,
+    onSelectAttestation: vi.fn(),
+    onViewAll: vi.fn(),
+    commitmentId: 'commitment-abc',
+    streamingEnabled: true,
+  }
+  return render(<RecentAttestationsPanel {...defaults} {...overrides} />)
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  MockEventSource.instances = []
+  vi.stubGlobal('EventSource', MockEventSource)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('RecentAttestationsPanel — real-time streaming', () => {
+  it('renders existing attestations without streaming', () => {
+    renderPanel({ commitmentId: null })
+    expect(screen.getByText('Health check passed')).toBeInTheDocument()
+  })
+
+  it('creates an EventSource for the correct commitment URL', () => {
+    renderPanel()
+    expect(MockEventSource.instances).toHaveLength(1)
+    expect(MockEventSource.instances[0].url).toBe('/api/commitments/commitment-abc/events')
+  })
+
+  it('does not create an EventSource when streamingEnabled is false', () => {
+    renderPanel({ streamingEnabled: false })
+    expect(MockEventSource.instances).toHaveLength(0)
+  })
+
+  it('does not create an EventSource when commitmentId is null', () => {
+    renderPanel({ commitmentId: null })
+    expect(MockEventSource.instances).toHaveLength(0)
+  })
+
+  it('prepends a new attestation live when an event is emitted', async () => {
+    renderPanel()
+    const newAttestation: Attestation = {
+      id: 'att-live-1',
+      title: 'Live warning',
+      description: 'Something changed',
+      txHash: '0xdeadbeef00000000',
+      timestamp: new Date().toISOString(),
+      severity: 'warning',
+    }
+
+    await act(async () => {
+      MockEventSource.instances[0].emit('attestation', newAttestation)
+    })
+
+    expect(screen.getByText('Live warning')).toBeInTheDocument()
+    // New item should appear before the initial one
+    const rows = screen.getAllByRole('listitem')
+    expect(rows[0]).toHaveAccessibleName(/Live warning/)
+    expect(rows[1]).toHaveAccessibleName(/Health check passed/)
+  })
+
+  it('deduplicates attestations already present in the initial list', async () => {
+    renderPanel()
+
+    await act(async () => {
+      // Emit an attestation with the same id as the initial one
+      MockEventSource.instances[0].emit('attestation', baseAttestation)
+    })
+
+    // Should still only show one item with that title
+    expect(screen.getAllByText('Health check passed')).toHaveLength(1)
+  })
+
+  it('deduplicates attestations that arrive more than once via SSE', async () => {
+    renderPanel({ attestations: [], summary: { complianceCount: 0, warningCount: 0, violationCount: 0 } })
+    const newAttestation: Attestation = {
+      id: 'att-dup',
+      title: 'Duplicate check',
+      description: 'Should only appear once',
+      txHash: '0x111111',
+      timestamp: new Date().toISOString(),
+      severity: 'ok',
+    }
+
+    await act(async () => {
+      MockEventSource.instances[0].emit('attestation', newAttestation)
+      MockEventSource.instances[0].emit('attestation', newAttestation)
+    })
+
+    expect(screen.getAllByText('Duplicate check')).toHaveLength(1)
+  })
+
+  it('announces new attestations via accessible live region', async () => {
+    renderPanel()
+    const newAttestation: Attestation = {
+      id: 'att-announce',
+      title: 'Announced attestation',
+      description: 'For a11y test',
+      txHash: '0xaaaa',
+      timestamp: new Date().toISOString(),
+      severity: 'ok',
+    }
+
+    await act(async () => {
+      MockEventSource.instances[0].emit('attestation', newAttestation)
+    })
+
+    const liveRegion = screen.getByRole('status')
+    expect(liveRegion).toHaveTextContent('New attestation: Announced attestation')
+  })
+
+  it('updates summary counts with live attestations', async () => {
+    renderPanel()
+    const warningAttestation: Attestation = {
+      id: 'att-warn',
+      title: 'Warning event',
+      description: 'Increments warning count',
+      txHash: '0xwarn',
+      timestamp: new Date().toISOString(),
+      severity: 'warning',
+    }
+
+    await act(async () => {
+      MockEventSource.instances[0].emit('attestation', warningAttestation)
+    })
+
+    // Initial warningCount was 0; after streaming it should be 1
+    expect(screen.getByLabelText('1 warning attestations')).toBeInTheDocument()
+  })
+
+  it('falls back gracefully when EventSource is unavailable', () => {
+    vi.stubGlobal('EventSource', undefined)
+    expect(() => renderPanel()).not.toThrow()
+    expect(screen.getByText('Health check passed')).toBeInTheDocument()
+  })
+
+  it('reconnects with backoff on EventSource error', async () => {
+    vi.useFakeTimers()
+    renderPanel()
+
+    const es = MockEventSource.instances[0]
+
+    await act(async () => {
+      es.onerror?.()
+    })
+
+    // After backoff delay a new EventSource should be created
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+    })
+
+    expect(MockEventSource.instances.length).toBeGreaterThanOrEqual(1)
+    vi.useRealTimers()
+  })
+})

--- a/src/components/RecentAttestationsPanel/RecentAttestationsPanel.tsx
+++ b/src/components/RecentAttestationsPanel/RecentAttestationsPanel.tsx
@@ -1,7 +1,9 @@
 'use client'
 
+import { useState, useCallback } from 'react'
 import styles from './RecentAttestationsPanel.module.css'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { useAttestationStream } from '@/hooks/useAttestationStream'
 
 export interface Attestation {
   id: string
@@ -21,6 +23,10 @@ export interface RecentAttestationsPanelProps {
   }
   onSelectAttestation: (id: string) => void
   onViewAll: () => void
+  /** Optional commitment ID to enable real-time SSE streaming of new attestations. */
+  commitmentId?: string | null
+  /** Set to false to disable streaming even when commitmentId is provided. */
+  streamingEnabled?: boolean
 }
 
 // Utility function to format relative time
@@ -130,11 +136,53 @@ function ArrowRightIcon() {
 }
 
 export default function RecentAttestationsPanel({
-  attestations,
-  summary,
+  attestations: initialAttestations,
+  summary: initialSummary,
   onSelectAttestation,
   onViewAll,
+  commitmentId = null,
+  streamingEnabled = true,
 }: RecentAttestationsPanelProps) {
+  // Live attestations prepend in front of the initial static list
+  const [liveAttestations, setLiveAttestations] = useState<Attestation[]>([])
+  const [liveAnnouncement, setLiveAnnouncement] = useState<string>('')
+
+  const handleAttestation = useCallback(
+    (attestation: Attestation) => {
+      setLiveAttestations((prev) => {
+        // Deduplicate by id against both live and initial lists
+        const existsInLive = prev.some((a) => a.id === attestation.id)
+        const existsInInitial = initialAttestations.some((a) => a.id === attestation.id)
+        if (existsInLive || existsInInitial) return prev
+        return [attestation, ...prev]
+      })
+      setLiveAnnouncement(`New attestation: ${attestation.title}`)
+    },
+    [initialAttestations],
+  )
+
+  useAttestationStream({
+    commitmentId,
+    onAttestation: handleAttestation,
+    enabled: streamingEnabled && commitmentId !== null,
+  })
+
+  // Merge live (prepended) with initial static list
+  const attestations = [...liveAttestations, ...initialAttestations]
+
+  // Derive live summary counts that include streamed items
+  const summary = {
+    complianceCount:
+      initialSummary.complianceCount +
+      liveAttestations.filter((a) => a.severity === 'ok').length,
+    warningCount:
+      initialSummary.warningCount +
+      liveAttestations.filter((a) => a.severity === 'warning').length,
+    violationCount:
+      initialSummary.violationCount +
+      liveAttestations.filter((a) => a.severity === 'violation').length,
+  }
+
   const getSeverityIcon = (severity: Attestation['severity']) => {
     switch (severity) {
       case 'ok':
@@ -163,6 +211,16 @@ export default function RecentAttestationsPanel({
 
   return (
     <section className={styles.panel} aria-label="Recent Attestations">
+      {/* Accessible live region for new attestation announcements */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {liveAnnouncement}
+      </div>
+
       <header className={styles.header}>
         <h2 className={styles.title}>Recent Attestations</h2>
         <button

--- a/src/hooks/useAttestationStream.ts
+++ b/src/hooks/useAttestationStream.ts
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useCallback } from 'react'
+import type { Attestation } from '@/components/RecentAttestationsPanel/RecentAttestationsPanel'
+
+export interface AttestationStreamEvent {
+  type: 'attestation'
+  data: Attestation
+}
+
+export interface UseAttestationStreamOptions {
+  commitmentId: string | null
+  onAttestation: (attestation: Attestation) => void
+  enabled?: boolean
+}
+
+const INITIAL_BACKOFF_MS = 1000
+const MAX_BACKOFF_MS = 30000
+const BACKOFF_MULTIPLIER = 2
+
+/**
+ * Hook that subscribes to the SSE events route for a commitment and calls
+ * `onAttestation` whenever a new attestation event arrives.
+ *
+ * Implements exponential back-off reconnect and tears down the EventSource
+ * on unmount or when `enabled` becomes false.
+ */
+export function useAttestationStream({
+  commitmentId,
+  onAttestation,
+  enabled = true,
+}: UseAttestationStreamOptions): void {
+  const onAttestationRef = useRef(onAttestation)
+  onAttestationRef.current = onAttestation
+
+  const backoffRef = useRef(INITIAL_BACKOFF_MS)
+  const esRef = useRef<EventSource | null>(null)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const mountedRef = useRef(true)
+
+  const cleanup = useCallback(() => {
+    if (reconnectTimerRef.current !== null) {
+      clearTimeout(reconnectTimerRef.current)
+      reconnectTimerRef.current = null
+    }
+    if (esRef.current) {
+      esRef.current.close()
+      esRef.current = null
+    }
+  }, [])
+
+  const connect = useCallback(() => {
+    if (!mountedRef.current || !commitmentId) return
+
+    cleanup()
+
+    let es: EventSource
+    try {
+      es = new EventSource(`/api/commitments/${commitmentId}/events`)
+    } catch {
+      // EventSource not supported — fall back silently
+      return
+    }
+
+    esRef.current = es
+    backoffRef.current = INITIAL_BACKOFF_MS
+
+    es.addEventListener('attestation', (e: MessageEvent) => {
+      if (!mountedRef.current) return
+      try {
+        const attestation = JSON.parse(e.data) as Attestation
+        onAttestationRef.current(attestation)
+      } catch {
+        // Malformed event — ignore
+      }
+    })
+
+    es.onerror = () => {
+      if (!mountedRef.current) return
+      cleanup()
+      const delay = Math.min(backoffRef.current, MAX_BACKOFF_MS)
+      backoffRef.current = Math.min(backoffRef.current * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS)
+      reconnectTimerRef.current = setTimeout(() => {
+        if (mountedRef.current) connect()
+      }, delay)
+    }
+  }, [commitmentId, cleanup])
+
+  useEffect(() => {
+    mountedRef.current = true
+
+    if (enabled && commitmentId && typeof EventSource !== 'undefined') {
+      connect()
+    }
+
+    return () => {
+      mountedRef.current = false
+      cleanup()
+    }
+  }, [commitmentId, enabled, connect, cleanup])
+}


### PR DESCRIPTION
Fixes #963

## Summary
- Adds `useAttestationStream` hook that subscribes to `/api/commitments/[id]/events` via SSE, reconnects with exponential back-off (1 s → 30 s), and tears down cleanly on unmount.
- Updates `RecentAttestationsPanel` with optional `commitmentId` / `streamingEnabled` props; new attestations are prepended and deduplicated; live summary counts are merged into the footer.
- Accessible `aria-live="polite"` live region announces each new arrival without disrupting scroll position or focus.
- Falls back to static behavior silently when `EventSource` is unavailable.

## Changes
- `src/hooks/useAttestationStream.ts` — new SSE hook with back-off reconnect
- `src/components/RecentAttestationsPanel/RecentAttestationsPanel.tsx` — wired to stream, deduplication, live region, merged summary
- `src/components/RecentAttestationsPanel/AttestationsRealtime.test.tsx` — focused test suite (render, SSE URL, live prepend, dedup, a11y announcement, summary counts, fallback, reconnect)
- `docs/ATTESTATIONS_REALTIME.md` — feature docs with props table, hook API, behaviour notes, accessibility, usage example