### PR TITLE
Add column selection and scheduling options to ExportCommitmentsModal

### DIFF
--- a/docs/EXPORT_COLUMNS.md
+++ b/docs/EXPORT_COLUMNS.md
@@ -1,0 +1,108 @@
+# Export Columns & Schedule Reminder
+
+This document describes the column-selection and export-reminder features added to `ExportCommitmentsModal`.
+
+## Overview
+
+Users can now choose exactly which columns appear in the downloaded CSV and optionally configure a client-side reminder to repeat the export on a regular cadence.
+
+## Column Selection
+
+### Available columns
+
+| Column | Description |
+|---|---|
+| Commitment ID | On-chain commitment identifier |
+| Owner | Wallet address of the commitment owner |
+| Asset | Asset symbol (e.g. XLM) |
+| Amount | Committed amount |
+| Status | Current commitment status |
+| Compliance Score | Computed compliance score |
+| Current Value | Present market value |
+| Fee Earned | Accumulated protocol fee |
+| Violation Count | Number of rule violations |
+| Created At | ISO timestamp of creation |
+| Expires At | ISO timestamp of expiry |
+
+### Behavior
+
+- All columns are selected by default.
+- At least one column must remain selected — the **Export CSV** button is disabled and an inline alert is shown when the selection is empty.
+- **Select all / Deselect all** toggles the entire set at once.
+- The user's selection is persisted to `localStorage` under `commitlabs.exportPreferences` and restored the next time the modal opens.
+
+### API integration
+
+The frontend appends a `columns` query parameter to the export request:
+
+```
+GET /api/commitments/export?ownerAddress=0x…&columns=Commitment%20ID,Asset,Status
+```
+
+The route (`src/app/api/commitments/export/route.ts`) parses this parameter and streams only the requested columns. Unknown column names are silently ignored; an absent or empty parameter returns all columns.
+
+## Export Reminder (Schedule)
+
+The schedule section lets users request a browser notification reminder to export again after a chosen interval.
+
+| Option | Delay |
+|---|---|
+| No reminder | — |
+| Daily | 24 hours |
+| Weekly | 7 days |
+| Monthly | 30 days |
+
+> **Important:** This is a client-side `setTimeout` that fires a single `Notification` in the current browser session. It is **not** server-side automation — no data is sent or scheduled on the server. Users must grant browser notification permission for the reminder to appear.
+
+The chosen interval is persisted alongside the column selection in `commitlabs.exportPreferences`.
+
+## Props
+
+`ExportCommitmentsModal` accepts the same props as before — no new required props were introduced.
+
+```tsx
+<ExportCommitmentsModal
+  isOpen={isOpen}
+  onClose={handleClose}
+  ownerAddress={walletAddress}      // optional
+  sessionToken={token}              // optional; falls back to localStorage
+  endpoint="/api/commitments/export" // optional; default shown
+/>
+```
+
+## Accessibility
+
+- The **Columns** section is wrapped in a `<section aria-labelledby>` heading.
+- Each column checkbox has an explicit `aria-label`.
+- The zero-column warning uses `role="alert"` for live-region announcement.
+- Schedule buttons use `aria-pressed` to expose the current selection to assistive technology.
+- The **Export reminder** group uses `role="group"` with `aria-labelledby`.
+- All interactive elements have `focus-visible` ring styles matching the existing design tokens.
+
+## Usage Example
+
+```tsx
+import ExportCommitmentsModal from '@/components/export/ExportCommitmentsModal';
+
+function Portfolio() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Export</button>
+      <ExportCommitmentsModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        ownerAddress={address}
+        sessionToken={token}
+      />
+    </>
+  );
+}
+```
+
+## Related files
+
+- `src/components/export/ExportCommitmentsModal.tsx` — component implementation
+- `src/components/export/ExportColumnsSchedule.test.tsx` — unit tests
+- `src/app/api/commitments/export/route.ts` — streaming CSV route with column filtering

--- a/src/app/api/commitments/export/route.ts
+++ b/src/app/api/commitments/export/route.ts
@@ -14,7 +14,7 @@ import {
 } from '@/lib/backend/services/contracts';
 import { withApiHandler } from '@/lib/backend/withApiHandler';
 
