### PR TITLE
test: cover MarketplaceResultsLayout view toggle and pagination

### DIFF
--- a/src/components/__tests__/MarketplaceResultsLayout.test.tsx
+++ b/src/components/__tests__/MarketplaceResultsLayout.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MarketplaceResultsLayout } from '../MarketplaceResultsLayout';
+
+describe('MarketplaceResultsLayout', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  const defaultProps = {
+    totalCount: 42,
+    viewMode: 'grid' as const,
+    onViewModeChange: vi.fn(),
+    currentPage: 1,
+    totalPages: 5,
+    onPageChange: vi.fn(),
+  };
+
+  it('renders totalCount, active view-mode correctly, and children', () => {
+    render(
+      <MarketplaceResultsLayout {...defaultProps}>
+        <div data-testid="test-child">Child Content</div>
+      </MarketplaceResultsLayout>
+    );
+
+    // Assert count display
+    expect(screen.getByText('42')).toBeTruthy();
+    expect(screen.getByText(/commitments found/i)).toBeTruthy();
+
+    // Assert active view mode
+    const gridButton = screen.getByRole('button', { name: 'Grid view' });
+    const listButton = screen.getByRole('button', { name: 'List view' });
+    expect(gridButton).toHaveAttribute('aria-pressed', 'true');
+    expect(listButton).toHaveAttribute('aria-pressed', 'false');
+
+    // Assert children render
+    expect(screen.getByTestId('test-child')).toBeTruthy();
+  });
+
+  it('fires onViewModeChange with the correct mode when view buttons are clicked', () => {
+    render(
+      <MarketplaceResultsLayout {...defaultProps} viewMode="list" />
+    );
+
+    const gridButton = screen.getByRole('button', { name: 'Grid view' });
+    fireEvent.click(gridButton);
+
+    expect(defaultProps.onViewModeChange).toHaveBeenCalledWith('grid');
+
+    const listButton = screen.getByRole('button', { name: 'List view' });
+    fireEvent.click(listButton);
+    expect(defaultProps.onViewModeChange).toHaveBeenCalledWith('list');
+  });
+
+  it('handles pagination correctly (middle page)', () => {
+    render(
+      <MarketplaceResultsLayout {...defaultProps} currentPage={3} />
+    );
+
+    const prevButton = screen.getByRole('button', { name: 'Previous page' });
+    const nextButton = screen.getByRole('button', { name: 'Next page' });
+    
+    // Both should be enabled on a middle page
+    expect(prevButton).not.toBeDisabled();
+    expect(nextButton).not.toBeDisabled();
+
+    // Click previous
+    fireEvent.click(prevButton);
+    expect(defaultProps.onPageChange).toHaveBeenCalledWith(2);
+
+    // Click next
+    fireEvent.click(nextButton);
+    expect(defaultProps.onPageChange).toHaveBeenCalledWith(4);
+    
+    // Click a specific page
+    const pageButton = screen.getByRole('button', { name: 'Page 5' });
+    fireEvent.click(pageButton);
+    expect(defaultProps.onPageChange).toHaveBeenCalledWith(5);
+  });
+
+  it('disables both previous and next buttons on a single page', () => {
+    render(
+      <MarketplaceResultsLayout {...defaultProps} totalPages={1} currentPage={1} />
+    );
+
+    const prevButton = screen.getByRole('button', { name: 'Previous page' });
+    const nextButton = screen.getByRole('button', { name: 'Next page' });
+
+    expect(prevButton).toBeDisabled();
+    expect(nextButton).toBeDisabled();
+  });
+
+  it('shows empty state and hides children and pagination when totalCount is 0', () => {
+    render(
+      <MarketplaceResultsLayout 
+        {...defaultProps} 
+        totalCount={0} 
+        totalPages={0} 
+        emptyStateType="empty"
+      >
+        <div data-testid="test-child">Child Content</div>
+      </MarketplaceResultsLayout>
+    );
+
+    // Children should not render
+    expect(screen.queryByTestId('test-child')).toBeNull();
+
+    // Pagination should not render
+    expect(screen.queryByRole('button', { name: 'Previous page' })).toBeNull();
+    
+    // Empty state should render
+    expect(screen.getByText('No commitments available')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #741

## What Changed
    - Created `src/components/__tests__/MarketplaceResultsLayout.test.tsx`.
    - Tests verify count display, children rendering, view mode toggle styles and callbacks, and pagination boundaries.

    ## Key Design Decisions
    - Stuck with the repo's existing use of `fireEvent` to keep patterns exactly identical to sibling tests like `MarketplaceEmptyState.test.tsx`.
   - The issue mentions asserting children render in the layout, but the codebase design actively prevents this when `totalCount === 0`, opting to show  `MarketplaceEmptyState` instead. The tests assert this actual real-world behavior to avoid lying about how the component operates.

    ## Acceptance Criteria
    - [x] Assert totalCount and the active viewMode render correctly.
    - [x] Click grid/list → onViewModeChange fires with the other mode.
    - [x] Click next/prev → onPageChange fires with the right page; assert prev is disabled on page 1 and next disabled on the last page.
    - [x] Assert children render inside the layout (when count > 0).
    - [x] Edge cases tested: single page (both disabled), zero results, page in the middle.
    - [x] Minimum 95% test coverage.

    ## Test Output & Coverage
    ```text
     ✓ src/components/__tests__/MarketplaceResultsLayout.test.tsx (5) 356ms

     % Coverage report from v8
    -------------------|---------|----------|---------|---------|-------------------
    File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
    -------------------|---------|----------|---------|---------|-------------------
    All files          |     100 |      100 |     100 |     100 |
     ...ultsLayout.tsx |     100 |      100 |     100 |     100 |
    -------------------|---------|----------|---------|---------|-------------------

## Security Note
No client input is processed insecurely, and no new environment variables or dependencies were introduced.
