### PR TITLE
Add configurable at-risk thresholds and alerts to AtRiskCommitments

### DIFF
--- a/docs/AT_RISK_THRESHOLDS.md
+++ b/docs/AT_RISK_THRESHOLDS.md
@@ -1,0 +1,89 @@
+# Configurable At-Risk Thresholds
+
+The `AtRiskCommitments` component supports user-tunable thresholds that control how sensitive the at-risk detection is. Users can adjust these through the **Configure Thresholds** panel in the widget, and developers can pass them as props.
+
+## Feature overview
+
+- Expose two numeric thresholds: `complianceScoreThreshold` and `daysRemainingThreshold`.
+- Default values preserve the original behavior when no override is provided.
+- A warning toast fires once when a commitment newly crosses into at-risk status (deduped — no duplicate alerts for already-known items).
+- All controls are fully accessible: labelled inputs, `aria-expanded`, `role="group"`, and an `aria-live` alert for validation errors.
+
+## Props / API
+
+```tsx
+interface AtRiskThresholds {
+  /** Compliance score below which a commitment is flagged. Default: 70 */
+  complianceScoreThreshold: number;
+  /** Days remaining at or below which a commitment is flagged. Default: 7 */
+  daysRemainingThreshold: number;
+}
+
+interface AtRiskCommitmentsProps {
+  commitments?: Commitment[];
+  /** Partial override of default thresholds. */
+  thresholds?: Partial<AtRiskThresholds>;
+  /** Called with the new thresholds after the user applies changes. */
+  onThresholdsChange?: (thresholds: AtRiskThresholds) => void;
+}
+```
+
+The exported constant `DEFAULT_AT_RISK_THRESHOLDS` reflects the baseline values:
+
+```ts
+export const DEFAULT_AT_RISK_THRESHOLDS: AtRiskThresholds = {
+  complianceScoreThreshold: 70,
+  daysRemainingThreshold: 7,
+};
+```
+
+## Classification utility
+
+`classifyAtRiskCommitments` in `src/utils/classification.ts` now accepts an optional third argument:
+
+```ts
+classifyAtRiskCommitments(commitments, constants, thresholds?)
+```
+
+When `thresholds` is omitted or `undefined`, the function falls back to the original hard-coded defaults, so existing call sites continue to work without changes.
+
+## Usage example
+
+```tsx
+import { AtRiskCommitments } from '@/components/dashboard/AtRiskCommitments';
+
+// Default behavior — unchanged from before this feature:
+<AtRiskCommitments commitments={myCommitments} />
+
+// Custom thresholds — flag when compliance < 85 or <= 14 days remain:
+<AtRiskCommitments
+  commitments={myCommitments}
+  thresholds={{ complianceScoreThreshold: 85, daysRemainingThreshold: 14 }}
+  onThresholdsChange={(t) => savePreferences(t)}
+/>
+```
+
+## Validation rules
+
+| Field | Min | Max | Error message |
+|---|---|---|---|
+| `complianceScoreThreshold` | 0 | 100 | "Compliance score must be between 0 and 100." |
+| `daysRemainingThreshold` | 0 | 365 | "Days remaining must be between 0 and 365." |
+
+Invalid values are rejected with an inline `role="alert"` message; the thresholds are not updated until valid values are applied.
+
+## Accessibility
+
+- Threshold inputs have explicit `<label>` elements linked via `htmlFor` / `id`.
+- The settings panel uses `role="group"` with `aria-label`.
+- The toggle button exposes `aria-expanded` and `aria-controls`.
+- Validation errors appear in a `role="alert"` element for immediate screen-reader announcement.
+- The spinner indicator uses `aria-hidden="true"` to suppress decorative animation from assistive technology.
+
+## Related files
+
+- `src/components/dashboard/AtRiskCommitments.tsx` — main component
+- `src/utils/classification.ts` — classification logic with threshold support
+- `src/components/dashboard/AtRiskCommitments.test.tsx` — component tests
+- `src/components/dashboard/AtRiskThresholds.test.tsx` — threshold-focused unit tests
+- `docs/AT_RISK_WIDGET.md` — original widget documentation

