### PR TITLE
Add a notification-history view linking ToastProvider toasts to the notifications center

### DIFF
--- a/docs/TOAST_HISTORY.md
+++ b/docs/TOAST_HISTORY.md
@@ -1,0 +1,136 @@
+# Toast History
+
+## Overview
+
+`ToastHistory` is a companion component to the existing `ToastProvider` that records every dismissed (or auto-expired) client toast into a bounded in-memory store and surfaces those entries as a reviewable notification-history panel.
+
+This bridges the gap between ephemeral toasts and the notifications center: users who miss a transient toast can open the history panel to review what happened.
+
+Server-derived notifications are deliberately kept separate — history entries carry `source: "toast"` so consuming UIs can filter them without ambiguity.
+
+---
+
+## Architecture
+
+```
+ToastProvider (context)
+├── active toasts (visible queue, max 5)
+└── history store (dismissed toasts, max 50 entries)
+    └── ToastHistoryEntry { id, severity, title, description,
+                           createdAt, dismissedAt, read, source }
+```
+
+`ToastHistory` reads from the same context and renders the history list. `useToastHistoryUnreadCount` is a lightweight hook for badge counts in nav bars or notification-center icons.
+
+---
+
+## Usage
+
+### Basic — drop into the notifications center
+
+```tsx
+import { ToastHistory } from '@/components/toast/ToastHistory';
+
+// Inside any component rendered within ToastProvider:
+export function NotificationsPanel() {
+  return (
+    <aside aria-label="Notifications panel">
+      <ToastHistory />
+    </aside>
+  );
+}
+```
+
+### Limit rendered entries
+
+```tsx
+<ToastHistory maxEntries={10} />
+```
+
+### Show an unread badge in a nav icon
+
+```tsx
+import { useToastHistoryUnreadCount } from '@/components/toast/ToastHistory';
+
+function NotificationsIcon() {
+  const unread = useToastHistoryUnreadCount();
+  return (
+    <button type="button" aria-label={`Notifications${unread > 0 ? `, ${unread} unread` : ''}`}>
+      <BellIcon />
+      {unread > 0 && <span aria-hidden="true">{unread}</span>}
+    </button>
+  );
+}
+```
+
+### Programmatic history access via `useToast`
+
+```tsx
+const { history, clearHistory, markHistoryRead, markAllHistoryRead } = useToast();
+```
+
+---
+
+## API
+
+### `<ToastHistory>` Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `maxEntries` | `number` | all entries | Maximum number of history items rendered. |
+
+### `useToastHistoryUnreadCount(): number`
+
+Returns the count of unread toast-history entries from context.
+
+### Context additions (`ToastContextValue`)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `history` | `ToastHistoryEntry[]` | Ordered (newest first) array of dismissed toasts. |
+| `clearHistory` | `() => void` | Remove all history entries. |
+| `markHistoryRead` | `(id: string) => void` | Mark a single entry as read. |
+| `markAllHistoryRead` | `() => void` | Mark all entries as read. |
+
+### `ToastHistoryEntry` shape
+
+```ts
+interface ToastHistoryEntry {
+  id: string;
+  severity: 'success' | 'error' | 'info' | 'warning';
+  title: string;
+  description?: string;
+  createdAt: number;   // ms since epoch — when the toast first appeared
+  dismissedAt: number; // ms since epoch — when it left the visible queue
+  read: boolean;
+  source: 'toast';     // always "toast" — never mixed with server notifications
+}
+```
+
+---
+
+## Behavior
+
+- **Bounded store** — the history is capped at 50 entries (oldest are discarded first).
+- **No duplicates** — dismissing the same toast ID twice is a no-op in the store.
+- **Auto-expire recording** — toasts that auto-dismiss via their timer are recorded exactly as manual dismissals are.
+- **`dismissAll` recording** — all currently visible toasts are archived when `dismissAll` is called.
+- **Privacy-safe** — only `title`, `description`, `severity`, and timestamps are stored. No user-supplied action callbacks or sensitive payloads are retained.
+
+---
+
+## Accessibility
+
+- The history panel is wrapped in a `<section aria-label="Notification history">` so keyboard users can jump to it with a landmarks shortcut.
+- The list uses `role="list"` with an `aria-label`.
+- Each list item has an `aria-label` describing severity, title, description, and dismissal time.
+- The unread badge uses `aria-label="N unread"` and is hidden from AT when count is zero.
+- "Mark read" and "Clear all" buttons have descriptive accessible labels.
+- No `prefers-reduced-motion` concerns — the panel is static (no animation).
+
+---
+
+## Related docs
+
+- [Toast System](./TOAST_SYSTEM.md) — the base toast provider, its API, and aria-live announcer details.
+- [Toast Actions](./TOAST_ACTIONS.md) — how to add interactive action buttons to toasts.

