### PR TITLE
Add an attestation CSV export action to RecentAttestationsPanel

### DIFF
--- a/docs/ATTESTATIONS_EXPORT.md
+++ b/docs/ATTESTATIONS_EXPORT.md
@@ -1,0 +1,65 @@
+# Attestation CSV Export
+
+## Overview
+
+`RecentAttestationsPanel` includes a **Export CSV** button that downloads the currently displayed (and potentially filtered) attestations as a comma-separated values file.
+
+## Feature Behaviour
+
+- The **Export CSV** button appears in the panel header alongside **View All**.
+- It is **disabled** (and `aria-disabled`) when there are no attestations to export.
+- Clicking it generates a CSV from the `attestations` prop and triggers a browser download.
+- The filename format is `attestations-<commitmentId>-<YYYY-MM-DD>.csv`, where both `<commitmentId>` and the date stamp are sanitized.
+- CSV fields are safely escaped using the shared `escapeCsvField` helper from `src/lib/backend/csv.ts`, which guards against CSV formula-injection attacks.
+
+## Props / API
+
+`RecentAttestationsPanel` accepts one new optional prop:
+
+| Prop           | Type     | Default | Description                                              |
+|----------------|----------|---------|----------------------------------------------------------|
+| `commitmentId` | `string` | `''`    | Used to build the download filename. Sanitized automatically. |
+
+All other existing props are unchanged.
+
+## Utility Functions (src/utils/chartExport.ts)
+
+| Export                           | Signature                                                    | Description                                             |
+|----------------------------------|--------------------------------------------------------------|---------------------------------------------------------|
+| `ATTESTATION_CSV_HEADERS`        | `readonly string[]`                                          | Column headers: ID, Title, Description, TX Hash, Timestamp, Severity |
+| `buildAttestationCsvRows`        | `(attestations: Attestation[]) => CsvRow[]`                  | Maps attestations to raw CSV rows.                      |
+| `buildAttestationCsvContent`     | `(attestations: Attestation[]) => string`                    | Produces a complete CSV string (headers + rows).        |
+| `buildAttestationExportFilename` | `(commitmentId: string) => string`                           | Builds a sanitized filename with today's date.          |
+
+## Usage Example
+
+```tsx
+import RecentAttestationsPanel from '@/components/RecentAttestationsPanel/RecentAttestationsPanel'
+
+<RecentAttestationsPanel
+  attestations={filteredAttestations}
+  commitmentId="cmt-42"
+  summary={{ complianceCount: 3, warningCount: 1, violationCount: 0 }}
+  onSelectAttestation={(id) => router.push(`/attestations/${id}`)}
+  onViewAll={() => router.push('/attestations')}
+/>
+```
+
+## Accessibility
+
+- The export button has a descriptive `aria-label`:
+  - When enabled: `"Export attestations as CSV"`
+  - When disabled: `"Export attestations as CSV (no attestations to export)"`
+- `aria-disabled` is set alongside the native `disabled` attribute.
+- The button is keyboard-focusable; focus ring is visible via `:focus-visible`.
+- The download icon is `aria-hidden` so screen readers only announce the button label.
+
+## Edge Cases
+
+| Scenario                       | Behaviour                                                            |
+|--------------------------------|----------------------------------------------------------------------|
+| Empty attestations list        | Button is disabled; no download triggered.                           |
+| Filtered / partial list        | Only the passed `attestations` appear in the CSV — not the full set. |
+| Fields containing commas       | Wrapped in double-quotes per RFC 4180.                               |
+| Formula-injection (`=`, `+`, `-`, `@`) | Prepended with `'` to neutralize spreadsheet formula execution. |
+| Special chars in `commitmentId`| Replaced with `-` via `sanitizeExportFilename`.                      |