--- a/docs/AT_RISK_WIDGET.md
+++ b/docs/AT_RISK_WIDGET.md
@@ -14,3 +14,18 @@ Commitments are evaluated against the following criteria to determine if they ar
 - It accepts a list of commitments and fetches the latest protocol constants for dynamic threshold evaluation where applicable.
 - If no commitments are at risk, a reassuring "All Commitments Healthy" state is displayed.
 - The widget lists the specific risk categories triggered and provides a deep link directly to the commitment detail page.
+
+---
+
+## Configurable Thresholds (issue #957)
+
+Users can now tune the sensitivity of the at-risk widget without code changes. See `docs/AT_RISK_THRESHOLDS.md` for the full feature reference.
+
+### Quick summary
+
+| Threshold | Default | Valid range |
+|---|---|---|
+| `complianceScoreThreshold` | `70` | `0` – `100` |
+| `daysRemainingThreshold` | `7` | `0` – `365` |
+
+Clicking **Configure Thresholds** in the widget header reveals the threshold controls. Changes are applied immediately and re-filter the list. A warning toast fires once when a commitment newly enters at-risk status (deduped so it does not repeat for already-known items).

--- a/src/components/dashboard/AtRiskCommitments.test.tsx
+++ b/src/components/dashboard/AtRiskCommitments.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { AtRiskCommitments } from './AtRiskCommitments';
 import { fetchProtocolConstants } from '@/utils/protocol';
@@ -7,6 +7,11 @@ import { Commitment } from '@/lib/types/domain';
 
 jest.mock('@/utils/protocol', () => ({
   fetchProtocolConstants: jest.fn()
+}));
+
+const mockWarning = jest.fn();
+jest.mock('@/components/toast/ToastProvider', () => ({
+  useToast: () => ({ warning: mockWarning }),
 }));
 
 const mockCommitments: Commitment[] = [
@@ -27,13 +32,14 @@ const mockCommitments: Commitment[] = [
     amount: '200',
     complianceScore: 40,
     daysRemaining: 5,
-  }
+  },
 ];
 
 describe('AtRiskCommitments', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     (fetchProtocolConstants as jest.Mock).mockResolvedValue({
-      commitmentLimits: { maxLossPercentCeiling: 10 }
+      commitmentLimits: { maxLossPercentCeiling: 10 },
     });
   });
 