--- a/src/components/toast/ToastHistory.test.tsx
+++ b/src/components/toast/ToastHistory.test.tsx
@@ -1,0 +1,272 @@
+// @vitest-environment happy-dom
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { ToastProvider, useToast } from './ToastProvider';
+import { ToastHistory, useToastHistoryUnreadCount } from './ToastHistory';
+
+vi.mock('./toast.css', () => ({}));
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(ToastProvider, null, children);
+}
+
+function TestConsumer() {
+  const toast = useToast();
+  return React.createElement(
+    'div',
+    null,
+    React.createElement('button', { onClick: () => toast.success({ title: 'Saved' }) }, 'add success'),
+    React.createElement('button', { onClick: () => toast.error({ title: 'Failed', description: 'Something went wrong' }) }, 'add error'),
+    React.createElement('button', { onClick: () => toast.info({ title: 'FYI' }) }, 'add info'),
+    React.createElement('button', { onClick: () => toast.warning({ title: 'Heads up' }) }, 'add warning'),
+    React.createElement('button', { onClick: () => toast.dismissAll() }, 'dismiss all'),
+    React.createElement(ToastHistory, null)
+  );
+}
+
+function UnreadConsumer() {
+  const count = useToastHistoryUnreadCount();
+  const toast = useToast();
+  return React.createElement(
+    'div',
+    null,
+    React.createElement('span', { 'data-testid': 'unread-count' }, String(count)),
+    React.createElement('button', { onClick: () => toast.success({ title: 'Hello', duration: 1 }) }, 'add')
+  );
+}
+
+describe('ToastHistory', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows empty state when no toasts have been dismissed', () => {
+    render(React.createElement(Wrapper, null, React.createElement(ToastHistory, null)));
+    expect(screen.getByTestId ? document.querySelector('[data-toast-history-empty]') : null).not.toBeUndefined();
+    expect(document.querySelector('[data-toast-history-empty]')?.textContent).toBe('No notifications yet.');
+  });
+
+  it('records a dismissed toast in history', () => {
+    render(React.createElement(Wrapper, null, React.createElement(TestConsumer, null)));
+
+    act(() => screen.getByText('add success').click());
+    act(() => screen.getByLabelText('Dismiss notification').click());
+
+    expect(document.querySelector('[data-toast-history-item]')).not.toBeNull();
+    expect(document.querySelector('.toast-history-title')?.textContent).toBe('Saved');
+  });
+
+  it('records a toast that auto-dismisses via timer', () => {
+    render(React.createElement(Wrapper, null, React.createElement(TestConsumer, null)));
+
+    act(() => screen.getByText('add success').click());
+    act(() => vi.advanceTimersByTime(5000));
+
+    const items = document.querySelectorAll('[data-toast-history-item]');
+    expect(items.length).toBe(1);
+    expect(document.querySelector('.toast-history-title')?.textContent).toBe('Saved');
+  });
+
+  it('records description alongside title', () => {
+    render(React.createElement(Wrapper, null, React.createElement(TestConsumer, null)));
+
+    act(() => screen.getByText('add error').click());
+    act(() => vi.advanceTimersByTime(5000));
+
+    expect(document.querySelector('.toast-history-description')?.textContent).toBe('Something went wrong');
+  });
+
+  it('history entries are tagged source=toast (not server notifications)', () => {
+    render(React.createElement(Wrapper, null, React.createElement(TestConsumer, null)));
+
+    act(() => screen.getByText('add info').click());
+    act(() => vi.advanceTimersByTime(5000));
+
+    // Access history via context by checking data attribute (source is stored in context)
+    const item = document.querySelector('[data-toast-history-item]');
+    expect(item).not.toBeNull();
+    // severity attribute confirms the correct entry was rendered
+    expect(item?.getAttribute('data-severity')).toBe('info');
+  });
+
+  it('marks a single entry as read', () => {
+    render(React.createElement(Wrapper, null, React.createElement(TestConsumer, null)));
+
+    act(() => screen.getByText('add success').click());
+    act(() => vi.advanceTimersByTime(5000));
+
+    const item = document.querySelector('[data-toast-history-item]');
+    expect(item?.getAttribute('data-read')).toBe('false');
+
+    const markBtn = document.querySelector('.toast-history-mark-read') as HTMLButtonElement | null;
+    expect(markBtn).not.toBeNull();
+    act(() => markBtn!.click());
+
+    expect(document.querySelector('[data-toast-history-item]')?.getAttribute('data-read')).toBe('true');
+  });
+
+  it('marks all entries as read', () => {
+    render(React.createElement(Wrapper, null, React.createElement(TestConsumer, null)));
+
+    act(() => screen.getByText('add success').click());
+    act(() => screen.getByText('add error').click());
+    act(() => screen.getByText('dismiss all').click());
+
+    const unreadBefore = document.querySelectorAll('[data-read="false"]');
+    expect(unreadBefore.length).toBe(2);
+
+    const markAllBtn = screen.getByText('Mark all read') as HTMLButtonElement;
+    act(() => markAllBtn.click());
+
+    expect(document.querySelectorAll('[data-read="false"]').length).toBe(0);
+    expect(document.querySelectorAll('[data-read="true"]').length).toBe(2);
+  });
+
+  it('clears the history', () => {
+    render(React.createElement(Wrapper, null, React.createElement(TestConsumer, null)));
+
+    act(() => screen.getByText('add success').click());
+    act(() => vi.advanceTimersByTime(5000));
+
+    expect(document.querySelectorAll('[data-toast-history-item]').length).toBe(1);
+
+    const clearBtn = screen.getByText('Clear all') as HTMLButtonElement;
+    act(() => clearBtn.click());
+
+    expect(document.querySelectorAll('[data-toast-history-item]').length).toBe(0);
+    expect(document.querySelector('[data-toast-history-empty]')).not.toBeNull();
+  });
+
+  it('dismissAll records all current toasts in history', () => {
+    render(React.createElement(Wrapper, null, React.createElement(TestConsumer, null)));
+
+    act(() => screen.getByText('add success').click());
+    act(() => screen.getByText('add error').click());
+    act(() => screen.getByText('add info').click());
+    act(() => screen.getByText('dismiss all').click());
+
+    const items = document.querySelectorAll('[data-toast-history-item]');
+    expect(items.length).toBe(3);
+  });
+
+  it('does not duplicate an entry when dismissed twice', () => {
+    render(React.createElement(Wrapper, null, React.createElement(TestConsumer, null)));
+
+    act(() => screen.getByText('add success').click());
+    // Manual dismiss
+    act(() => screen.getByLabelText('Dismiss notification').click());
+    // dismissAll on empty list — should not add a second entry
+    act(() => screen.getByText('dismiss all').click());
+
+    expect(document.querySelectorAll('[data-toast-history-item]').length).toBe(1);
+  });
+
+  it('maxEntries prop limits rendered entries', () => {
+    render(
+      React.createElement(Wrapper, null,
+        React.createElement(() => {
+          const toast = useToast();
+          return React.createElement(
+            'div',
+            null,
+            React.createElement('button', { onClick: () => { toast.success({ title: 'A' }); toast.success({ title: 'B' }); toast.success({ title: 'C' }); } }, 'add three'),
+            React.createElement('button', { onClick: () => toast.dismissAll() }, 'dismiss all'),
+            React.createElement(ToastHistory, { maxEntries: 2 })
+          );
+        }, null)
+      )
+    );
+
+    act(() => screen.getByText('add three').click());
+    act(() => screen.getByText('dismiss all').click());
+
+    const items = document.querySelectorAll('[data-toast-history-item]');
+    expect(items.length).toBe(2);
+  });
+
+  it('history is bounded to MAX_HISTORY_ENTRIES (50)', () => {
+    render(
+      React.createElement(Wrapper, null,
+        React.createElement(() => {
+          const toast = useToast();
+          return React.createElement(
+            'div',
+            null,
+            React.createElement('button', {
+              onClick: () => {
+                for (let i = 0; i < 60; i++) {
+                  toast.success({ title: `Toast ${i}`, duration: 1 });
+                }
+              },
+            }, 'add 60'),
+            React.createElement(ToastHistory, null)
+          );
+        }, null)
+      )
+    );
+
+    act(() => screen.getByText('add 60').click());
+    act(() => vi.advanceTimersByTime(200));
+
+    const items = document.querySelectorAll('[data-toast-history-item]');
+    expect(items.length).toBeLessThanOrEqual(50);
+  });
+
+  it('useToastHistoryUnreadCount returns correct unread count', () => {
+    render(React.createElement(Wrapper, null, React.createElement(UnreadConsumer, null)));
+
+    expect(document.querySelector('[data-testid="unread-count"]')?.textContent).toBe('0');
+
+    act(() => screen.getByText('add').click());
+    act(() => vi.advanceTimersByTime(10));
+
+    expect(document.querySelector('[data-testid="unread-count"]')?.textContent).toBe('1');
+  });
+
+  it('history region has accessible label', () => {
+    render(React.createElement(Wrapper, null, React.createElement(ToastHistory, null)));
+    const region = document.querySelector('[data-toast-history]');
+    expect(region?.getAttribute('aria-label')).toBe('Notification history');
+  });
+
+  it('unread badge shows count when there are unread entries', () => {
+    render(React.createElement(Wrapper, null, React.createElement(TestConsumer, null)));
+
+    act(() => screen.getByText('add success').click());
+    act(() => vi.advanceTimersByTime(5000));
+
+    const badge = document.querySelector('.toast-history-unread-badge');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toBe('1');
+    expect(badge?.getAttribute('aria-label')).toBe('1 unread');
+  });
+
+  it('unread badge disappears after all entries are marked read', () => {
+    render(React.createElement(Wrapper, null, React.createElement(TestConsumer, null)));
+
+    act(() => screen.getByText('add success').click());
+    act(() => vi.advanceTimersByTime(5000));
+
+    act(() => (screen.getByText('Mark all read') as HTMLButtonElement).click());
+
+    expect(document.querySelector('.toast-history-unread-badge')).toBeNull();
+  });
+});

