### PR TITLE
Add customizable reorderable widgets to the commitments overview page

### DIFF
--- a/docs/OVERVIEW_WIDGETS.md
+++ b/docs/OVERVIEW_WIDGETS.md
@@ -1,0 +1,97 @@
+# Overview Widgets — Customizable, Reorderable Layout
+
+This document describes the customizable widget system for the commitments overview page (`src/app/commitments/overview/page.tsx`).
+
+## Feature Overview
+
+Users can show/hide and reorder the widgets on the overview page. The layout is persisted in `localStorage` so preferences survive page refreshes.
+
+## Components
+
+### `OverviewWidgetGrid` (`src/components/dashboard/OverviewWidgetGrid.tsx`)
+
+Renders a list of widgets with show/hide toggles, drag-and-drop reordering, and keyboard-accessible reordering controls.
+
+#### Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `widgets` | `WidgetConfig[]` | Ordered list of widget configurations |
+| `onReorder` | `(fromIndex: number, toIndex: number) => void` | Called when widget order changes |
+| `onToggleVisibility` | `(id: string) => void` | Called to show or hide a widget by id |
+| `onReset` | `() => void` | Called to reset layout to defaults |
+| `children` | `(id: string) => React.ReactNode` | Render function per widget id |
+
+#### `WidgetConfig`
+
+```ts
+interface WidgetConfig {
+  id: string;       // Unique identifier
+  label: string;    // Human-readable name shown in the control bar
+  visible: boolean; // Whether the widget content is rendered
+  order: number;    // Ascending sort order
+}
+```
+
+### `useWidgetLayout` (`src/hooks/useWidgetLayout.ts`)
+
+Custom hook that manages widget state and persists it to `localStorage`.
+
+```ts
+const { widgets, reorder, toggleVisibility, reset } = useWidgetLayout();
+```
+
+| Return | Type | Description |
+|--------|------|-------------|
+| `widgets` | `WidgetConfig[]` | Current sorted widget configs |
+| `reorder` | `(from: number, to: number) => void` | Move widget at `from` to `to` |
+| `toggleVisibility` | `(id: string) => void` | Toggle a widget's `visible` flag |
+| `reset` | `() => void` | Restore `DEFAULT_WIDGET_LAYOUT` |
+
+## Usage Example
+
+```tsx
+import { OverviewWidgetGrid } from "@/components/dashboard/OverviewWidgetGrid";
+import { useWidgetLayout } from "@/hooks/useWidgetLayout";
+
+export default function MyPage() {
+  const { widgets, reorder, toggleVisibility, reset } = useWidgetLayout();
+
+  return (
+    <OverviewWidgetGrid
+      widgets={widgets}
+      onReorder={reorder}
+      onToggleVisibility={toggleVisibility}
+      onReset={reset}
+    >
+      {(id) => {
+        if (id === "my-widget") return <MyWidget />;
+        return null;
+      }}
+    </OverviewWidgetGrid>
+  );
+}
+```
+
+## Accessibility
+
+- **Keyboard reordering**: Focus a widget's grip handle, then press `ArrowUp`/`ArrowDown` to move it.
+- **Screen reader announcements**: The widget list container uses `aria-live="polite"` to announce reorder changes.
+- **Show/hide buttons**: Each toggle button has a descriptive `aria-label` and `aria-pressed` state.
+- **`prefers-reduced-motion`**: Drag-and-drop uses no CSS transitions; the layout snaps without animation.
+- **Focus management**: Keyboard focus remains on the reorder handle after a move, allowing repeated presses.
+
+## Persistence
+
+Layout is stored in `localStorage` under the key `overview-widget-layout`. The server-side preferences API (`/api/user/preferences`) also accepts an `overviewWidgetLayout` field for future cross-device sync.
+
+## Reset to Default
+
+Clicking **Reset to default** restores the two built-in widgets in their original order, both visible:
+
+1. At-Risk Commitments
+2. Commitment Detail
+
+## Hidden Widgets and Data Fetching
+
+When a widget is hidden (`visible: false`), its content is not rendered and any associated data fetches are skipped. For example, the at-risk commitments API call only runs when that widget is visible, avoiding unnecessary network requests.

--- a/src/app/commitments/overview/page.tsx
+++ b/src/app/commitments/overview/page.tsx
@@ -4,53 +4,74 @@ import React, { useEffect, useState } from "react";
 import { apiGet } from '@/lib/apiClient';
 import { CommitmentDetailOverview } from "@/components/CommitmentDetailOverview";
 import { AtRiskCommitments } from "@/components/dashboard/AtRiskCommitments";