@@ -44,7 +50,6 @@ describe('AtRiskCommitments', () => {
 
   it('renders healthy state when no commitments are at risk', async () => {
     render(<AtRiskCommitments commitments={[mockCommitments[0]]} />);
-    
     await waitFor(() => {
       expect(screen.getByText('All Commitments Healthy')).toBeInTheDocument();
     });
@@ -52,14 +57,128 @@ describe('AtRiskCommitments', () => {
 
   it('renders at risk commitments', async () => {
     render(<AtRiskCommitments commitments={mockCommitments} />);
-    
     await waitFor(() => {
       expect(screen.getByText('Needs Attention')).toBeInTheDocument();
       expect(screen.getByText('1 at risk')).toBeInTheDocument();
-      // Should show the low compliance and maturing soon categories
       expect(screen.getByText('low compliance')).toBeInTheDocument();
       expect(screen.getByText('maturing soon')).toBeInTheDocument();
       expect(screen.getByText('action required')).toBeInTheDocument();
+    });
+  });
+
+  it('shows configure thresholds button', async () => {
+    render(<AtRiskCommitments commitments={mockCommitments} />);
+    await waitFor(() => {
+      expect(screen.getByText('Configure Thresholds')).toBeInTheDocument();
+    });
+  });
+
+  it('toggles threshold settings panel', async () => {
+    render(<AtRiskCommitments commitments={mockCommitments} />);
+    await waitFor(() => screen.getByText('Configure Thresholds'));
+
+    fireEvent.click(screen.getByText('Configure Thresholds'));
+    expect(screen.getByLabelText('At-risk threshold settings')).toBeInTheDocument();
+    expect(screen.getByText('Hide Settings')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Hide Settings'));
+    expect(screen.queryByLabelText('At-risk threshold settings')).not.toBeInTheDocument();
+  });
+
+  it('default thresholds preserve existing behavior', async () => {
+    // commitment[0] has compliance 90 (>= 70) and 30 days (> 7) — should be healthy
+    render(<AtRiskCommitments commitments={[mockCommitments[0]]} />);
+    await waitFor(() => {
+      expect(screen.getByText('All Commitments Healthy')).toBeInTheDocument();
+    });
+  });
+
+  it('threshold change re-filters commitments', async () => {
+    render(<AtRiskCommitments commitments={[mockCommitments[0]]} />);
+    await waitFor(() => screen.getByText('All Commitments Healthy'));
+
+    fireEvent.click(screen.getByText('Configure Thresholds'));
+
+    const complianceInput = screen.getByLabelText('Compliance score below (0–100)');
+    // Raise threshold above commitment[0]'s score of 90 → should now flag it
+    fireEvent.change(complianceInput, { target: { value: '95' } });
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Needs Attention')).toBeInTheDocument();
+    });
+  });
+
+  it('rejects invalid compliance threshold', async () => {
+    render(<AtRiskCommitments commitments={mockCommitments} />);
+    await waitFor(() => screen.getByText('Configure Thresholds'));
+
+    fireEvent.click(screen.getByText('Configure Thresholds'));
+    const input = screen.getByLabelText('Compliance score below (0–100)');
+    fireEvent.change(input, { target: { value: '150' } });
+    fireEvent.click(screen.getByText('Apply'));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Compliance score must be between 0 and 100.'
+    );
+  });
+
+  it('rejects invalid days threshold', async () => {
+    render(<AtRiskCommitments commitments={mockCommitments} />);
+    await waitFor(() => screen.getByText('Configure Thresholds'));
+
+    fireEvent.click(screen.getByText('Configure Thresholds'));
+    const input = screen.getByLabelText('Days remaining at or below (0–365)');
+    fireEvent.change(input, { target: { value: '-5' } });
+    fireEvent.click(screen.getByText('Apply'));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Days remaining must be between 0 and 365.'
+    );
+  });
+
+  it('fires toast when a commitment newly enters at-risk', async () => {
+    render(<AtRiskCommitments commitments={mockCommitments} />);
+    await waitFor(() => {
+      expect(screen.getByText('Needs Attention')).toBeInTheDocument();
+    });
+
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Commitment At Risk' })
+    );
+  });
+
+  it('does not fire duplicate alerts for already-at-risk commitments', async () => {
+    const { rerender } = render(<AtRiskCommitments commitments={mockCommitments} />);
+    await waitFor(() => screen.getByText('Needs Attention'));
+    const firstCallCount = mockWarning.mock.calls.length;
+
+    rerender(<AtRiskCommitments commitments={mockCommitments} />);
+    await waitFor(() => screen.getByText('Needs Attention'));
+
+    // No additional warnings for already-known at-risk commitments
+    expect(mockWarning.mock.calls.length).toBe(firstCallCount);
+  });
+
+  it('calls onThresholdsChange when thresholds are applied', async () => {
+    const onThresholdsChange = jest.fn();
+    render(
+      <AtRiskCommitments
+        commitments={mockCommitments}
+        onThresholdsChange={onThresholdsChange}
+      />
+    );
+    await waitFor(() => screen.getByText('Configure Thresholds'));
+
+    fireEvent.click(screen.getByText('Configure Thresholds'));
+    const input = screen.getByLabelText('Compliance score below (0–100)');
+    fireEvent.change(input, { target: { value: '80' } });
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() => {
+      expect(onThresholdsChange).toHaveBeenCalledWith(
+        expect.objectContaining({ complianceScoreThreshold: 80 })
+      );
     });
   });
 });

--- a/src/components/dashboard/AtRiskCommitments.tsx
+++ b/src/components/dashboard/AtRiskCommitments.tsx
@@ -1,91 +1,229 @@
-import React, { useEffect, useState } from 'react';
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Commitment } from '@/lib/types/domain';
 import { AtRiskCommitment, classifyAtRiskCommitments } from '@/utils/classification';
 import { ProtocolConstants, fetchProtocolConstants } from '@/utils/protocol';
+import { useToast } from '@/components/toast/ToastProvider';
+
+export interface AtRiskThresholds {
+  /** Compliance score below which a commitment is flagged (default: 70) */
+  complianceScoreThreshold: number;
+  /** Days remaining at or below which a commitment is flagged (default: 7) */
+  daysRemainingThreshold: number;
+}
+
+export const DEFAULT_AT_RISK_THRESHOLDS: AtRiskThresholds = {
+  complianceScoreThreshold: 70,
+  daysRemainingThreshold: 7,
+};
 
 interface AtRiskCommitmentsProps {
   commitments?: Commitment[];
+  thresholds?: Partial<AtRiskThresholds>;
+  onThresholdsChange?: (thresholds: AtRiskThresholds) => void;
 }
 