--- a/src/components/toast/ToastHistory.tsx
+++ b/src/components/toast/ToastHistory.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import React from 'react';
+import { useToast } from './ToastProvider';
+import { ToastHistoryEntry, ToastSeverity } from './types';
+
+/** Severity label used in the accessible list item description. */
+const severityLabel: Record<ToastSeverity, string> = {
+  success: 'Success',
+  error: 'Error',
+  info: 'Info',
+  warning: 'Warning',
+};
+
+interface ToastHistoryItemProps {
+  entry: ToastHistoryEntry;
+  onMarkRead: (id: string) => void;
+}
+
+function ToastHistoryItem({ entry, onMarkRead }: ToastHistoryItemProps) {
+  const date = new Date(entry.dismissedAt);
+  const timeString = date.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return (
+    <li
+      data-toast-history-item
+      data-severity={entry.severity}
+      data-read={entry.read}
+      aria-label={`${severityLabel[entry.severity]}: ${entry.title}${entry.description ? ` — ${entry.description}` : ''}, dismissed at ${timeString}`}
+    >
+      <span className={`toast-history-badge toast-history-badge--${entry.severity}`} aria-hidden="true" />
+      <div className="toast-history-content">
+        <p className="toast-history-title">{entry.title}</p>
+        {entry.description && (
+          <p className="toast-history-description">{entry.description}</p>
+        )}
+        <time
+          className="toast-history-time"
+          dateTime={new Date(entry.dismissedAt).toISOString()}
+        >
+          {timeString}
+        </time>
+      </div>
+      {!entry.read && (
+        <button
+          type="button"
+          className="toast-history-mark-read"
+          aria-label={`Mark "${entry.title}" as read`}
+          onClick={() => onMarkRead(entry.id)}
+        >
+          Mark read
+        </button>
+      )}
+    </li>
+  );
+}
+
+export interface ToastHistoryProps {
+  /** Maximum number of entries rendered. Defaults to all entries. */
+  maxEntries?: number;
+}
+
+/**
+ * ToastHistory renders the bounded history of dismissed client toasts.
+ *
+ * Place this anywhere inside `ToastProvider`. It integrates with the
+ * notifications center by exposing unread counts through the shared context;
+ * server-derived notifications are kept separate (source === "toast" filter).
+ *
+ * Accessibility: the list is wrapped in an `aria-label`ed region so keyboard
+ * and assistive-technology users can navigate to it independently.
+ */
+export function ToastHistory({ maxEntries }: ToastHistoryProps) {
+  const { history, clearHistory, markHistoryRead, markAllHistoryRead } = useToast();
+
+  // Filter to client-toast entries only — never mix with server notifications.
+  const entries = history
+    .filter((e) => e.source === 'toast')
+    .slice(0, maxEntries);
+
+  const unreadCount = entries.filter((e) => !e.read).length;
+
+  return (
+    <section
+      aria-label="Notification history"
+      data-toast-history
+    >
+      <div className="toast-history-header">
+        <h2 className="toast-history-heading">
+          Notifications
+          {unreadCount > 0 && (
+            <span
+              className="toast-history-unread-badge"
+              aria-label={`${unreadCount} unread`}
+            >
+              {unreadCount}
+            </span>
+          )}
+        </h2>
+        <div className="toast-history-actions">
+          {unreadCount > 0 && (
+            <button
+              type="button"
+              className="toast-history-action-btn"
+              onClick={markAllHistoryRead}
+            >
+              Mark all read
+            </button>
+          )}
+          {entries.length > 0 && (
+            <button
+              type="button"
+              className="toast-history-action-btn"
+              onClick={clearHistory}
+            >
+              Clear all
+            </button>
+          )}
+        </div>
+      </div>
+
+      {entries.length === 0 ? (
+        <p className="toast-history-empty" data-toast-history-empty>
+          No notifications yet.
+        </p>
+      ) : (
+        <ul
+          className="toast-history-list"
+          role="list"
+          aria-label="Dismissed notifications"
+        >
+          {entries.map((entry) => (
+            <ToastHistoryItem
+              key={entry.id}
+              entry={entry}
+              onMarkRead={markHistoryRead}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+/** Returns the count of unread toast-history entries from context. */
+export function useToastHistoryUnreadCount(): number {
+  const { history } = useToast();
+  return history.filter((e) => e.source === 'toast' && !e.read).length;
+}

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -9,12 +9,20 @@ import React, {
   useEffect,
   ReactNode,
 } from 'react';
-import { Toast, ToastOptions, ToastContextValue, ToastSeverity } from './types';
+import {
+  Toast,
+  ToastOptions,
+  ToastContextValue,
+  ToastSeverity,
+  ToastHistoryEntry,
+} from './types';
 import ToastItem from './ToastItem';
 import './toast.css';
 
 const MAX_VISIBLE_TOASTS = 5;
 const DEFAULT_DURATION = 5000;
+/** Maximum number of dismissed toasts retained in the history store. */
+const MAX_HISTORY_ENTRIES = 50;
 
 const ToastContext = createContext<ToastContextValue | undefined>(undefined);
 
@@ -32,10 +40,18 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [visibleIds, setVisibleIds] = useState<Set<string>>(new Set());
   const [announcer, setAnnouncer] = useState<AnnouncerState>({ polite: '', assertive: '' });
+  const [history, setHistory] = useState<ToastHistoryEntry[]>([]);
   const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   const timerStartedAtRef = useRef<Map<string, number>>(new Map());
   const timerRemainingRef = useRef<Map<string, number>>(new Map());
   const reducedMotion = useRef<boolean>(false);
+  /** Keep a ref copy of toasts so dismiss callbacks can read it without
+   *  needing toasts in their dependency arrays (avoids stale-closure issues). */
+  const toastsRef = useRef<Toast[]>([]);
+
+  useEffect(() => {
+    toastsRef.current = toasts;
+  }, [toasts]);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
@@ -47,30 +63,64 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     return () => mediaQuery.removeEventListener('change', handler);
   }, []);
 
-  const dismiss = useCallback((id: string) => {
-    setToasts((prev) => prev.filter((t) => t.id !== id));
-    setVisibleIds((prev) => {
-      const next = new Set(prev);
-      next.delete(id);
-      return next;
+  /** Record a dismissed toast into the bounded history store. */
+  const recordHistory = useCallback((toast: Toast) => {
+    const entry: ToastHistoryEntry = {
+      id: toast.id,
+      severity: toast.severity,
+      title: toast.title,
+      description: toast.description,
+      createdAt: toast.createdAt,
+      dismissedAt: Date.now(),
+      read: false,
+      source: 'toast',
+    };
+    setHistory((prev) => {
+      // Guard against duplicate entries (e.g. double-dismiss).
+      if (prev.some((e) => e.id === entry.id)) return prev;
+      const next = [entry, ...prev];
+      return next.length > MAX_HISTORY_ENTRIES ? next.slice(0, MAX_HISTORY_ENTRIES) : next;
     });
-    const timer = timersRef.current.get(id);
-    if (timer) {
-      clearTimeout(timer);
-      timersRef.current.delete(id);
-    }
-    timerStartedAtRef.current.delete(id);
-    timerRemainingRef.current.delete(id);
   }, []);
 
+  const dismiss = useCallback(
+    (id: string) => {
+      // Capture the toast before removing it so we can archive it.
+      const toast = toastsRef.current.find((t) => t.id === id);
+
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+      setVisibleIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      const timer = timersRef.current.get(id);
+      if (timer) {
+        clearTimeout(timer);
+        timersRef.current.delete(id);
+      }
+      timerStartedAtRef.current.delete(id);
+      timerRemainingRef.current.delete(id);
+
+      if (toast) {
+        recordHistory(toast);
+      }
+    },
+    [recordHistory]
+  );
+
   const dismissAll = useCallback(() => {
+    // Archive all currently visible toasts before clearing.
+    const current = toastsRef.current;
     timersRef.current.forEach((timer) => clearTimeout(timer));
     timersRef.current.clear();
     timerStartedAtRef.current.clear();
     timerRemainingRef.current.clear();
     setToasts([]);
     setVisibleIds(new Set());
-  }, []);
+
+    current.forEach((toast) => recordHistory(toast));
+  }, [recordHistory]);
 
   const startTimer = useCallback(
     (id: string, duration: number) => {
@@ -163,6 +213,18 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     [toasts, startTimer]
   );
 
+  const clearHistory = useCallback(() => setHistory([]), []);
+
+  const markHistoryRead = useCallback((id: string) => {
+    setHistory((prev) =>
+      prev.map((entry) => (entry.id === id ? { ...entry, read: true } : entry))
+    );
+  }, []);
+
+  const markAllHistoryRead = useCallback(() => {
+    setHistory((prev) => prev.map((entry) => ({ ...entry, read: true })));
+  }, []);
+
   const success = useCallback(
     (options: ToastOptions) => showToast('success', options),
     [showToast]
@@ -187,6 +249,10 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     warning,
     dismiss,
     dismissAll,
+    history,
+    clearHistory,
+    markHistoryRead,
+    markAllHistoryRead,
   };
 
   return (

--- a/src/components/toast/types.ts
+++ b/src/components/toast/types.ts
@@ -30,4 +30,25 @@ export interface ToastContextValue {
   warning: (options: ToastOptions) => void;
   dismiss: (id: string) => void;
   dismissAll: () => void;
+  history: ToastHistoryEntry[];
+  clearHistory: () => void;
+  markHistoryRead: (id: string) => void;
+  markAllHistoryRead: () => void;
+}
+
+/** A record of a dismissed/expired toast kept in the bounded history store. */
+export interface ToastHistoryEntry {
+  id: string;
+  severity: ToastSeverity;
+  title: string;
+  description?: string;
+  /** Unix-ms timestamp when the toast was first created. */
+  createdAt: number;
+  /** Unix-ms timestamp when the toast was dismissed/expired. */
+  dismissedAt: number;
+  /** Whether the user has acknowledged this entry in the history panel. */
+  read: boolean;
+  /** Source tag so history viewers can distinguish ephemeral client toasts
+   *  from server-derived notifications.  Always "toast" for this store. */
+  source: 'toast';
 }


### PR DESCRIPTION
Fixes #958

## Summary
- Records every dismissed/auto-expired client toast into a bounded (max 50) in-memory history store inside `ToastProvider`
- Adds `ToastHistory` component that renders the history list with unread parity, mark-read, and clear-all controls; integrates with the notifications center via `source: 'toast'` tag to keep client toasts separate from server-derived notifications
- Adds `useToastHistoryUnreadCount` hook for nav-badge / notification-center icon integration

## Changes
- `src/components/toast/types.ts` — new `ToastHistoryEntry` type and history context methods (`history`, `clearHistory`, `markHistoryRead`, `markAllHistoryRead`)
- `src/components/toast/ToastProvider.tsx` — records dismissed toasts into bounded store; exposes history API through context
- `src/components/toast/ToastHistory.tsx` — new history panel component and `useToastHistoryUnreadCount` hook
- `src/components/toast/ToastHistory.test.tsx` — 14 focused tests covering empty state, auto-expire recording, manual dismiss, deduplication, dismissAll archiving, history bound, maxEntries prop, read/unread parity, accessibility attributes
- `docs/TOAST_HISTORY.md` — feature documentation with API reference, usage examples, and accessibility notes