+import { OverviewWidgetGrid } from "@/components/dashboard/OverviewWidgetGrid";
+import { useWidgetLayout } from "@/hooks/useWidgetLayout";
 import { Commitment } from "@/lib/types/domain";
 
 export default function CommitmentOverviewPage() {
   const [commitments, setCommitments] = useState<Commitment[]>([]);
+  const { widgets, reorder, toggleVisibility, reset } = useWidgetLayout();
+
+  const atRiskVisible = widgets.find((w) => w.id === "at-risk")?.visible ?? true;
 
   useEffect(() => {
+    if (!atRiskVisible) return;
     async function loadCommitments() {
       try {
         const data = await apiGet<{ data: Commitment[] }>('/api/commitments');
-        setCommitments(data.data);
-          if (data && Array.isArray(data.data)) {
-            setCommitments(data.data);
-          } else if (Array.isArray(data)) {
-            setCommitments(data);
-          }
+        if (data && Array.isArray(data.data)) {
+          setCommitments(data.data);
+        } else if (Array.isArray(data)) {
+          setCommitments(data as unknown as Commitment[]);
         }
       } catch (err) {
         console.error("Failed to load commitments", err);
       }
     }
     loadCommitments();
-  }, []);
+  }, [atRiskVisible]);
+
+  const renderWidget = (id: string) => {
+    switch (id) {
+      case "at-risk":
+        return <AtRiskCommitments commitments={commitments} />;
+      case "commitment-detail":
+        return (
+          <CommitmentDetailOverview
+            commitmentTypeLabel="Safe Commitment"
+            currentValue="52,600"
+            currentValueAsset="XLM"
+            gainLossLabel="+5.20% (+2,600 XLM)"
+            gainLossVariant="positive"
+            initialAmount="50,000"
+            initialAmountAsset="XLM"
+            createdDate="Jan 10, 2026"
+            expiresDate="Feb 9, 2026"
+            daysRemaining={12}
+            durationPercentComplete={87}
+            complianceScore={95}
+            complianceScoreLabel="Excellent compliance with commitment rules"
+            maxLossThreshold="2%"
+            currentDrawdown="0.8%"
+            feesGenerated="$126"
+          />
+        );
+      default:
+        return null;
+    }
+  };
 
   return (
     <main className="min-h-screen w-full bg-[#0a0a0a] px-6 py-10 text-white">
-      <div className="mx-auto w-full max-w-[1200px] flex flex-col gap-6">
-        <div className="w-full">
-          <AtRiskCommitments commitments={commitments} />
-        </div>
-        <CommitmentDetailOverview
-          commitmentTypeLabel="Safe Commitment"
-          currentValue="52,600"
-          currentValueAsset="XLM"
-          gainLossLabel="+5.20% (+2,600 XLM)"
-          gainLossVariant="positive"
-          initialAmount="50,000"
-          initialAmountAsset="XLM"
-          createdDate="Jan 10, 2026"
-          expiresDate="Feb 9, 2026"
-          daysRemaining={12}
-          durationPercentComplete={87}
-          complianceScore={95}
-          complianceScoreLabel="Excellent compliance with commitment rules"
-          maxLossThreshold="2%"
-          currentDrawdown="0.8%"
-          feesGenerated="$126"
-        />
+      <div className="mx-auto w-full max-w-[1200px]">
+        <OverviewWidgetGrid
+          widgets={widgets}
+          onReorder={reorder}
+          onToggleVisibility={toggleVisibility}
+          onReset={reset}
+        >
+          {renderWidget}
+        </OverviewWidgetGrid>
       </div>
     </main>
   );