--- a/src/components/RecentAttestationsPanel/AttestationsExport.test.tsx
+++ b/src/components/RecentAttestationsPanel/AttestationsExport.test.tsx
@@ -1,0 +1,226 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import RecentAttestationsPanel, { type Attestation } from './RecentAttestationsPanel'
+import {
+  buildAttestationCsvContent,
+  buildAttestationCsvRows,
+  buildAttestationExportFilename,
+  ATTESTATION_CSV_HEADERS,
+} from '@/utils/chartExport'
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_SUMMARY = { complianceCount: 1, warningCount: 1, violationCount: 0 }
+
+const ATTESTATIONS: Attestation[] = [
+  {
+    id: 'a1',
+    title: 'Compliance check',
+    description: 'All policies met',
+    txHash: '0xabc123def456',
+    timestamp: '2026-01-01T10:00:00.000Z',
+    severity: 'ok',
+  },
+  {
+    id: 'a2',
+    title: 'Threshold warning',
+    description: 'Near limit',
+    txHash: '0x111222333444',
+    timestamp: new Date('2026-01-02T12:00:00.000Z'),
+    severity: 'warning',
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Unit tests for chartExport attestation helpers
+// ---------------------------------------------------------------------------
+
+describe('buildAttestationCsvRows', () => {
+  it('maps each attestation to the correct columns', () => {
+    const rows = buildAttestationCsvRows(ATTESTATIONS)
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toEqual(['a1', 'Compliance check', 'All policies met', '0xabc123def456', '2026-01-01T10:00:00.000Z', 'ok'])
+    // Date instance should be serialised to ISO string
+    expect(rows[1][4]).toBe('2026-01-02T12:00:00.000Z')
+  })
+
+  it('returns an empty array for no attestations', () => {
+    expect(buildAttestationCsvRows([])).toEqual([])
+  })
+})
+
+describe('buildAttestationCsvContent', () => {
+  it('includes the CSV header row', () => {
+    const csv = buildAttestationCsvContent(ATTESTATIONS)
+    const headerRow = [...ATTESTATION_CSV_HEADERS].join(',')
+    expect(csv).toContain(headerRow)
+  })
+
+  it('produces only a header row when attestations are empty', () => {
+    const csv = buildAttestationCsvContent([])
+    expect(csv).toBe('ID,Title,Description,TX Hash,Timestamp,Severity\r\n')
+  })
+
+  it('escapes formula-injection characters in fields', () => {
+    const malicious: Attestation[] = [
+      {
+        id: '=CMD()',
+        title: '+formula',
+        description: 'safe',
+        txHash: '0x000',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        severity: 'ok',
+      },
+    ]
+    const csv = buildAttestationCsvContent(malicious)
+    // escapeCsvField prepends ' to formula-like values
+    expect(csv).toContain("'=CMD()")
+    expect(csv).toContain("'+formula")
+  })
+
+  it('wraps fields containing commas in double-quotes', () => {
+    const withComma: Attestation[] = [
+      {
+        id: 'x',
+        title: 'title, with comma',
+        description: 'desc',
+        txHash: '0x0',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        severity: 'ok',
+      },
+    ]
+    const csv = buildAttestationCsvContent(withComma)
+    expect(csv).toContain('"title, with comma"')
+  })
+})
+
+describe('buildAttestationExportFilename', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-29T00:00:00.000Z'))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('includes the sanitized commitment id and date', () => {
+    const name = buildAttestationExportFilename('cmt/001')
+    expect(name).toBe('attestations-cmt-001-2026-06-29.csv')
+  })
+
+  it('falls back to "commitment" when id is empty', () => {
+    const name = buildAttestationExportFilename('')
+    expect(name).toBe('attestations-commitment-2026-06-29.csv')
+  })
+
+  it('strips special characters from the commitment id', () => {
+    const name = buildAttestationExportFilename('bad name!!!')
+    expect(name).toBe('attestations-bad-name-2026-06-29.csv')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Component integration tests
+// ---------------------------------------------------------------------------
+
+function setupDownloadMocks() {
+  Object.defineProperty(window.URL, 'createObjectURL', {
+    configurable: true,
+    value: vi.fn(() => 'blob:test'),
+  })
+  Object.defineProperty(window.URL, 'revokeObjectURL', {
+    configurable: true,
+    value: vi.fn(),
+  })
+  return vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+}
+
+describe('RecentAttestationsPanel – Export CSV button', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-29T00:00:00.000Z'))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('renders the Export CSV button', () => {
+    render(
+      <RecentAttestationsPanel
+        attestations={ATTESTATIONS}
+        summary={BASE_SUMMARY}
+        onSelectAttestation={vi.fn()}
+        onViewAll={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /export attestations as csv/i })).toBeInTheDocument()
+  })
+
+  it('disables the Export CSV button when attestations is empty', () => {
+    render(
+      <RecentAttestationsPanel
+        attestations={[]}
+        summary={{ complianceCount: 0, warningCount: 0, violationCount: 0 }}
+        onSelectAttestation={vi.fn()}
+        onViewAll={vi.fn()}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: /export attestations as csv/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('is enabled when there are attestations', () => {
+    render(
+      <RecentAttestationsPanel
+        attestations={ATTESTATIONS}
+        summary={BASE_SUMMARY}
+        onSelectAttestation={vi.fn()}
+        onViewAll={vi.fn()}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: /export attestations as csv/i })
+    expect(btn).not.toBeDisabled()
+  })
+
+  it('triggers a CSV download when clicked', async () => {
+    const clickSpy = setupDownloadMocks()
+    render(
+      <RecentAttestationsPanel
+        attestations={ATTESTATIONS}
+        commitmentId="cmt-42"
+        summary={BASE_SUMMARY}
+        onSelectAttestation={vi.fn()}
+        onViewAll={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /export attestations as csv/i }))
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled())
+    expect(window.URL.createObjectURL).toHaveBeenCalled()
+  })
+
+  it('reflects only the displayed attestations in the CSV (filtered set)', async () => {
+    const clickSpy = setupDownloadMocks()
+    // Only pass one attestation to simulate a filtered view
+    render(
+      <RecentAttestationsPanel
+        attestations={[ATTESTATIONS[0]]}
+        commitmentId="cmt-42"
+        summary={{ complianceCount: 1, warningCount: 0, violationCount: 0 }}
+        onSelectAttestation={vi.fn()}
+        onViewAll={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /export attestations as csv/i }))
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled())
+
+    const blobArg = (window.URL.createObjectURL as ReturnType<typeof vi.fn>).mock.calls[0][0] as Blob
+    const text = await blobArg.text()
+    expect(text).toContain('Compliance check')
+    expect(text).not.toContain('Threshold warning')
+  })
+})