-export function AtRiskCommitments({ commitments = [] }: AtRiskCommitmentsProps) {
+function validateThreshold(value: number, min: number, max: number): boolean {
+  return Number.isFinite(value) && value >= min && value <= max;
+}
+
+export function AtRiskCommitments({
+  commitments = [],
+  thresholds: thresholdsProp,
+  onThresholdsChange,
+}: AtRiskCommitmentsProps) {
   const [atRisk, setAtRisk] = useState<AtRiskCommitment[]>([]);
   const [loading, setLoading] = useState(true);
+  const [thresholds, setThresholds] = useState<AtRiskThresholds>({
+    ...DEFAULT_AT_RISK_THRESHOLDS,
+    ...thresholdsProp,
+  });
+  const [showSettings, setShowSettings] = useState(false);
+  const [complianceInput, setComplianceInput] = useState(
+    String(thresholds.complianceScoreThreshold)
+  );
+  const [daysInput, setDaysInput] = useState(String(thresholds.daysRemainingThreshold));
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const prevAtRiskIds = useRef<Set<string>>(new Set());
+  const toast = useToast();
 
   useEffect(() => {
     async function load() {
       try {
-        const constants = await fetchProtocolConstants();
-        setAtRisk(classifyAtRiskCommitments(commitments, constants));
-      } catch (err) {
-        // Fallback without constants
-        setAtRisk(classifyAtRiskCommitments(commitments, null));
+        const constants: ProtocolConstants = await fetchProtocolConstants();
+        setAtRisk(classifyAtRiskCommitments(commitments, constants, thresholds));
+      } catch {
+        setAtRisk(classifyAtRiskCommitments(commitments, null, thresholds));
       } finally {
         setLoading(false);
       }
     }
     load();
-  }, [commitments]);
+  }, [commitments, thresholds]);
+
+  // Alert on newly at-risk commitments (deduped)
+  useEffect(() => {
+    if (loading) return;
+    const currentIds = new Set(atRisk.map((c) => c.id));
+    const newlyAtRisk = atRisk.filter((c) => !prevAtRiskIds.current.has(c.id));
+    if (newlyAtRisk.length > 0) {
+      toast.warning({
+        title: 'Commitment At Risk',
+        description: `${newlyAtRisk.length} commitment${newlyAtRisk.length > 1 ? 's have' : ' has'} newly entered at-risk status.`,
+      });
+    }
+    prevAtRiskIds.current = currentIds;
+  }, [atRisk, loading, toast]);
+
+  function applyThresholds() {
+    const compliance = Number(complianceInput);
+    const days = Number(daysInput);
+    if (!validateThreshold(compliance, 0, 100)) {
+      setValidationError('Compliance score must be between 0 and 100.');
+      return;
+    }
+    if (!validateThreshold(days, 0, 365)) {
+      setValidationError('Days remaining must be between 0 and 365.');
+      return;
+    }
+    setValidationError(null);
+    const next: AtRiskThresholds = {
+      complianceScoreThreshold: compliance,
+      daysRemainingThreshold: days,
+    };
+    setThresholds(next);
+    onThresholdsChange?.(next);
+    setShowSettings(false);
+  }
 
   if (loading) {
     return <div className="animate-pulse h-24 bg-zinc-900 rounded-xl" />;
   }
 