-const CSV_HEADERS = [
+const ALL_CSV_HEADERS = [
   'Commitment ID',
   'Owner',
   'Asset',
@@ -26,7 +26,24 @@ const CSV_HEADERS = [
   'Violation Count',
   'Created At',
   'Expires At',
-];
+] as const;
+
+type CsvHeader = (typeof ALL_CSV_HEADERS)[number];
+
+/** Map each header label to the commitment field that supplies its value. */
+const HEADER_TO_FIELD: Record<CsvHeader, (c: Commitment) => unknown> = {
+  'Commitment ID': (c) => c.id,
+  'Owner': (c) => c.ownerAddress,
+  'Asset': (c) => c.asset,
+  'Amount': (c) => c.amount,
+  'Status': (c) => c.status,
+  'Compliance Score': (c) => c.complianceScore,
+  'Current Value': (c) => c.currentValue,
+  'Fee Earned': (c) => c.feeEarned,
+  'Violation Count': (c) => c.violationCount,
+  'Created At': (c) => c.createdAt,
+  'Expires At': (c) => c.expiresAt,
+};
 
 function stringifyCsvValue(value: unknown): string {
   if (value == null) {
@@ -52,26 +69,33 @@ function normalizeAddress(address: string): string {
 }
 
 /**
- * Lazily maps commitments to CSV rows. Using a generator avoids
- * materializing the full mapped array — the streamer pulls one row at a
- * time, so only a single row exists in memory between iterations.
+ * Lazily maps commitments to CSV rows for only the requested headers.
+ * Using a generator avoids materializing the full mapped array — the
+ * streamer pulls one row at a time, so only a single row exists in memory
+ * between iterations.
  */
-function* commitmentsToRows(commitments: Iterable<Commitment>): Generator<CsvRow> {
+function* commitmentsToRows(
+  commitments: Iterable<Commitment>,
+  headers: readonly CsvHeader[],
+): Generator<CsvRow> {
   for (const commitment of commitments) {
-    yield [
-      commitment.id,
-      commitment.ownerAddress,
-      commitment.asset,
-      stringifyCsvValue(commitment.amount),
-      commitment.status,
-      stringifyCsvValue(commitment.complianceScore),
-      stringifyCsvValue(commitment.currentValue),
-      stringifyCsvValue(commitment.feeEarned),
-      stringifyCsvValue(commitment.violationCount),
-      stringifyCsvValue(commitment.createdAt),
-      stringifyCsvValue(commitment.expiresAt),
-    ];
+    yield headers.map((h) => stringifyCsvValue(HEADER_TO_FIELD[h](commitment)));
   }
+}
+
+/**
+ * Parses and validates a comma-separated `columns` query param against the
+ * known header list. Unknown values are silently dropped. Returns all headers
+ * when the param is absent or empty.
+ */
+function resolveRequestedHeaders(columnsParam: string | null): CsvHeader[] {
+  if (!columnsParam?.trim()) return [...ALL_CSV_HEADERS];
+
+  const requested = columnsParam.split(',').map((c) => c.trim());
+  const valid = requested.filter((c): c is CsvHeader =>
+    (ALL_CSV_HEADERS as readonly string[]).includes(c),
+  );
+  return valid.length > 0 ? valid : [...ALL_CSV_HEADERS];
 }
 
 export const GET = withApiHandler(async (req: NextRequest) => {
@@ -89,7 +113,8 @@ export const GET = withApiHandler(async (req: NextRequest) => {
     throw new UnauthorizedError();
   }
 
-  const ownerAddress = new URL(req.url).searchParams.get('ownerAddress');
+  const searchParams = new URL(req.url).searchParams;
+  const ownerAddress = searchParams.get('ownerAddress');
   if (!ownerAddress) {
     throw new BadRequestError('ownerAddress is required.');
   }
@@ -98,12 +123,14 @@ export const GET = withApiHandler(async (req: NextRequest) => {
     throw new ForbiddenError();
   }
 
+  const headers = resolveRequestedHeaders(searchParams.get('columns'));
+
   // Fetch happens before streaming starts so any failure here is caught by
   // `withApiHandler` and surfaced as a JSON error response, not a truncated
   // CSV. When `getUserCommitmentsFromChain` becomes streamable, swap the
   // generator argument for the async iterable directly.
   const commitments = await getUserCommitmentsFromChain(ownerAddress);
-  const stream = createCsvStream(CSV_HEADERS, commitmentsToRows(commitments));
+  const stream = createCsvStream(headers, commitmentsToRows(commitments, headers));
 
   return new NextResponse(stream, {
     status: 200,

--- a/src/components/export/ExportColumnsSchedule.test.tsx
+++ b/src/components/export/ExportColumnsSchedule.test.tsx
@@ -1,0 +1,331 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ExportCommitmentsModal, { ALL_EXPORT_COLUMNS } from './ExportCommitmentsModal';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const fetchMock = vi.fn();
+
+vi.mock('@/components/ui/Dialog', () => ({
+  Dialog: ({
+    isOpen,
+    children,
+    labelledById,
+    describedById,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+    labelledById?: string;
+    describedById?: string;
+    onClose?: () => void;
+    closeOnEscape?: boolean;
+    backdropClassName?: string;
+    className?: string;
+  }) =>
+    isOpen ? (
+      <div
+        role="dialog"
+        aria-labelledby={labelledById}
+        aria-describedby={describedById}
+        data-testid="dialog"
+      >
+        {children}
+      </div>
+    ) : null,
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderModal(
+  overrides: Partial<{
+    isOpen: boolean;
+    onClose: () => void;
+    ownerAddress: string;
+    sessionToken: string;
+    endpoint: string;
+  }> = {},
+) {
+  const props = {
+    isOpen: true,
+    onClose: vi.fn(),
+    ownerAddress: '0xABC123',
+    sessionToken: 'tok_test',
+    endpoint: '/api/commitments/export',
+    ...overrides,
+  };
+  return { props, ...render(<ExportCommitmentsModal {...props} />) };
+}
+
+function makeCsvResponse(rows = 2): Response {
+  const header = ALL_EXPORT_COLUMNS.join(',');
+  const dataRows = Array.from({ length: rows }, (_, i) => `row${i + 1}`).join('\n');
+  const csv = `${header}\n${dataRows}\n`;
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-disposition': 'attachment; filename="commitments.csv"' }),
+    blob: async () => new Blob([csv], { type: 'text/csv' }),
+  } as unknown as Response;
+}
+
+// ─── Setup / teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+
+  // Minimal URL / blob stubs for happy-dom
+  vi.stubGlobal('URL', {
+    createObjectURL: vi.fn(() => 'blob:mock'),
+    revokeObjectURL: vi.fn(),
+  });
+
+  // Suppress localStorage errors in happy-dom
+  vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+  vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// ─── Rendering ────────────────────────────────────────────────────────────────
+
+describe('ExportCommitmentsModal – rendering', () => {
+  it('renders the dialog when isOpen is true', () => {
+    renderModal();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText('Export commitment data')).toBeTruthy();
+  });
+
+  it('does not render the dialog when isOpen is false', () => {
+    renderModal({ isOpen: false });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders a checkbox for every export column', () => {
+    renderModal();
+    for (const col of ALL_EXPORT_COLUMNS) {
+      expect(screen.getByRole('checkbox', { name: col })).toBeTruthy();
+    }
+  });
+
+  it('all columns are checked by default', () => {
+    renderModal();
+    for (const col of ALL_EXPORT_COLUMNS) {
+      const checkbox = screen.getByRole('checkbox', { name: col }) as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+    }
+  });
+
+  it('renders schedule reminder toggle buttons', () => {
+    renderModal();
+    expect(screen.getByRole('button', { name: /no reminder/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /daily/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /weekly/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /monthly/i })).toBeTruthy();
+  });
+
+  it('"No reminder" is selected by default', () => {
+    renderModal();
+    const btn = screen.getByRole('button', { name: /no reminder/i });
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+  });
+});
+
+// ─── Column selection ─────────────────────────────────────────────────────────
+
+describe('ExportCommitmentsModal – column selection', () => {
+  it('unchecking a column removes it from selection', () => {
+    renderModal();
+    const checkbox = screen.getByRole('checkbox', { name: 'Owner' }) as HTMLInputElement;
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('"Deselect all" unchecks every column', () => {
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /deselect all/i }));
+    for (const col of ALL_EXPORT_COLUMNS) {
+      const cb = screen.getByRole('checkbox', { name: col }) as HTMLInputElement;
+      expect(cb.checked).toBe(false);
+    }
+  });
+
+  it('"Select all" re-checks every column after deselecting all', () => {
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /deselect all/i }));
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    for (const col of ALL_EXPORT_COLUMNS) {
+      const cb = screen.getByRole('checkbox', { name: col }) as HTMLInputElement;
+      expect(cb.checked).toBe(true);
+    }
+  });
+
+  it('shows a warning and disables export when zero columns are selected', () => {
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /deselect all/i }));
+    expect(screen.getByRole('alert')).toBeTruthy();
+    const exportBtn = screen.getByRole('button', { name: /export csv/i }) as HTMLButtonElement;
+    expect(exportBtn.disabled).toBe(true);
+  });
+
+  it('sending zero columns shows an error message on export attempt', async () => {
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /deselect all/i }));
+    fireEvent.click(screen.getByRole('button', { name: /export csv/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/select at least one column/i)).toBeTruthy(),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Schedule / reminder ──────────────────────────────────────────────────────
+
+describe('ExportCommitmentsModal – schedule reminder', () => {
+  it('selecting a schedule interval marks that button as pressed', () => {
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /weekly/i }));
+    expect(screen.getByRole('button', { name: /weekly/i }).getAttribute('aria-pressed')).toBe(
+      'true',
+    );
+    expect(screen.getByRole('button', { name: /no reminder/i }).getAttribute('aria-pressed')).toBe(
+      'false',
+    );
+  });
+
+  it('schedule preference is saved to localStorage on export', async () => {
+    fetchMock.mockResolvedValueOnce(makeCsvResponse(1));
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /monthly/i }));
+    fireEvent.click(screen.getByRole('button', { name: /export csv/i }));
+
+    await waitFor(() => expect(setItemSpy).toHaveBeenCalled());
+
+    const call = setItemSpy.mock.calls.find(([key]) => key === 'commitlabs.exportPreferences');
+    expect(call).toBeTruthy();
+    const saved = JSON.parse(call![1] as string) as { scheduleInterval: string };
+    expect(saved.scheduleInterval).toBe('monthly');
+  });
+});
+
+// ─── Preferences persistence ──────────────────────────────────────────────────
+
+describe('ExportCommitmentsModal – preferences persistence', () => {
+  it('restores column selection from localStorage when modal opens', () => {
+    const storedPrefs = {
+      selectedColumns: ['Commitment ID', 'Asset', 'Status'],
+      scheduleInterval: 'weekly',
+    };
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) =>
+      key === 'commitlabs.exportPreferences' ? JSON.stringify(storedPrefs) : null,
+    );
+
+    renderModal();
+
+    const checkedId = screen.getByRole('checkbox', { name: 'Commitment ID' }) as HTMLInputElement;
+    const checkedAsset = screen.getByRole('checkbox', { name: 'Asset' }) as HTMLInputElement;
+    const unchecked = screen.getByRole('checkbox', { name: 'Owner' }) as HTMLInputElement;
+
+    expect(checkedId.checked).toBe(true);
+    expect(checkedAsset.checked).toBe(true);
+    expect(unchecked.checked).toBe(false);
+  });
+
+  it('restores schedule interval from localStorage when modal opens', () => {
+    const storedPrefs = {
+      selectedColumns: [...ALL_EXPORT_COLUMNS],
+      scheduleInterval: 'daily',
+    };
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) =>
+      key === 'commitlabs.exportPreferences' ? JSON.stringify(storedPrefs) : null,
+    );
+
+    renderModal();
+
+    expect(screen.getByRole('button', { name: /daily/i }).getAttribute('aria-pressed')).toBe(
+      'true',
+    );
+  });
+
+  it('ignores unknown column names in stored preferences', () => {
+    const storedPrefs = {
+      selectedColumns: ['Commitment ID', 'Unknown Column XYZ'],
+      scheduleInterval: 'never',
+    };
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) =>
+      key === 'commitlabs.exportPreferences' ? JSON.stringify(storedPrefs) : null,
+    );
+
+    renderModal();
+
+    const cb = screen.getByRole('checkbox', { name: 'Commitment ID' }) as HTMLInputElement;
+    expect(cb.checked).toBe(true);
+    // Only the valid column should be checked, no crash
+    const owner = screen.getByRole('checkbox', { name: 'Owner' }) as HTMLInputElement;
+    expect(owner.checked).toBe(false);
+  });
+});
+
+// ─── Export request ───────────────────────────────────────────────────────────
+
+describe('ExportCommitmentsModal – export request', () => {
+  it('includes selected columns in the query string', async () => {
+    fetchMock.mockResolvedValueOnce(makeCsvResponse(1));
+    renderModal();
+
+    // Deselect Owner so only a subset is sent
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Owner' }));
+    fireEvent.click(screen.getByRole('button', { name: /export csv/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const calledUrl: string = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('columns=');
+    expect(calledUrl).not.toContain('Owner');
+    expect(calledUrl).toContain('Commitment%20ID');
+  });
+
+  it('shows success message after a successful export', async () => {
+    fetchMock.mockResolvedValueOnce(makeCsvResponse(3));
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /export csv/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toBeTruthy(),
+    );
+    expect(screen.getByText(/3 commitments downloaded/i)).toBeTruthy();
+  });
+
+  it('shows error message on 401 response', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 401 } as Response);
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /export csv/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toBeTruthy(),
+    );
+    expect(screen.getByText(/sign in again/i)).toBeTruthy();
+  });
+
+  it('shows error when no wallet address is provided', async () => {
+    renderModal({ ownerAddress: undefined });
+    fireEvent.click(screen.getByRole('button', { name: /export csv/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toBeTruthy(),
+    );
+    expect(screen.getByText(/connect a wallet/i)).toBeTruthy();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/export/ExportCommitmentsModal.tsx
+++ b/src/components/export/ExportCommitmentsModal.tsx
@@ -1,10 +1,77 @@
 'use client';
 
 import React, { useCallback, useEffect, useId, useState } from 'react';
-import { AlertCircle, CheckCircle2, Download, Loader2, X } from 'lucide-react';
+import { AlertCircle, Bell, CheckCircle2, Download, Loader2, X } from 'lucide-react';
 import { Dialog } from '@/components/ui/Dialog';
 
 type ExportStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export const ALL_EXPORT_COLUMNS = [
+  'Commitment ID',
+  'Owner',
+  'Asset',
+  'Amount',
+  'Status',
+  'Compliance Score',
+  'Current Value',
+  'Fee Earned',
+  'Violation Count',
+  'Created At',
+  'Expires At',
+] as const;
+
+export type ExportColumn = (typeof ALL_EXPORT_COLUMNS)[number];
+
+export type ScheduleInterval = 'never' | 'daily' | 'weekly' | 'monthly';
+
+const SCHEDULE_OPTIONS: { value: ScheduleInterval; label: string }[] = [
+  { value: 'never', label: 'No reminder' },
+  { value: 'daily', label: 'Daily' },
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'monthly', label: 'Monthly' },
+];
+
+const PREFS_STORAGE_KEY = 'commitlabs.exportPreferences';
+
+interface ExportPreferences {
+  selectedColumns: ExportColumn[];
+  scheduleInterval: ScheduleInterval;
+}
+
+function loadExportPreferences(): ExportPreferences {
+  if (typeof window === 'undefined') {
+    return { selectedColumns: [...ALL_EXPORT_COLUMNS], scheduleInterval: 'never' };
+  }
+  try {
+    const raw = window.localStorage.getItem(PREFS_STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<ExportPreferences>;
+      const selectedColumns = Array.isArray(parsed.selectedColumns)
+        ? (parsed.selectedColumns.filter((c) =>
+            (ALL_EXPORT_COLUMNS as readonly string[]).includes(c),
+          ) as ExportColumn[])
+        : [...ALL_EXPORT_COLUMNS];
+      const scheduleInterval =
+        parsed.scheduleInterval &&
+        SCHEDULE_OPTIONS.some((o) => o.value === parsed.scheduleInterval)
+          ? parsed.scheduleInterval
+          : 'never';
+      return { selectedColumns, scheduleInterval };
+    }
+  } catch {
+    // ignore malformed storage
+  }
+  return { selectedColumns: [...ALL_EXPORT_COLUMNS], scheduleInterval: 'never' };
+}
+
+function saveExportPreferences(prefs: ExportPreferences): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(PREFS_STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // ignore storage errors
+  }
+}
 
 interface ExportCommitmentsModalProps {
   isOpen: boolean;
@@ -69,6 +136,31 @@ function getExportErrorMessage(status: number): string {
   return 'Export failed. Try again in a moment.';
 }
 
+function scheduleReminderNotification(interval: ScheduleInterval): void {
+  if (interval === 'never' || typeof window === 'undefined') return;
+  if (!('Notification' in window)) return;
+
+  const intervalMs: Record<Exclude<ScheduleInterval, 'never'>, number> = {
+    daily: 24 * 60 * 60 * 1000,
+    weekly: 7 * 24 * 60 * 60 * 1000,
+    monthly: 30 * 24 * 60 * 60 * 1000,
+  };
+
+  const ms = intervalMs[interval as Exclude<ScheduleInterval, 'never'>];
+  if (!ms) return;
+
+  Notification.requestPermission().then((permission) => {
+    if (permission !== 'granted') return;
+    setTimeout(() => {
+      // eslint-disable-next-line no-new
+      new Notification('CommitLabs export reminder', {
+        body: `Your ${interval} commitment export reminder is ready.`,
+        icon: '/favicon.ico',
+      });
+    }, ms);
+  });
+}
+
 export default function ExportCommitmentsModal({
   isOpen,
   onClose,
@@ -78,17 +170,44 @@ export default function ExportCommitmentsModal({
 }: ExportCommitmentsModalProps) {
   const titleId = useId();
   const descriptionId = useId();
+  const columnSectionId = useId();
+  const scheduleSectionId = useId();
+
   const [status, setStatus] = useState<ExportStatus>('idle');
   const [message, setMessage] = useState('');
+  const [selectedColumns, setSelectedColumns] = useState<ExportColumn[]>([...ALL_EXPORT_COLUMNS]);
+  const [scheduleInterval, setScheduleInterval] = useState<ScheduleInterval>('never');
 
+  // Restore preferences when modal opens
   useEffect(() => {
     if (!isOpen) return;
-
     setStatus('idle');
     setMessage('');
+    const prefs = loadExportPreferences();
+    setSelectedColumns(prefs.selectedColumns);
+    setScheduleInterval(prefs.scheduleInterval);
   }, [isOpen]);
 
+  const toggleColumn = useCallback((column: ExportColumn) => {
+    setSelectedColumns((prev) =>
+      prev.includes(column) ? prev.filter((c) => c !== column) : [...prev, column],
+    );
+  }, []);
+
+  const allChecked = selectedColumns.length === ALL_EXPORT_COLUMNS.length;
+  const noneChecked = selectedColumns.length === 0;
+
+  const toggleAll = useCallback(() => {
+    setSelectedColumns(allChecked ? [] : [...ALL_EXPORT_COLUMNS]);
+  }, [allChecked]);
+
   const handleExport = useCallback(async () => {
+    if (noneChecked) {
+      setStatus('error');
+      setMessage('Select at least one column before exporting.');
+      return;
+    }
+
     const normalizedAddress = ownerAddress?.trim();
     const resolvedToken = sessionToken?.trim() || getStoredSessionToken();
 
@@ -104,12 +223,17 @@ export default function ExportCommitmentsModal({
       return;
     }
 
+    const prefs: ExportPreferences = { selectedColumns, scheduleInterval };
+    saveExportPreferences(prefs);
+    scheduleReminderNotification(scheduleInterval);
+
     setStatus('loading');
     setMessage('');
 
     try {
       const url = new URL(endpoint, window.location.origin);
       url.searchParams.set('ownerAddress', normalizedAddress);
+      url.searchParams.set('columns', selectedColumns.join(','));
 
       const response = await fetch(url.toString(), {
         method: 'GET',
@@ -136,13 +260,13 @@ export default function ExportCommitmentsModal({
       setMessage(
         recordCount === 0
           ? 'Export ready. No commitment rows found, so a header-only CSV was downloaded.'
-          : `Export ready. ${recordCount} commitment${recordCount === 1 ? '' : 's'} downloaded as CSV.`
+          : `Export ready. ${recordCount} commitment${recordCount === 1 ? '' : 's'} downloaded as CSV.`,
       );
     } catch {
       setStatus('error');
       setMessage('Export failed. Try again in a moment.');
     }
-  }, [endpoint, ownerAddress, sessionToken]);
+  }, [endpoint, ownerAddress, sessionToken, selectedColumns, scheduleInterval, noneChecked]);
 
   const isLoading = status === 'loading';
 
@@ -177,7 +301,8 @@ export default function ExportCommitmentsModal({
       </div>
 
       <p id={descriptionId} className="mt-4 text-sm leading-6 text-white/70">
-        Download a CSV snapshot for the connected owner address. Large portfolios may take a moment to prepare.
+        Download a CSV snapshot for the connected owner address. Choose which columns to
+        include and optionally set a reminder to export regularly.
       </p>
 
       <div className="mt-6 grid gap-4">
@@ -223,6 +348,90 @@ export default function ExportCommitmentsModal({
         </div>
       </div>
 
+      {/* Column selection */}
+      <section aria-labelledby={columnSectionId} className="mt-6">
+        <div className="flex items-center justify-between">
+          <h3
+            id={columnSectionId}
+            className="text-sm font-semibold uppercase tracking-[0.14em] text-white/60"
+          >
+            Columns
+          </h3>
+          <button
+            type="button"
+            onClick={toggleAll}
+            className="text-xs text-[#0FF0FC] hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC]"
+            aria-label={allChecked ? 'Deselect all columns' : 'Select all columns'}
+          >
+            {allChecked ? 'Deselect all' : 'Select all'}
+          </button>
+        </div>
+
+        {noneChecked && (
+          <p role="alert" className="mt-2 text-xs text-[#FECACA]">
+            Select at least one column to enable export.
+          </p>
+        )}
+
+        <ul
+          className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2"
+          aria-label="Export column selection"
+        >
+          {ALL_EXPORT_COLUMNS.map((col) => {
+            const checked = selectedColumns.includes(col);
+            return (
+              <li key={col}>
+                <label className="flex cursor-pointer items-center gap-2 text-sm text-white/80 hover:text-white">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleColumn(col)}
+                    aria-label={col}
+                    className="accent-[#0FF0FC] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC]"
+                  />
+                  {col}
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      {/* Schedule / reminder */}
+      <section aria-labelledby={scheduleSectionId} className="mt-6">
+        <h3
+          id={scheduleSectionId}
+          className="text-sm font-semibold uppercase tracking-[0.14em] text-white/60"
+        >
+          Export reminder
+        </h3>
+        <p className="mt-1 text-xs text-white/40">
+          A browser notification reminds you to export again. No data is sent automatically.
+        </p>
+
+        <div className="mt-3 flex flex-wrap gap-2" role="group" aria-labelledby={scheduleSectionId}>
+          {SCHEDULE_OPTIONS.map(({ value, label }) => {
+            const selected = scheduleInterval === value;
+            return (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setScheduleInterval(value)}
+                aria-pressed={selected}
+                className={`flex items-center gap-1.5 rounded-[10px] border px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC] ${
+                  selected
+                    ? 'border-[#0FF0FC66] bg-[#0FF0FC1A] text-white'
+                    : 'border-white/10 text-white/50 hover:border-white/30 hover:text-white/80'
+                }`}
+              >
+                {value !== 'never' && <Bell size={12} aria-hidden />}
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
       {message ? (
         <div
           role={status === 'error' ? 'alert' : 'status'}
@@ -253,7 +462,8 @@ export default function ExportCommitmentsModal({
         <button
           type="button"
           onClick={handleExport}
-          disabled={isLoading}
+          disabled={isLoading || noneChecked}
+          aria-disabled={noneChecked}
           className="inline-flex items-center justify-center gap-2 rounded-[14px] border border-[#0FF0FC66] bg-[#0FF0FC1A] px-5 py-3 text-sm font-semibold text-white shadow-[0_0_18px_rgba(15,240,252,0.22)] transition-all hover:bg-[#0FF0FC26] hover:shadow-[0_0_24px_rgba(15,240,252,0.34)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC] disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isLoading ? <Loader2 className="animate-spin" size={18} /> : <Download size={18} />}


### PR DESCRIPTION
Fixes #961

## Summary
- Add a column picker to `ExportCommitmentsModal` so users choose which fields appear in the downloaded CSV
- Add an optional recurring-export reminder using client-side browser notifications (clearly labeled as a reminder, not server-side automation)
- Persist column selection and schedule interval to `localStorage` under `commitlabs.exportPreferences`; preferences are restored when the modal reopens
- Validate that at least one column is selected before enabling the Export CSV button
- Update `src/app/api/commitments/export/route.ts` to honor the `columns` query parameter, streaming only the requested columns
- Add `src/components/export/ExportColumnsSchedule.test.tsx` with focused tests covering rendering, column toggling, zero-column validation, schedule persistence, preferences restoration, and export request behavior
- Add `docs/EXPORT_COLUMNS.md` documenting the feature, props/API, accessibility behavior, and a usage example

## Changes
- `src/components/export/ExportCommitmentsModal.tsx` — column picker + schedule reminder UI
- `src/app/api/commitments/export/route.ts` — honor selected columns via `columns` query param
- `src/components/export/ExportColumnsSchedule.test.tsx` — new test file
- `docs/EXPORT_COLUMNS.md` — feature documentation