--- a/src/components/RecentAttestationsPanel/RecentAttestationsPanel.module.css
+++ b/src/components/RecentAttestationsPanel/RecentAttestationsPanel.module.css
@@ -22,6 +22,45 @@
   margin: 0;
 }
 
+.headerActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.exportButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 0.5px solid rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+  white-space: nowrap;
+}
+
+.exportButton:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.25);
+  transform: translateY(-1px);
+}
+
+.exportButton:focus-visible {
+  outline: 2px solid rgba(15, 240, 252, 0.6);
+  outline-offset: 2px;
+}
+
+.exportButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .viewAllButton {
   display: inline-flex;
   align-items: center;

--- a/src/components/RecentAttestationsPanel/RecentAttestationsPanel.tsx
+++ b/src/components/RecentAttestationsPanel/RecentAttestationsPanel.tsx
@@ -1,7 +1,13 @@
 'use client'
 
+import { useCallback, useState } from 'react'
 import styles from './RecentAttestationsPanel.module.css'
 import { EmptyState } from '@/components/ui/EmptyState'
+import {
+  buildAttestationCsvContent,
+  buildAttestationExportFilename,
+  downloadCsvContent,
+} from '@/utils/chartExport'
 
 export interface Attestation {
   id: string
@@ -14,6 +20,7 @@ export interface Attestation {
 
 export interface RecentAttestationsPanelProps {
   attestations: Attestation[]
+  commitmentId?: string
   summary: {
     complianceCount: number
     warningCount: number
@@ -129,12 +136,47 @@ function ArrowRightIcon() {
   )
 }
 
+function DownloadIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path
+        d="M8 2v8M5 7l3 3 3-3"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M3 13h10"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
 export default function RecentAttestationsPanel({
   attestations,
+  commitmentId = '',
   summary,
   onSelectAttestation,
   onViewAll,
 }: RecentAttestationsPanelProps) {
+  const [isExporting, setIsExporting] = useState(false)
+
+  const handleExportCsv = useCallback(async () => {
+    if (attestations.length === 0) return
+    setIsExporting(true)
+    try {
+      const content = buildAttestationCsvContent(attestations)
+      const filename = buildAttestationExportFilename(commitmentId)
+      await downloadCsvContent(content, filename)
+    } finally {
+      setIsExporting(false)
+    }
+  }, [attestations, commitmentId])
+
   const getSeverityIcon = (severity: Attestation['severity']) => {
     switch (severity) {
       case 'ok':
@@ -165,15 +207,32 @@ export default function RecentAttestationsPanel({
     <section className={styles.panel} aria-label="Recent Attestations">
       <header className={styles.header}>
         <h2 className={styles.title}>Recent Attestations</h2>
-        <button
-          type="button"
-          className={styles.viewAllButton}
-          onClick={onViewAll}
-          aria-label="View all attestations"
-        >
-          View All
-          <ArrowRightIcon />
-        </button>
+        <div className={styles.headerActions}>
+          <button
+            type="button"
+            className={styles.exportButton}
+            onClick={handleExportCsv}
+            disabled={attestations.length === 0 || isExporting}
+            aria-label={
+              attestations.length === 0
+                ? 'Export attestations as CSV (no attestations to export)'
+                : 'Export attestations as CSV'
+            }
+            aria-disabled={attestations.length === 0 || isExporting}
+          >
+            <DownloadIcon />
+            {isExporting ? 'Exporting…' : 'Export CSV'}
+          </button>
+          <button
+            type="button"
+            className={styles.viewAllButton}
+            onClick={onViewAll}
+            aria-label="View all attestations"
+          >
+            View All
+            <ArrowRightIcon />
+          </button>
+        </div>
       </header>
 
       <div className={styles.attestationsList} role="list">

--- a/src/utils/chartExport.ts
+++ b/src/utils/chartExport.ts
@@ -1,4 +1,5 @@
 import { buildCsv, type CsvRow } from '@/lib/backend/csv';
+import type { Attestation } from '@/components/RecentAttestationsPanel/RecentAttestationsPanel';
 
 export type HealthMetricsTab = 'value' | 'drawdown' | 'fee' | 'compliance';
 
@@ -160,4 +161,32 @@ function loadImage(src: string): Promise<HTMLImageElement> {
     image.onerror = () => reject(new Error('Failed to load chart SVG for PNG export'));
     image.src = src;
   });
+}
+
+// ── Attestation CSV export helpers ──────────────────────────────────────────
+
+export const ATTESTATION_CSV_HEADERS = ['ID', 'Title', 'Description', 'TX Hash', 'Timestamp', 'Severity'] as const;
+
+export function buildAttestationCsvRows(attestations: Attestation[]): CsvRow[] {
+  return attestations.map((a) => [
+    a.id,
+    a.title,
+    a.description,
+    a.txHash,
+    typeof a.timestamp === 'string' ? a.timestamp : a.timestamp.toISOString(),
+    a.severity,
+  ]);
+}
+
+export function buildAttestationCsvContent(attestations: Attestation[]): string {
+  return buildCsv(
+    [...ATTESTATION_CSV_HEADERS],
+    buildAttestationCsvRows(attestations),
+  );
+}
+
+export function buildAttestationExportFilename(commitmentId: string): string {
+  const safeId = sanitizeExportFilename(commitmentId || 'commitment');
+  const dateStamp = new Date().toISOString().slice(0, 10);
+  return sanitizeExportFilename(`attestations-${safeId}-${dateStamp}.csv`);
 }


### PR DESCRIPTION
Fixes #962

## Summary
- Add **Export CSV** button to `RecentAttestationsPanel` header; disabled when attestations list is empty
- Add `buildAttestationCsvContent`, `buildAttestationCsvRows`, and `buildAttestationExportFilename` helpers to `src/utils/chartExport.ts`, reusing `escapeCsvField`/`buildCsv` from `src/lib/backend/csv.ts`
- Add `AttestationsExport.test.tsx` covering: rendering, empty-disabled state, download trigger, filtered set reflects in CSV, safe CSV escaping, and filename sanitization

## Changes
Implements the feature as described in the issue, following existing code patterns from `chartExport.ts` and the CSV helper conventions from `csv.ts`. Includes `docs/ATTESTATIONS_EXPORT.md` documenting props/API, accessibility behaviour, and edge cases.