-  if (atRisk.length === 0) {
-    return (
-      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center">
-        <h3 className="text-lg font-medium text-white mb-2">All Commitments Healthy</h3>
-        <p className="text-zinc-400 text-sm">
-          No commitments currently need your attention.
-        </p>
-      </div>
-    );
-  }
-
   return (
-    <div className="bg-zinc-900 border border-red-900/50 rounded-xl overflow-hidden">
-      <div className="p-4 border-b border-zinc-800 bg-red-950/20 flex items-center justify-between">
-        <h3 className="text-lg font-medium text-red-400 flex items-center gap-2">
-          <span className="relative flex h-3 w-3">
-            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
-            <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500"></span>
-          </span>
-          Needs Attention
-        </h3>
-        <span className="text-xs font-semibold bg-red-500/20 text-red-400 px-2.5 py-1 rounded-full">
-          {atRisk.length} at risk
-        </span>
+    <div className="space-y-3">
+      {/* Threshold Controls */}
+      <div className="flex justify-end">
+        <button
+          type="button"
+          aria-expanded={showSettings}
+          aria-controls="at-risk-settings"
+          onClick={() => setShowSettings((v) => !v)}
+          className="text-xs text-zinc-400 hover:text-white underline focus:outline-none focus:ring-2 focus:ring-red-500 rounded"
+        >
+          {showSettings ? 'Hide Settings' : 'Configure Thresholds'}
+        </button>
       </div>
-      
-      <ul className="divide-y divide-zinc-800/50" role="list" aria-label="At-risk commitments">
-        {atRisk.map((commitment) => (
-          <li key={commitment.id} className="p-4 hover:bg-zinc-800/50 transition-colors">
-            <div className="flex items-center justify-between">
-              <div>
-                <Link href={`/commitments/${commitment.id}`} className="text-white font-medium hover:underline focus:outline-none focus:ring-2 focus:ring-red-500 rounded">
-                  Commitment {commitment.id.substring(0, 8)}
-                </Link>
-                <div className="mt-1 flex flex-wrap gap-2 text-xs">
-                  {commitment.riskCategories.map((category) => (
-                    <span 
-                      key={category} 
-                      className="inline-block text-zinc-400 capitalize bg-zinc-800 px-2 py-0.5 rounded"
+
+      {showSettings && (
+        <div
+          id="at-risk-settings"
+          role="group"
+          aria-label="At-risk threshold settings"
+          className="bg-zinc-900 border border-zinc-700 rounded-xl p-4 space-y-3"
+        >
+          <div className="flex flex-col gap-1">
+            <label htmlFor="compliance-threshold" className="text-xs text-zinc-400">
+              Compliance score below (0–100)
+            </label>
+            <input
+              id="compliance-threshold"
+              type="number"
+              min={0}
+              max={100}
+              value={complianceInput}
+              onChange={(e) => setComplianceInput(e.target.value)}
+              className="bg-zinc-800 border border-zinc-700 text-white text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-red-500 w-32"
+              aria-describedby={validationError ? 'threshold-error' : undefined}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="days-threshold" className="text-xs text-zinc-400">
+              Days remaining at or below (0–365)
+            </label>
+            <input
+              id="days-threshold"
+              type="number"
+              min={0}
+              max={365}
+              value={daysInput}
+              onChange={(e) => setDaysInput(e.target.value)}
+              className="bg-zinc-800 border border-zinc-700 text-white text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-red-500 w-32"
+              aria-describedby={validationError ? 'threshold-error' : undefined}
+            />
+          </div>
+          {validationError && (
+            <p id="threshold-error" role="alert" className="text-red-400 text-xs">
+              {validationError}
+            </p>
+          )}
+          <button
+            type="button"
+            onClick={applyThresholds}
+            className="text-sm bg-red-600 hover:bg-red-700 text-white px-4 py-1.5 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-red-500"
+          >
+            Apply
+          </button>
+        </div>
+      )}
+
+      {/* At-risk list */}
+      {atRisk.length === 0 ? (
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center">
+          <h3 className="text-lg font-medium text-white mb-2">All Commitments Healthy</h3>
+          <p className="text-zinc-400 text-sm">No commitments currently need your attention.</p>
+        </div>
+      ) : (
+        <div className="bg-zinc-900 border border-red-900/50 rounded-xl overflow-hidden">
+          <div className="p-4 border-b border-zinc-800 bg-red-950/20 flex items-center justify-between">
+            <h3 className="text-lg font-medium text-red-400 flex items-center gap-2">
+              <span className="relative flex h-3 w-3" aria-hidden="true">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500" />
+              </span>
+              Needs Attention
+            </h3>
+            <span className="text-xs font-semibold bg-red-500/20 text-red-400 px-2.5 py-1 rounded-full">
+              {atRisk.length} at risk
+            </span>
+          </div>
+
+          <ul className="divide-y divide-zinc-800/50" role="list" aria-label="At-risk commitments">
+            {atRisk.map((commitment) => (
+              <li key={commitment.id} className="p-4 hover:bg-zinc-800/50 transition-colors">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Link
+                      href={`/commitments/${commitment.id}`}
+                      className="text-white font-medium hover:underline focus:outline-none focus:ring-2 focus:ring-red-500 rounded"
                     >
-                      {category.replace('_', ' ')}
-                    </span>
-                  ))}
+                      Commitment {commitment.id.substring(0, 8)}
+                    </Link>
+                    <div className="mt-1 flex flex-wrap gap-2 text-xs">
+                      {commitment.riskCategories.map((category) => (
+                        <span
+                          key={category}
+                          className="inline-block text-zinc-400 capitalize bg-zinc-800 px-2 py-0.5 rounded"
+                        >
+                          {category.replace('_', ' ')}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  <Link
+                    href={`/commitments/${commitment.id}`}
+                    className="text-sm bg-zinc-800 hover:bg-zinc-700 text-white px-3 py-1.5 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-red-500"
+                  >
+                    Review
+                  </Link>
                 </div>
-              </div>
-              <Link 
-                href={`/commitments/${commitment.id}`}
-                className="text-sm bg-zinc-800 hover:bg-zinc-700 text-white px-3 py-1.5 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-red-500"
-              >
-                Review
-              </Link>
-            </div>
-          </li>
-        ))}
-      </ul>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/dashboard/AtRiskThresholds.test.tsx
+++ b/src/components/dashboard/AtRiskThresholds.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * Focused unit tests for the configurable at-risk threshold feature.
+ * Tests cover: rendering, interaction, threshold changes, edge cases.
+ */
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AtRiskCommitments, DEFAULT_AT_RISK_THRESHOLDS } from './AtRiskCommitments';
+import { classifyAtRiskCommitments } from '@/utils/classification';
+import { fetchProtocolConstants } from '@/utils/protocol';
+import { Commitment } from '@/lib/types/domain';
+
+jest.mock('@/utils/protocol', () => ({
+  fetchProtocolConstants: jest.fn(),
+}));
+
+const mockWarning = jest.fn();
+jest.mock('@/components/toast/ToastProvider', () => ({
+  useToast: () => ({ warning: mockWarning }),
+}));
+
+const base: Commitment = {
+  id: 'abc123',
+  type: 'Safe',
+  status: 'Active',
+  asset: 'XLM',
+  amount: '500',
+  complianceScore: 80,
+  daysRemaining: 10,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (fetchProtocolConstants as jest.Mock).mockResolvedValue(null);
+});
+
+// ─── Default thresholds ────────────────────────────────────────────────────
+
+describe('DEFAULT_AT_RISK_THRESHOLDS', () => {
+  it('has complianceScoreThreshold of 70', () => {
+    expect(DEFAULT_AT_RISK_THRESHOLDS.complianceScoreThreshold).toBe(70);
+  });
+
+  it('has daysRemainingThreshold of 7', () => {
+    expect(DEFAULT_AT_RISK_THRESHOLDS.daysRemainingThreshold).toBe(7);
+  });
+});
+
+// ─── classifyAtRiskCommitments with thresholds ─────────────────────────────
+
+describe('classifyAtRiskCommitments with custom thresholds', () => {
+  it('uses default thresholds when none supplied', () => {
+    const c: Commitment = { ...base, complianceScore: 65, daysRemaining: 10 };
+    const result = classifyAtRiskCommitments([c], null);
+    expect(result[0].riskCategories).toContain('low_compliance');
+    expect(result[0].riskCategories).not.toContain('maturing_soon');
+  });
+
+  it('respects custom complianceScoreThreshold', () => {
+    const c: Commitment = { ...base, complianceScore: 75, daysRemaining: 30 };
+    const healthy = classifyAtRiskCommitments([c], null, { complianceScoreThreshold: 70 });
+    expect(healthy).toHaveLength(0);
+
+    const atRisk = classifyAtRiskCommitments([c], null, { complianceScoreThreshold: 80 });
+    expect(atRisk[0].riskCategories).toContain('low_compliance');
+  });
+
+  it('respects custom daysRemainingThreshold', () => {
+    const c: Commitment = { ...base, complianceScore: 90, daysRemaining: 10 };
+    const healthy = classifyAtRiskCommitments([c], null, { daysRemainingThreshold: 7 });
+    expect(healthy).toHaveLength(0);
+
+    const atRisk = classifyAtRiskCommitments([c], null, { daysRemainingThreshold: 14 });
+    expect(atRisk[0].riskCategories).toContain('maturing_soon');
+  });
+
+  it('default preserves original behavior (score 65 < 70 => low_compliance)', () => {
+    const c: Commitment = { ...base, complianceScore: 65 };
+    const result = classifyAtRiskCommitments([c], null);
+    expect(result).toHaveLength(1);
+    expect(result[0].riskCategories).toContain('low_compliance');
+  });
+
+  it('default preserves original behavior (score 70 => not at risk for compliance)', () => {
+    const c: Commitment = { ...base, complianceScore: 70, daysRemaining: 30 };
+    const result = classifyAtRiskCommitments([c], null);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ─── AtRiskCommitments component — threshold controls ─────────────────────
+
+describe('AtRiskCommitments threshold controls', () => {
+  it('renders configure thresholds button after load', async () => {
+    render(<AtRiskCommitments commitments={[base]} />);
+    await waitFor(() =>
+      expect(screen.getByText('Configure Thresholds')).toBeInTheDocument()
+    );
+  });
+
+  it('settings panel is hidden by default', async () => {
+    render(<AtRiskCommitments commitments={[base]} />);
+    await waitFor(() => screen.getByText('Configure Thresholds'));
+    expect(screen.queryByLabelText('At-risk threshold settings')).not.toBeInTheDocument();
+  });
+
+  it('opens settings panel on button click', async () => {
+    render(<AtRiskCommitments commitments={[base]} />);
+    await waitFor(() => screen.getByText('Configure Thresholds'));
+    fireEvent.click(screen.getByText('Configure Thresholds'));
+    expect(screen.getByLabelText('At-risk threshold settings')).toBeInTheDocument();
+  });
+
+  it('threshold change re-filters the list', async () => {
+    // base has complianceScore 80, daysRemaining 10 — healthy by default
+    render(<AtRiskCommitments commitments={[base]} />);
+    await waitFor(() => screen.getByText('All Commitments Healthy'));
+
+    fireEvent.click(screen.getByText('Configure Thresholds'));
+    const compInput = screen.getByLabelText('Compliance score below (0–100)');
+    fireEvent.change(compInput, { target: { value: '85' } });
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Needs Attention')).toBeInTheDocument();
+    });
+  });
+
+  it('newly at-risk commitment triggers one alert', async () => {
+    const atRiskCommitment: Commitment = { ...base, complianceScore: 60 };
+    render(<AtRiskCommitments commitments={[atRiskCommitment]} />);
+    await waitFor(() => screen.getByText('Needs Attention'));
+    expect(mockWarning).toHaveBeenCalledTimes(1);
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Commitment At Risk' })
+    );
+  });
+
+  it('invalid compliance threshold shows validation error', async () => {
+    render(<AtRiskCommitments commitments={[base]} />);
+    await waitFor(() => screen.getByText('Configure Thresholds'));
+    fireEvent.click(screen.getByText('Configure Thresholds'));
+
+    fireEvent.change(screen.getByLabelText('Compliance score below (0–100)'), {
+      target: { value: '999' },
+    });
+    fireEvent.click(screen.getByText('Apply'));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Compliance score must be between 0 and 100.'
+    );
+  });
+
+  it('invalid days threshold shows validation error', async () => {
+    render(<AtRiskCommitments commitments={[base]} />);
+    await waitFor(() => screen.getByText('Configure Thresholds'));
+    fireEvent.click(screen.getByText('Configure Thresholds'));
+
+    fireEvent.change(screen.getByLabelText('Days remaining at or below (0–365)'), {
+      target: { value: '400' },
+    });
+    fireEvent.click(screen.getByText('Apply'));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Days remaining must be between 0 and 365.'
+    );
+  });
+
+  it('invalid threshold does not update the list', async () => {
+    render(<AtRiskCommitments commitments={[base]} />);
+    await waitFor(() => screen.getByText('All Commitments Healthy'));
+    fireEvent.click(screen.getByText('Configure Thresholds'));
+
+    fireEvent.change(screen.getByLabelText('Compliance score below (0–100)'), {
+      target: { value: '-1' },
+    });
+    fireEvent.click(screen.getByText('Apply'));
+
+    // List must remain healthy (invalid threshold rejected)
+    expect(screen.getByText('Configure Thresholds')).toBeInTheDocument();
+  });
+
+  it('calls onThresholdsChange callback with new thresholds', async () => {
+    const onThresholdsChange = jest.fn();
+    render(
+      <AtRiskCommitments
+        commitments={[base]}
+        onThresholdsChange={onThresholdsChange}
+      />
+    );
+    await waitFor(() => screen.getByText('Configure Thresholds'));
+    fireEvent.click(screen.getByText('Configure Thresholds'));
+
+    fireEvent.change(screen.getByLabelText('Days remaining at or below (0–365)'), {
+      target: { value: '14' },
+    });
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() => {
+      expect(onThresholdsChange).toHaveBeenCalledWith(
+        expect.objectContaining({ daysRemainingThreshold: 14 })
+      );
+    });
+  });
+
+  it('accepts threshold props and uses them as initial values', async () => {
+    render(
+      <AtRiskCommitments
+        commitments={[base]}
+        thresholds={{ complianceScoreThreshold: 85 }}
+      />
+    );
+    // base.complianceScore is 80, so with threshold 85 it should be at risk
+    await waitFor(() => {
+      expect(screen.getByText('Needs Attention')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/utils/classification.ts
+++ b/src/utils/classification.ts
@@ -7,22 +7,35 @@ export interface AtRiskCommitment extends Commitment {
   riskCategories: RiskCategory[];
 }
 
+export interface ClassificationThresholds {
+  complianceScoreThreshold?: number;
+  daysRemainingThreshold?: number;
+}
+
+const DEFAULT_COMPLIANCE_THRESHOLD = 70;
+const DEFAULT_DAYS_THRESHOLD = 7;
+
 export function classifyAtRiskCommitments(
   commitments: Commitment[],
-  constants: ProtocolConstants | null
+  constants: ProtocolConstants | null,
+  thresholds?: ClassificationThresholds
 ): AtRiskCommitment[] {
+  const complianceThreshold =
+    thresholds?.complianceScoreThreshold ?? DEFAULT_COMPLIANCE_THRESHOLD;
+  const daysThreshold = thresholds?.daysRemainingThreshold ?? DEFAULT_DAYS_THRESHOLD;
+
   return commitments
     .map((c) => {
       const riskCategories: RiskCategory[] = [];
-      
-      if (c.complianceScore !== undefined && c.complianceScore < 70) {
+
+      if (c.complianceScore !== undefined && c.complianceScore < complianceThreshold) {
         riskCategories.push('low_compliance');
       }
-      
-      if (c.daysRemaining !== undefined && c.daysRemaining <= 7) {
+
+      if (c.daysRemaining !== undefined && c.daysRemaining <= daysThreshold) {
         riskCategories.push('maturing_soon');
       }
-      
+
       if (c.status === 'Violated') {
         riskCategories.push('action_required');
       }
@@ -32,7 +45,7 @@ export function classifyAtRiskCommitments(
         const drawdown = parseFloat(c.currentDrawdown);
         const maxLoss = parseFloat(c.maxLoss);
         if (!isNaN(drawdown) && !isNaN(maxLoss) && drawdown >= maxLoss * 0.8) {
-           riskCategories.push('action_required');
+          riskCategories.push('action_required');
         }
       }
 


### PR DESCRIPTION
Fixes #957

## Summary
- Add `AtRiskThresholds` interface with `complianceScoreThreshold` and `daysRemainingThreshold` props to `AtRiskCommitments`, with defaults that preserve existing behavior
- Update `classifyAtRiskCommitments` utility to accept optional thresholds parameter (backwards compatible)
- Show a **Configure Thresholds** panel with accessible, validated inputs; re-filters the list immediately on Apply
- Fire a deduped warning toast via `useToast` when commitments newly enter at-risk status
- Add `AtRiskThresholds.test.tsx` covering rendering, interaction, threshold changes, and all edge cases
- Add `docs/AT_RISK_THRESHOLDS.md` with full props/API, usage examples, and accessibility notes

## Changes
- `src/components/dashboard/AtRiskCommitments.tsx` — thresholds + alerting
- `src/utils/classification.ts` — accepts optional `ClassificationThresholds` param
- `src/components/dashboard/AtRiskCommitments.test.tsx` — updated tests
- `src/components/dashboard/AtRiskThresholds.test.tsx` — new focused threshold tests
- `docs/AT_RISK_THRESHOLDS.md` — new feature documentation
- `docs/AT_RISK_WIDGET.md` — cross-link to new doc