--- a/src/components/dashboard/OverviewWidgetGrid.tsx
+++ b/src/components/dashboard/OverviewWidgetGrid.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import React, { useCallback, useRef } from "react";
+import { GripVertical, Eye, EyeOff } from "lucide-react";
+
+export interface WidgetConfig {
+  id: string;
+  label: string;
+  visible: boolean;
+  order: number;
+}
+
+interface OverviewWidgetGridProps {
+  widgets: WidgetConfig[];
+  onReorder: (fromIndex: number, toIndex: number) => void;
+  onToggleVisibility: (id: string) => void;
+  onReset: () => void;
+  children: (id: string) => React.ReactNode;
+}
+
+export function OverviewWidgetGrid({
+  widgets,
+  onReorder,
+  onToggleVisibility,
+  onReset,
+  children,
+}: OverviewWidgetGridProps) {
+  const dragIndex = useRef<number | null>(null);
+  const sorted = [...widgets].sort((a, b) => a.order - b.order);
+
+  const handleDragStart = useCallback((index: number) => {
+    dragIndex.current = index;
+  }, []);
+
+  const handleDrop = useCallback(
+    (index: number) => {
+      if (dragIndex.current !== null && dragIndex.current !== index) {
+        onReorder(dragIndex.current, index);
+      }
+      dragIndex.current = null;
+    },
+    [onReorder]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, index: number) => {
+      if (e.key === "ArrowUp" && index > 0) {
+        e.preventDefault();
+        onReorder(index, index - 1);
+      } else if (e.key === "ArrowDown" && index < sorted.length - 1) {
+        e.preventDefault();
+        onReorder(index, index + 1);
+      }
+    },
+    [onReorder, sorted.length]
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-wider">
+          Overview Widgets
+        </h2>
+        <div className="flex gap-2">
+          <button
+            onClick={onReset}
+            className="text-xs text-zinc-400 hover:text-white bg-zinc-800 hover:bg-zinc-700 px-3 py-1.5 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-500"
+            aria-label="Reset widget layout to default"
+          >
+            Reset to default
+          </button>
+        </div>
+      </div>
+
+      <div
+        role="list"
+        aria-label="Overview widgets, use arrow keys to reorder"
+        aria-live="polite"
+        className="flex flex-col gap-3"
+      >
+        {sorted.map((widget, index) => (
+          <div
+            key={widget.id}
+            role="listitem"
+            draggable
+            onDragStart={() => handleDragStart(index)}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={() => handleDrop(index)}
+            className="group relative"
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <button
+                tabIndex={0}
+                onKeyDown={(e) => handleKeyDown(e, index)}
+                aria-label={`Reorder ${widget.label} widget, use arrow keys to move`}
+                className="cursor-grab text-zinc-600 hover:text-zinc-300 focus:outline-none focus:text-zinc-300 focus:ring-2 focus:ring-zinc-500 rounded p-1 transition-colors"
+                aria-grabbed={false}
+              >
+                <GripVertical size={16} />
+              </button>
+              <span className="text-xs font-medium text-zinc-500 flex-1">
+                {widget.label}
+              </span>
+              <button
+                onClick={() => onToggleVisibility(widget.id)}
+                aria-label={widget.visible ? `Hide ${widget.label} widget` : `Show ${widget.label} widget`}
+                aria-pressed={widget.visible}
+                className="text-zinc-600 hover:text-zinc-300 focus:outline-none focus:ring-2 focus:ring-zinc-500 rounded p-1 transition-colors"
+              >
+                {widget.visible ? <Eye size={16} /> : <EyeOff size={16} />}
+              </button>
+            </div>
+            {widget.visible && (
+              <div className="w-full">{children(widget.id)}</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/OverviewWidgets.test.tsx
+++ b/src/components/dashboard/OverviewWidgets.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { OverviewWidgetGrid, type WidgetConfig } from './OverviewWidgetGrid';
+
+const defaultWidgets: WidgetConfig[] = [
+  { id: 'at-risk', label: 'At-Risk Commitments', visible: true, order: 0 },
+  { id: 'commitment-detail', label: 'Commitment Detail', visible: true, order: 1 },
+];
+
+const renderGrid = (overrides: {
+  widgets?: WidgetConfig[];
+  onReorder?: (from: number, to: number) => void;
+  onToggleVisibility?: (id: string) => void;
+  onReset?: () => void;
+} = {}) => {
+  const onReorder = overrides.onReorder ?? vi.fn();
+  const onToggleVisibility = overrides.onToggleVisibility ?? vi.fn();
+  const onReset = overrides.onReset ?? vi.fn();
+  const widgets = overrides.widgets ?? defaultWidgets;
+
+  const result = render(
+    <OverviewWidgetGrid
+      widgets={widgets}
+      onReorder={onReorder}
+      onToggleVisibility={onToggleVisibility}
+      onReset={onReset}
+    >
+      {(id) => <div data-testid={`widget-${id}`}>{id} content</div>}
+    </OverviewWidgetGrid>
+  );
+
+  return { ...result, onReorder, onToggleVisibility, onReset };
+};
+
+describe('OverviewWidgetGrid', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders all visible widgets', () => {
+    renderGrid();
+    expect(screen.getByTestId('widget-at-risk')).toBeTruthy();
+    expect(screen.getByTestId('widget-commitment-detail')).toBeTruthy();
+  });
+
+  it('renders widget labels in the control bar', () => {
+    renderGrid();
+    expect(screen.getByText('At-Risk Commitments')).toBeTruthy();
+    expect(screen.getByText('Commitment Detail')).toBeTruthy();
+  });
+
+  it('does not render hidden widget content', () => {
+    const widgets: WidgetConfig[] = [
+      { id: 'at-risk', label: 'At-Risk Commitments', visible: false, order: 0 },
+      { id: 'commitment-detail', label: 'Commitment Detail', visible: true, order: 1 },
+    ];
+    renderGrid({ widgets });
+    expect(screen.queryByTestId('widget-at-risk')).toBeNull();
+    expect(screen.getByTestId('widget-commitment-detail')).toBeTruthy();
+  });
+
+  it('calls onToggleVisibility when eye button is clicked', () => {
+    const onToggleVisibility = vi.fn();
+    renderGrid({ onToggleVisibility });
+    const hideButton = screen.getByLabelText('Hide At-Risk Commitments widget');
+    fireEvent.click(hideButton);
+    expect(onToggleVisibility).toHaveBeenCalledWith('at-risk');
+  });
+
+  it('calls onToggleVisibility to show a hidden widget', () => {
+    const onToggleVisibility = vi.fn();
+    const widgets: WidgetConfig[] = [
+      { id: 'at-risk', label: 'At-Risk Commitments', visible: false, order: 0 },
+      { id: 'commitment-detail', label: 'Commitment Detail', visible: true, order: 1 },
+    ];
+    renderGrid({ widgets, onToggleVisibility });
+    const showButton = screen.getByLabelText('Show At-Risk Commitments widget');
+    fireEvent.click(showButton);
+    expect(onToggleVisibility).toHaveBeenCalledWith('at-risk');
+  });
+
+  it('calls onReset when reset button is clicked', () => {
+    const onReset = vi.fn();
+    renderGrid({ onReset });
+    const resetButton = screen.getByRole('button', { name: /reset to default/i });
+    fireEvent.click(resetButton);
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onReorder on ArrowUp key press', () => {
+    const onReorder = vi.fn();
+    renderGrid({ onReorder });
+    const reorderButtons = screen.getAllByLabelText(/reorder/i);
+    // Second widget (index 1), press ArrowUp
+    fireEvent.keyDown(reorderButtons[1]!, { key: 'ArrowUp' });
+    expect(onReorder).toHaveBeenCalledWith(1, 0);
+  });
+
+  it('calls onReorder on ArrowDown key press', () => {
+    const onReorder = vi.fn();
+    renderGrid({ onReorder });
+    const reorderButtons = screen.getAllByLabelText(/reorder/i);
+    // First widget (index 0), press ArrowDown
+    fireEvent.keyDown(reorderButtons[0]!, { key: 'ArrowDown' });
+    expect(onReorder).toHaveBeenCalledWith(0, 1);
+  });
+
+  it('does not call onReorder on ArrowUp at first position', () => {
+    const onReorder = vi.fn();
+    renderGrid({ onReorder });
+    const reorderButtons = screen.getAllByLabelText(/reorder/i);
+    fireEvent.keyDown(reorderButtons[0]!, { key: 'ArrowUp' });
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it('does not call onReorder on ArrowDown at last position', () => {
+    const onReorder = vi.fn();
+    renderGrid({ onReorder });
+    const reorderButtons = screen.getAllByLabelText(/reorder/i);
+    fireEvent.keyDown(reorderButtons[1]!, { key: 'ArrowDown' });
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it('has aria-live region for announcements', () => {
+    renderGrid();
+    const liveRegion = screen.getByRole('list', { name: /overview widgets/i });
+    expect(liveRegion.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('renders widget list with accessible role', () => {
+    renderGrid();
+    expect(screen.getByRole('list', { name: /overview widgets/i })).toBeTruthy();
+  });
+});
+
+describe('OverviewWidgetGrid — hide/show persistence edge cases', () => {
+  afterEach(() => cleanup());
+
+  it('shows EyeOff icon label for hidden widget', () => {
+    const widgets: WidgetConfig[] = [
+      { id: 'at-risk', label: 'At-Risk Commitments', visible: false, order: 0 },
+    ];
+    renderGrid({ widgets });
+    expect(screen.getByLabelText('Show At-Risk Commitments widget')).toBeTruthy();
+  });
+
+  it('shows Eye icon label for visible widget', () => {
+    renderGrid();
+    expect(screen.getByLabelText('Hide At-Risk Commitments widget')).toBeTruthy();
+  });
+
+  it('renders widgets in order defined by order field', () => {
+    const widgets: WidgetConfig[] = [
+      { id: 'commitment-detail', label: 'Commitment Detail', visible: true, order: 0 },
+      { id: 'at-risk', label: 'At-Risk Commitments', visible: true, order: 1 },
+    ];
+    renderGrid({ widgets });
+    const labels = screen.getAllByText(/At-Risk Commitments|Commitment Detail/);
+    expect(labels[0]?.textContent).toBe('Commitment Detail');
+    expect(labels[1]?.textContent).toBe('At-Risk Commitments');
+  });
+});

--- a/src/hooks/useWidgetLayout.ts
+++ b/src/hooks/useWidgetLayout.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export interface WidgetConfig {
+  id: string;
+  label: string;
+  visible: boolean;
+  order: number;
+}
+
+const STORAGE_KEY = "overview-widget-layout";
+
+export const DEFAULT_WIDGET_LAYOUT: WidgetConfig[] = [
+  { id: "at-risk", label: "At-Risk Commitments", visible: true, order: 0 },
+  { id: "commitment-detail", label: "Commitment Detail", visible: true, order: 1 },
+];
+
+function loadFromStorage(): WidgetConfig[] | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      return parsed as WidgetConfig[];
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function saveToStorage(layout: WidgetConfig[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(layout));
+  } catch {
+    // Storage not available; ignore
+  }
+}
+
+export function useWidgetLayout() {
+  const [widgets, setWidgets] = useState<WidgetConfig[]>(() => {
+    const stored = loadFromStorage();
+    return stored ?? DEFAULT_WIDGET_LAYOUT;
+  });
+
+  useEffect(() => {
+    const stored = loadFromStorage();
+    if (stored) {
+      setWidgets(stored);
+    }
+  }, []);
+
+  const reorder = useCallback((fromIndex: number, toIndex: number) => {
+    setWidgets((prev) => {
+      const sorted = [...prev].sort((a, b) => a.order - b.order);
+      const moved = sorted.splice(fromIndex, 1)[0];
+      if (!moved) return prev;
+      sorted.splice(toIndex, 0, moved);
+      const updated = sorted.map((w, i) => ({ ...w, order: i }));
+      saveToStorage(updated);
+      return updated;
+    });
+  }, []);
+
+  const toggleVisibility = useCallback((id: string) => {
+    setWidgets((prev) => {
+      const updated = prev.map((w) =>
+        w.id === id ? { ...w, visible: !w.visible } : w
+      );
+      saveToStorage(updated);
+      return updated;
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    saveToStorage(DEFAULT_WIDGET_LAYOUT);
+    setWidgets(DEFAULT_WIDGET_LAYOUT);
+  }, []);
+
+  return { widgets, reorder, toggleVisibility, reset };
+}

--- a/src/lib/backend/preferences.ts
+++ b/src/lib/backend/preferences.ts
@@ -64,10 +64,26 @@ export const userPreferencesSchema = z.object({
         .regex(/^[a-z]{2,3}(-[A-Z]{2,3})?$/, 'language must be a valid BCP-47 tag (e.g. "en", "en-US")')
         .optional(),
     seenWizardTour: z.boolean().optional(),
+    overviewWidgetLayout: z
+        .array(
+            z.object({
+                id: z.string(),
+                label: z.string(),
+                visible: z.boolean(),
+                order: z.number().int().nonnegative(),
+            })
+        )
+        .optional(),
 });
 
 /** Shape returned/stored for a single wallet. */
 export type UserPreferences = z.infer<typeof userPreferencesSchema>;
+
+/** Default ordered widget layout for the overview page. */
+export const DEFAULT_OVERVIEW_WIDGET_LAYOUT: NonNullable<UserPreferences['overviewWidgetLayout']> = [
+    { id: 'at-risk', label: 'At-Risk Commitments', visible: true, order: 0 },
+    { id: 'commitment-detail', label: 'Commitment Detail', visible: true, order: 1 },
+];
 
 /** The defaults applied when no preferences exist yet. */
 export const DEFAULT_PREFERENCES: Required<UserPreferences> = {
@@ -77,6 +93,7 @@ export const DEFAULT_PREFERENCES: Required<UserPreferences> = {
     theme: 'system',
     language: 'en',
     seenWizardTour: false,
+    overviewWidgetLayout: DEFAULT_OVERVIEW_WIDGET_LAYOUT,
 };
 
 // ─── Storage Adapter Interface ───────────────────────────────────────────────


### PR DESCRIPTION
Fixes #956

## Summary
Basic implementation of: Add customizable reorderable widgets to the commitments overview page

## Changes
Implements the feature/fix as described in the issue, following existing code patterns.