### PR TITLE
Add commitment detail copy and explorer actions

### DIFF
--- a/docs/DETAIL_HEADER_COPY.md
+++ b/docs/DETAIL_HEADER_COPY.md
@@ -1,0 +1,33 @@
+# Commitment Detail Header Copy and Explorer Actions
+
+`CommitmentDetailHeader` exposes quick actions beside the commitment id so users can preserve the full identifier or inspect it externally without leaving the detail context.
+
+## Behavior
+
+- `Copy ID` writes the full `commitmentId` prop to the clipboard.
+- A transient `Copied` status confirms a successful copy.
+- If `navigator.clipboard.writeText` is unavailable or fails, the component shows `Clipboard unavailable` instead of throwing.
+- `Explorer` links are built with `buildExplorerUrl('contract', commitmentId, explorerNetwork)`.
+- Invalid or unsupported identifiers render a disabled `Explorer unavailable` control rather than an unsafe URL.
+
+## Props
+
+```tsx
+<CommitmentDetailHeader
+  commitmentId={commitmentId}
+  statusLabel="Active"
+  statusVariant="active"
+  explorerNetwork="testnet"
+  onBack={handleBack}
+  onShare={handleShare}
+/>
+```
+
+`explorerNetwork` is optional and defaults to `public`. Use `testnet` when the commitment id refers to a testnet contract.
+
+## Accessibility
+
+- Both actions are keyboard focusable when available.
+- The copy action has an explicit accessible name.
+- Copy outcomes are announced through a polite status region.
+- External explorer links use `target="_blank"` with `rel="noopener noreferrer"`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ Welcome to the CommitLabs documentation index. This document serves as a single 
 - **[MARKETPLACE_EMPTY_STATES.md](MARKETPLACE_EMPTY_STATES.md)** — UI variations shown when searches or categories yield zero marketplace results.
 - **[RELIST_EDIT_PRICE.md](RELIST_EDIT_PRICE.md)** — Relisting logic and price updates for existing marketplace offerings.
 - **[PURCHASE_SUCCESS.md](PURCHASE_SUCCESS.md)** — UX and flow details showing post-purchase confirmation and routing.
+- **[DETAIL_HEADER_COPY.md](DETAIL_HEADER_COPY.md)** — Commitment detail header copy-id and safe explorer-link actions.
 
 ## 🎨 UI/UX Design & Branding
 - **[design/FigmaDesign.md](design/FigmaDesign.md)** — Figma success state designs and visual directions.

--- a/src/components/Commitmentdetailheader.tsx
+++ b/src/components/Commitmentdetailheader.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React from 'react';
-import { ArrowLeft, Share2 } from 'lucide-react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ArrowLeft, Copy, ExternalLink, Share2 } from 'lucide-react';
+import { buildExplorerUrl, type ExplorerNetwork } from '@/utils/explorerLinks';
 
 interface CommitmentDetailHeaderProps {
     commitmentId: string;
@@ -9,7 +10,12 @@ interface CommitmentDetailHeaderProps {
     statusVariant: 'active' | 'settled' | 'violated' | 'early_exit' | string;
     onBack: () => void;
     onShare: () => void;
+    explorerNetwork?: ExplorerNetwork;
 }
+
+type CopyStatus = 'idle' | 'copied' | 'unavailable';
+
+const COPY_STATUS_RESET_MS = 2000;
 
 const statusConfig = {
     active: {
@@ -44,8 +50,49 @@ export default function CommitmentDetailHeader({
     statusVariant,
     onBack,
     onShare,
+    explorerNetwork = 'public',
 }: CommitmentDetailHeaderProps) {
     const config = statusConfig[statusVariant as keyof typeof statusConfig] || statusConfig.active;
+    const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
+    const resetCopyStatusRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const explorerUrl = useMemo(
+        () => buildExplorerUrl('contract', commitmentId, explorerNetwork),
+        [commitmentId, explorerNetwork],
+    );
+
+    useEffect(() => () => {
+        if (resetCopyStatusRef.current) {
+            clearTimeout(resetCopyStatusRef.current);
+        }
+    }, []);
+
+    const showCopyStatus = (status: Exclude<CopyStatus, 'idle'>) => {
+        if (resetCopyStatusRef.current) {
+            clearTimeout(resetCopyStatusRef.current);
+        }
+
+        setCopyStatus(status);
+        resetCopyStatusRef.current = setTimeout(() => {
+            setCopyStatus('idle');
+            resetCopyStatusRef.current = null;
+        }, COPY_STATUS_RESET_MS);
+    };
+
+    const handleCopyCommitmentId = async () => {
+        const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined;
+
+        if (!clipboard?.writeText) {
+            showCopyStatus('unavailable');
+            return;
+        }
+
+        try {
+            await clipboard.writeText(commitmentId);
+            showCopyStatus('copied');
+        } catch {
+            showCopyStatus('unavailable');
+        }
+    };
 
     return (
         <header className="w-full space-y-4 sm:space-y-6">
@@ -64,9 +111,57 @@ export default function CommitmentDetailHeader({
                 {/* Left Section: ID and Status */}
                 <div className="flex flex-col gap-3">
                     {/* Commitment ID */}
-                    <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold font-mono uppercase tracking-tight text-[#f5f5f7]">
-                        {commitmentId}
-                    </h1>
+                    <div className="flex flex-col gap-2">
+                        <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold font-mono uppercase tracking-tight text-[#f5f5f7] break-all">
+                            {commitmentId}
+                        </h1>
+
+                        <div className="flex flex-wrap items-center gap-2">
+                            <button
+                                type="button"
+                                onClick={handleCopyCommitmentId}
+                                className="group inline-flex items-center gap-2 px-3 py-1.5 bg-[#0a0a0a] border border-[#222] rounded-full text-[#f5f5f7] text-xs font-medium hover:border-[#0ff0fc]/40 hover:bg-[#0ff0fc]/5 hover:shadow-[0_0_16px_rgba(15,240,252,0.12)] transition-all duration-200 focus:outline-none focus:border-[#0ff0fc]/60 focus:shadow-[0_0_20px_rgba(15,240,252,0.22)]"
+                                aria-label="Copy commitment ID"
+                            >
+                                <Copy className="w-3.5 h-3.5" aria-hidden="true" />
+                                <span>{copyStatus === 'copied' ? 'Copied' : 'Copy ID'}</span>
+                            </button>
+
+                            {explorerUrl ? (
+                                <a
+                                    href={explorerUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="group inline-flex items-center gap-2 px-3 py-1.5 bg-[#0a0a0a] border border-[#222] rounded-full text-[#f5f5f7] text-xs font-medium hover:border-[#0ff0fc]/40 hover:bg-[#0ff0fc]/5 hover:shadow-[0_0_16px_rgba(15,240,252,0.12)] transition-all duration-200 focus:outline-none focus:border-[#0ff0fc]/60 focus:shadow-[0_0_20px_rgba(15,240,252,0.22)]"
+                                    aria-label="Open commitment in Stellar explorer"
+                                >
+                                    <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
+                                    <span>Explorer</span>
+                                </a>
+                            ) : (
+                                <button
+                                    type="button"
+                                    disabled
+                                    className="inline-flex items-center gap-2 px-3 py-1.5 bg-[#0a0a0a] border border-[#222] rounded-full text-[#777] text-xs font-medium cursor-not-allowed"
+                                    aria-label="Explorer link unavailable for this commitment"
+                                    title="Explorer link unavailable for this commitment"
+                                >
+                                    <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
+                                    <span>Explorer unavailable</span>
+                                </button>
+                            )}
+
+                            {copyStatus !== 'idle' ? (
+                                <span
+                                    role="status"
+                                    aria-live="polite"
+                                    className="text-xs font-medium text-[#0ff0fc]"
+                                >
+                                    {copyStatus === 'copied' ? 'Copied' : 'Clipboard unavailable'}
+                                </span>
+                            ) : null}
+                        </div>
+                    </div>
 
                     {/* Status Pill */}
                     <div className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full w-fit ${config.bg} ${config.border} border`}>

--- a/src/components/__tests__/CommitmentDetailHeaderCopy.test.tsx
+++ b/src/components/__tests__/CommitmentDetailHeaderCopy.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import CommitmentDetailHeader from '@/components/Commitmentdetailheader';
+
+const validContractId = `C${'B'.repeat(55)}`;
+
+const defaultProps = {
+  commitmentId: validContractId,
+  statusLabel: 'Active',
+  statusVariant: 'active',
+  onBack: vi.fn(),
+  onShare: vi.fn(),
+} satisfies React.ComponentProps<typeof CommitmentDetailHeader>;
+
+function renderHeader(
+  overrides: Partial<React.ComponentProps<typeof CommitmentDetailHeader>> = {},
+) {
+  const props = {
+    ...defaultProps,
+    onBack: vi.fn(),
+    onShare: vi.fn(),
+    ...overrides,
+  };
+
+  const view = render(<CommitmentDetailHeader {...props} />);
+  return { props, ...view };
+}
+
+describe('CommitmentDetailHeader copy and explorer actions', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('copies the full commitment id instead of the rendered or truncated text', async () => {
+    renderHeader();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy commitment ID' }));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(validContractId);
+    });
+  });
+
+  it('shows a copied confirmation after a successful copy', async () => {
+    renderHeader();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy commitment ID' }));
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Copied');
+    expect(screen.getByRole('button', { name: 'Copy commitment ID' })).toHaveTextContent(
+      'Copied',
+    );
+  });
+
+  it('renders a sanitized explorer link with anti-tabnabbing attributes', () => {
+    renderHeader({ explorerNetwork: 'testnet' });
+
+    const link = screen.getByRole('link', {
+      name: 'Open commitment in Stellar explorer',
+    }) as HTMLAnchorElement;
+
+    expect(link.href).toBe(
+      `https://stellar.expert/explorer/testnet/contract/${validContractId}`,
+    );
+    expect(link.target).toBe('_blank');
+    expect(link.rel).toContain('noopener');
+    expect(link.rel).toContain('noreferrer');
+  });
+
+  it('does not render an explorer link for an invalid commitment id', () => {
+    renderHeader({ commitmentId: 'CMT-001' });
+
+    expect(
+      screen.queryByRole('link', { name: 'Open commitment in Stellar explorer' }),
+    ).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Explorer link unavailable for this commitment' }),
+    ).toBeDisabled();
+  });
+
+  it('shows a graceful status when the clipboard API is unavailable', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+    });
+
+    renderHeader();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy commitment ID' }));
+
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'Clipboard unavailable',
+    );
+  });
+
+  it('keeps the existing back and share controls working', () => {
+    const { props } = renderHeader();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go back to My Commitments' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Share commitment' }));
+
+    expect(props.onBack).toHaveBeenCalledTimes(1);
+    expect(props.onShare).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Copy ID and Explorer actions to `CommitmentDetailHeader`
- use `buildExplorerUrl` so invalid commitment IDs do not produce unsafe explorer links
- add focused RTL coverage and documentation for copy, unavailable clipboard, sanitized explorer links, and existing controls

Closes #965

## Verification
- `pnpm vitest run src/components/__tests__/CommitmentDetailHeaderCopy.test.tsx` - 6 tests passed
- `pnpm exec eslint src/components/Commitmentdetailheader.tsx src/components/__tests__/CommitmentDetailHeaderCopy.test.tsx` - passed
- `pnpm exec tsc --noEmit --pretty false` - blocked by pre-existing syntax errors in `src/app/commitments/overview/page.tsx`