### PR TITLE
Add early-exit grace countdown

### DIFF
--- a/docs/EARLY_EXIT_TIMING.md
+++ b/docs/EARLY_EXIT_TIMING.md
@@ -12,3 +12,9 @@ To help liquidity providers make informed decisions about when to trigger an ear
 - **Debouncing:** The slider utilizes a simulated debounce strategy to ensure the UI feels responsive while deferring state recalculations by a small timeout.
 - **Fallback Mechanism:** If the preview API fails or rate-limits, it gracefully falls back to a static calculation using the `originalAmount` and `penaltyPercent` props to estimate the baseline penalty.
 - **Accessibility:** Uses accessible range input features (`aria-label`) to announce the currently selected simulated date. It is strictly presented as an objective projection and eschews financial advice wording.
+
+## Grace Period Countdown
+
+The modal also includes a grace-period countdown banner driven by `commitmentLimits.earlyExitGracePeriodDays` from the protocol constants endpoint. The banner appears before `ExitTimingPreview` and tells the user whether the current early exit still incurs a penalty or whether waiting reaches a penalty-free window near maturity.
+
+See [GRACE_COUNTDOWN.md](GRACE_COUNTDOWN.md) for the component states, accessibility behavior, and tests.

--- a/docs/GRACE_COUNTDOWN.md
+++ b/docs/GRACE_COUNTDOWN.md
@@ -1,0 +1,64 @@
+# Early Exit Grace Countdown
+
+The early-exit modal shows a grace-period countdown banner before the timing preview. The banner tells users whether exiting now still incurs the configured penalty or whether waiting reaches a penalty-free grace window near maturity.
+
+## Protocol Constant
+
+The client reads `commitmentLimits.earlyExitGracePeriodDays` from `GET /api/protocol/constants` through `fetchProtocolConstants()`.
+
+Default backend value:
+
+```text
+COMMITLABS_EARLY_EXIT_GRACE_PERIOD_DAYS=7
+```
+
+If the value is missing, invalid, or `0`, the banner falls back to the penalty-now state and does not promise a grace window.
+
+## Modal Behavior
+
+`CommitmentEarlyExitModal` loads protocol constants when the modal opens and passes the resolved grace-period value to:
+
+- `GraceCountdownBanner`, which displays the accessible status message.
+- `ExitTimingPreview`, which projects penalty decay to `0` once the grace window starts.
+
+States:
+
+| State | Condition | User message |
+| --- | --- | --- |
+| Loading | Protocol constants are still loading | Checking grace period |
+| Pre-grace | Current time is before `maturityDate - gracePeriodDays` | Penalty applies now, with a countdown to the grace window |
+| In-grace | Current time is on or after the grace-window start | Early exit is penalty-free until maturity |
+| No grace | Grace period is `0` or unavailable | Early exit uses the penalty shown in the modal |
+
+## Accessibility
+
+- The banner uses `role="status"` with `aria-live="polite"` and `aria-atomic="true"` so assistive technology receives timing updates without interrupting the user.
+- Countdown updates every second by default.
+- When `prefers-reduced-motion: reduce` is enabled, countdown text omits seconds and updates on a slower cadence.
+- The status uses both iconography and text; color is not the only signal.
+
+## Usage Example
+
+```tsx
+<GraceCountdownBanner
+  maturityDate={maturityDate}
+  gracePeriodDays={7}
+/>
+
+<ExitTimingPreview
+  commitmentId={commitmentId}
+  originalAmount={parsedOriginalAmount}
+  currentPenaltyPercent={parsedPenaltyPercent}
+  maturityDate={maturityDate}
+  gracePeriodDays={7}
+/>
+```
+
+## Tests
+
+Focused coverage lives in `src/components/CommitmentEarlyExitModal/GraceCountdown.test.tsx` and covers:
+
+- in-grace penalty-free copy;
+- pre-grace countdown updates;
+- no-grace penalty-now copy;
+- reduced-motion countdown formatting.

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Welcome to the CommitLabs documentation index. This document serves as a single 
 - **[CREATE_THEN_FUND.md](CREATE_THEN_FUND.md)** — Multi-step sequence of creating a commitment on-chain followed by depositing assets.
 - **[CREATE_WIZARD_TOUR.md](CREATE_WIZARD_TOUR.md)** — Interactive onboarding wizard guide for new users.
 - **[EARLY_EXIT_TIMING.md](EARLY_EXIT_TIMING.md)** — Timing restrictions, cooldowns, and penalty formulas for exiting a commitment early.
+- **[GRACE_COUNTDOWN.md](GRACE_COUNTDOWN.md)** — Early-exit grace-period countdown banner behavior, protocol constant, accessibility notes, and tests.
 - **[NOTIFICATION_TEST_SEND.md](NOTIFICATION_TEST_SEND.md)** — Testing notification alerts and event trigger flows.
 - **[SETTINGS_UNSAVED_GUARD.md](SETTINGS_UNSAVED_GUARD.md)** — Navigation blocks and prompt dialogs for unsaved settings forms.
 - **[ROUTE_AUTH_GUARD.md](ROUTE_AUTH_GUARD.md)** — Client-side route protection and redirection for unauthenticated/disconnected wallets.

--- a/src/components/CommitmentEarlyExitModal/CommitmentEarlyExitModal.tsx
+++ b/src/components/CommitmentEarlyExitModal/CommitmentEarlyExitModal.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { AlertTriangle, X, Info } from 'lucide-react';
 import { Dialog } from '@/components/ui/Dialog';
+import {
+  fetchProtocolConstants,
+  getEarlyExitGracePeriodDays,
+} from '@/utils/protocol';
 import { ExitTimingPreview } from './ExitTimingPreview';
+import { GraceCountdownBanner } from './GraceCountdownBanner';
 
 export interface CommitmentEarlyExitModalProps {
   isOpen: boolean;
@@ -43,6 +48,7 @@ export default function CommitmentEarlyExitModal({
   maturityDate,
 }: CommitmentEarlyExitModalProps) {
   const [confirmationInput, setConfirmationInput] = useState('')
+  const [gracePeriodDays, setGracePeriodDays] = useState<number | null>(null)
   const hasTypedConfirmation = confirmationInput.trim() === commitmentId
   const canConfirm = hasAcknowledged && hasTypedConfirmation
 
@@ -53,6 +59,31 @@ export default function CommitmentEarlyExitModal({
   const handleClose = useCallback(() => {
     (onClose ?? onCancel)();
   }, [onClose, onCancel]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    let isMounted = true;
+    setGracePeriodDays(null);
+
+    fetchProtocolConstants()
+      .then((constants) => {
+        if (isMounted) {
+          setGracePeriodDays(getEarlyExitGracePeriodDays(constants));
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setGracePeriodDays(0);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [isOpen]);
 
   return (
     <Dialog
@@ -135,11 +166,17 @@ export default function CommitmentEarlyExitModal({
           </tbody>
         </table>
 
-        <ExitTimingPreview 
+        <GraceCountdownBanner
+          maturityDate={effectiveMaturityDate}
+          gracePeriodDays={gracePeriodDays}
+        />
+
+        <ExitTimingPreview
           commitmentId={commitmentId}
           originalAmount={parsedOriginalAmount}
           currentPenaltyPercent={parsedPenaltyPercent}
           maturityDate={effectiveMaturityDate}
+          gracePeriodDays={gracePeriodDays ?? 0}
         />
 
         {/* Important Notice Block */}

--- a/src/components/CommitmentEarlyExitModal/ExitTimingPreview.test.tsx
+++ b/src/components/CommitmentEarlyExitModal/ExitTimingPreview.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
 import { ExitTimingPreview } from './ExitTimingPreview';
 
-const mockFetch = jest.fn();
+const mockFetch = vi.fn();
 global.fetch = mockFetch;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 describe('ExitTimingPreview', () => {
   const defaultProps = {
@@ -76,6 +78,28 @@ describe('ExitTimingPreview', () => {
     // Scrub to 30 days (maturity)
     fireEvent.change(slider, { target: { value: '30' } });
     
+    await waitFor(() => {
+      expect(screen.getByText('-0.00')).toBeInTheDocument();
+      expect(screen.getByText('50,000.00')).toBeInTheDocument();
+    });
+  });
+
+  it('projects 0 penalty once the grace window starts', async () => {
+    render(
+      <ExitTimingPreview
+        {...defaultProps}
+        maturityDate={new Date(Date.now() + 10 * DAY_MS)}
+        gracePeriodDays={7}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('-1,500.00')).toBeInTheDocument();
+    });
+
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '3' } });
+
     await waitFor(() => {
       expect(screen.getByText('-0.00')).toBeInTheDocument();
       expect(screen.getByText('50,000.00')).toBeInTheDocument();

--- a/src/components/CommitmentEarlyExitModal/ExitTimingPreview.tsx
+++ b/src/components/CommitmentEarlyExitModal/ExitTimingPreview.tsx
@@ -1,10 +1,16 @@
 import React, { useState, useEffect, useMemo } from 'react';
+import {
+  DAY_MS,
+  getGracePeriodStartDate,
+  normalizeGracePeriodDays,
+} from './gracePeriod';
 
 interface ExitTimingPreviewProps {
   commitmentId: string;
   originalAmount: number;
   currentPenaltyPercent: number;
   maturityDate: Date;
+  gracePeriodDays?: number;
 }
 
 interface PreviewResult {
@@ -17,6 +23,7 @@ export function ExitTimingPreview({
   originalAmount,
   currentPenaltyPercent,
   maturityDate,
+  gracePeriodDays = 0,
 }: ExitTimingPreviewProps) {
   const [daysFromNow, setDaysFromNow] = useState(0);
   const [preview, setPreview] = useState<PreviewResult | null>(null);
@@ -30,8 +37,13 @@ export function ExitTimingPreview({
   const totalDays = useMemo(() => {
     const now = new Date();
     const diffTime = maturityDate.getTime() - now.getTime();
-    return Math.max(1, Math.ceil(diffTime / (1000 * 60 * 60 * 24)));
+    return Math.max(1, Math.ceil(diffTime / DAY_MS));
   }, [maturityDate]);
+
+  const normalizedGracePeriodDays = useMemo(
+    () => normalizeGracePeriodDays(gracePeriodDays),
+    [gracePeriodDays],
+  );
 
   // Fetch the baseline penalty from the API when component mounts
   useEffect(() => {
@@ -48,7 +60,7 @@ export function ExitTimingPreview({
         if (isMounted) {
           setBasePenaltyAmount(data.data?.penaltyAmount ?? (originalAmount * currentPenaltyPercent / 100));
         }
-      } catch (err) {
+      } catch (_err) {
         if (isMounted) {
           // Fallback to calculation if API fails
           setBasePenaltyAmount(originalAmount * currentPenaltyPercent / 100);
@@ -66,9 +78,34 @@ export function ExitTimingPreview({
   useEffect(() => {
     if (basePenaltyAmount === null) return;
     
-    // Linearly interpolate the penalty down to 0 at maturity
-    const remainingDays = Math.max(0, totalDays - daysFromNow);
-    const interpolatedPenalty = basePenaltyAmount * (remainingDays / totalDays);
+    const projectedExitDate = new Date(Date.now() + daysFromNow * DAY_MS);
+    let interpolatedPenalty: number;
+
+    if (normalizedGracePeriodDays > 0) {
+      const penaltyFreeDate = getGracePeriodStartDate(
+        maturityDate,
+        normalizedGracePeriodDays,
+      );
+      if (projectedExitDate.getTime() >= penaltyFreeDate.getTime()) {
+        interpolatedPenalty = 0;
+      } else {
+        const fullPenaltyWindowMs = Math.max(
+          DAY_MS,
+          penaltyFreeDate.getTime() - Date.now(),
+        );
+        const remainingPenaltyWindowMs = Math.max(
+          0,
+          penaltyFreeDate.getTime() - projectedExitDate.getTime(),
+        );
+        interpolatedPenalty =
+          basePenaltyAmount * (remainingPenaltyWindowMs / fullPenaltyWindowMs);
+      }
+    } else {
+      // Existing behavior: linearly interpolate the penalty down to 0 at maturity.
+      const remainingDays = Math.max(0, totalDays - daysFromNow);
+      interpolatedPenalty = basePenaltyAmount * (remainingDays / totalDays);
+    }
+
     const netRefund = originalAmount - interpolatedPenalty;
     
     // Simulate debounced API call feel for UI responsiveness
@@ -80,7 +117,14 @@ export function ExitTimingPreview({
     }, 300);
     
     return () => clearTimeout(timeout);
-  }, [daysFromNow, basePenaltyAmount, totalDays, originalAmount]);
+  }, [
+    daysFromNow,
+    basePenaltyAmount,
+    totalDays,
+    originalAmount,
+    maturityDate,
+    normalizedGracePeriodDays,
+  ]);
 
   const projectedDate = new Date();
   projectedDate.setDate(projectedDate.getDate() + daysFromNow);
@@ -113,6 +157,11 @@ export function ExitTimingPreview({
         <div className="text-center mt-3 text-[13px] text-white/80 font-medium">
           Projected Exit Date: <span className="text-white">{projectedDate.toLocaleDateString()}</span>
         </div>
+        {normalizedGracePeriodDays > 0 && (
+          <p className="mt-2 text-center text-[12px] text-white/45">
+            Penalty projection reaches 0 in the final {normalizedGracePeriodDays} days before maturity.
+          </p>
+        )}
       </div>
 
       <div className="bg-white/[0.02] rounded-xl p-4 flex justify-between items-center border border-white/[0.05]">

--- a/src/components/CommitmentEarlyExitModal/GraceCountdown.test.tsx
+++ b/src/components/CommitmentEarlyExitModal/GraceCountdown.test.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchProtocolConstants } from '@/utils/protocol';
+import CommitmentEarlyExitModal from './CommitmentEarlyExitModal';
+import { GraceCountdownBanner } from './GraceCountdownBanner';
+
+const FIXED_NOW = new Date('2026-06-29T12:00:00.000Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+const mockExitTimingPreview = vi.hoisted(() => vi.fn());
+
+vi.mock('@/utils/protocol', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/protocol')>(
+    '@/utils/protocol',
+  );
+
+  return {
+    ...actual,
+    fetchProtocolConstants: vi.fn(),
+  };
+});
+
+vi.mock('./ExitTimingPreview', () => ({
+  ExitTimingPreview: (props: Record<string, unknown>) => {
+    mockExitTimingPreview(props);
+    return null;
+  },
+}));
+
+function setReducedMotion(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+describe('GraceCountdownBanner', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    setReducedMotion(false);
+    mockExitTimingPreview.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('shows penalty-free copy when the commitment is inside the grace period', () => {
+    render(
+      <GraceCountdownBanner
+        maturityDate={new Date(FIXED_NOW.getTime() + 3 * DAY_MS)}
+        gracePeriodDays={7}
+      />,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('Penalty-free grace period');
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'You are inside the 7-day grace period.',
+    );
+  });
+
+  it('shows a ticking countdown before the grace period opens', () => {
+    render(
+      <GraceCountdownBanner
+        maturityDate={new Date(FIXED_NOW.getTime() + 10 * DAY_MS)}
+        gracePeriodDays={7}
+      />,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('Grace window opens in');
+    expect(screen.getByRole('status')).toHaveTextContent('Wait 3d 0h 0m 0s');
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('Wait 2d 23h 59m 59s');
+  });
+
+  it('shows penalty-now copy when no grace period is configured', () => {
+    render(
+      <GraceCountdownBanner
+        maturityDate={new Date(FIXED_NOW.getTime() + 10 * DAY_MS)}
+        gracePeriodDays={0}
+      />,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('Penalty applies now');
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'no penalty-free grace period',
+    );
+  });
+
+  it('honors reduced motion by omitting seconds from the live countdown', async () => {
+    setReducedMotion(true);
+
+    render(
+      <GraceCountdownBanner
+        maturityDate={new Date(FIXED_NOW.getTime() + 10 * DAY_MS)}
+        gracePeriodDays={7}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('Wait 3d 0h 0m');
+    expect(screen.getByRole('status')).not.toHaveTextContent('0s');
+  });
+
+  it('loads the protocol grace period when the early-exit modal opens', async () => {
+    vi.mocked(fetchProtocolConstants).mockResolvedValueOnce({
+      protocolVersion: '1.0.0',
+      network: 'testnet',
+      fees: {
+        networkBaseFeeStroops: 100,
+        platformFeePercent: 0,
+      },
+      penalties: [],
+      commitmentLimits: {
+        minAmountXlm: 10,
+        maxAmountXlm: 1_000_000,
+        minDurationDays: 1,
+        maxDurationDays: 365,
+        maxLossPercentCeiling: 100,
+        earlyExitGracePeriodDays: 5,
+      },
+      cachedAt: FIXED_NOW.toISOString(),
+    });
+
+    render(
+      <CommitmentEarlyExitModal
+        isOpen
+        commitmentId="cm_123456"
+        originalAmount="50,000 XLM"
+        penaltyPercent="3%"
+        penaltyAmount="1,500 XLM"
+        netReceiveAmount="48,500 XLM"
+        hasAcknowledged={false}
+        onChangeAcknowledged={vi.fn()}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+        maturityDate={new Date(FIXED_NOW.getTime() + 10 * DAY_MS)}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '5-day penalty-free grace period',
+    );
+    expect(mockExitTimingPreview).toHaveBeenLastCalledWith(
+      expect.objectContaining({ gracePeriodDays: 5 }),
+    );
+  });
+});

--- a/src/components/CommitmentEarlyExitModal/GraceCountdownBanner.tsx
+++ b/src/components/CommitmentEarlyExitModal/GraceCountdownBanner.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, Clock, ShieldCheck } from 'lucide-react';
+import useReducedMotion from '@/lib/a11y/useReducedMotion';
+import { getGraceCountdownStatus } from './gracePeriod';
+
+export interface GraceCountdownBannerProps {
+  maturityDate: Date;
+  gracePeriodDays: number | null;
+}
+
+const SECOND_MS = 1000;
+const MINUTE_MS = 60 * SECOND_MS;
+
+export function GraceCountdownBanner({
+  maturityDate,
+  gracePeriodDays,
+}: GraceCountdownBannerProps) {
+  const reducedMotion = useReducedMotion();
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    setNow(new Date());
+    const interval = window.setInterval(
+      () => setNow(new Date()),
+      reducedMotion ? MINUTE_MS : SECOND_MS,
+    );
+
+    return () => window.clearInterval(interval);
+  }, [reducedMotion]);
+
+  const status = useMemo(
+    () => getGraceCountdownStatus({
+      gracePeriodDays,
+      maturityDate,
+      now,
+      reducedMotion,
+    }),
+    [gracePeriodDays, maturityDate, now, reducedMotion],
+  );
+
+  const Icon =
+    status.state === 'in_grace'
+      ? ShieldCheck
+      : status.state === 'pre_grace'
+        ? Clock
+        : AlertTriangle;
+
+  const toneClass =
+    status.state === 'in_grace'
+      ? 'border-[#0FF0FC]/30 bg-[#0FF0FC]/10 text-[#0FF0FC]'
+      : 'border-[#FF8A04]/25 bg-[#FF8A04]/10 text-[#FF8A04]';
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className={`mb-6 rounded-2xl border p-4 ${toneClass}`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-current/20 bg-black/20">
+          <Icon className="h-4 w-4" aria-hidden="true" />
+        </div>
+        <div className="min-w-0">
+          <p className="text-[12px] font-bold uppercase tracking-widest">
+            {status.title}
+          </p>
+          <p className="mt-1 text-[13px] font-medium leading-snug text-white/75">
+            {status.detail}
+          </p>
+          {status.targetDate && (
+            <p className="mt-2 text-[12px] leading-snug text-white/45">
+              Target date: {status.targetDate.toLocaleDateString()}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CommitmentEarlyExitModal/gracePeriod.ts
+++ b/src/components/CommitmentEarlyExitModal/gracePeriod.ts
@@ -1,0 +1,109 @@
+export const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type GraceCountdownState = 'loading' | 'no_grace' | 'pre_grace' | 'in_grace';
+
+export interface GraceCountdownStatus {
+  state: GraceCountdownState;
+  title: string;
+  detail: string;
+  countdownLabel?: string;
+  targetDate?: Date;
+}
+
+export function normalizeGracePeriodDays(value: number | null | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor(value));
+}
+
+export function getGracePeriodStartDate(maturityDate: Date, gracePeriodDays: number): Date {
+  return new Date(maturityDate.getTime() - normalizeGracePeriodDays(gracePeriodDays) * DAY_MS);
+}
+
+export function formatGraceCountdown(msUntilTarget: number, reducedMotion = false): string {
+  const safeMs = Math.max(0, msUntilTarget);
+  if (safeMs <= 0) {
+    return 'now';
+  }
+
+  const totalSeconds = Math.ceil(safeMs / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (reducedMotion) {
+    if (days > 0) {
+      return `${days}d ${hours}h ${minutes}m`;
+    }
+    if (hours > 0) {
+      return `${hours}h ${minutes}m`;
+    }
+    return minutes > 0 ? `${minutes}m` : 'less than 1m';
+  }
+
+  if (days > 0) {
+    return `${days}d ${hours}h ${minutes}m ${seconds}s`;
+  }
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${seconds}s`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+export function getGraceCountdownStatus({
+  gracePeriodDays,
+  maturityDate,
+  now,
+  reducedMotion = false,
+}: {
+  gracePeriodDays: number | null;
+  maturityDate: Date;
+  now: Date;
+  reducedMotion?: boolean;
+}): GraceCountdownStatus {
+  if (gracePeriodDays === null) {
+    return {
+      state: 'loading',
+      title: 'Checking grace period',
+      detail: 'Loading protocol timing before calculating the early-exit grace window.',
+    };
+  }
+
+  const normalizedGraceDays = normalizeGracePeriodDays(gracePeriodDays);
+  if (normalizedGraceDays === 0) {
+    return {
+      state: 'no_grace',
+      title: 'Penalty applies now',
+      detail: 'This protocol configuration has no penalty-free grace period. Early exit uses the penalty shown below.',
+    };
+  }
+
+  const graceStartsAt = getGracePeriodStartDate(maturityDate, normalizedGraceDays);
+  if (now.getTime() >= graceStartsAt.getTime()) {
+    return {
+      state: 'in_grace',
+      title: 'Penalty-free grace period',
+      detail: `You are inside the ${normalizedGraceDays}-day grace period. Early exit is penalty-free until maturity.`,
+      targetDate: maturityDate,
+    };
+  }
+
+  const countdownLabel = formatGraceCountdown(
+    graceStartsAt.getTime() - now.getTime(),
+    reducedMotion,
+  );
+
+  return {
+    state: 'pre_grace',
+    title: 'Grace window opens in',
+    detail: `Penalty applies now. Wait ${countdownLabel} to enter the ${normalizedGraceDays}-day penalty-free grace period.`,
+    countdownLabel,
+    targetDate: graceStartsAt,
+  };
+}

--- a/src/components/create/AllocationConstraintsEditor.test.tsx
+++ b/src/components/create/AllocationConstraintsEditor.test.tsx
@@ -18,6 +18,7 @@ const mockProtocolConstants = {
     minDurationDays: 1,
     maxDurationDays: 365,
     maxLossPercentCeiling: 100,
+    earlyExitGracePeriodDays: 7,
   },
   cachedAt: new Date().toISOString(),
 }

--- a/src/lib/backend/services/protocolConstants.ts
+++ b/src/lib/backend/services/protocolConstants.ts
@@ -41,6 +41,8 @@ export interface CommitmentLimits {
   maxDurationDays: number;
   /** Maximum allowed drawdown / loss percentage (0–100). */
   maxLossPercentCeiling: number;
+  /** Number of days before maturity where early exit becomes penalty-free. */
+  earlyExitGracePeriodDays: number;
 }
 
 export interface ProtocolConstants {
@@ -68,6 +70,7 @@ const DEFAULT_MAX_AMOUNT_XLM = 1_000_000;
 const DEFAULT_MIN_DURATION_DAYS = 1;
 const DEFAULT_MAX_DURATION_DAYS = 365;
 const DEFAULT_MAX_LOSS_PERCENT_CEILING = 100;
+const DEFAULT_EARLY_EXIT_GRACE_PERIOD_DAYS = 7;
 
 const DEFAULT_PENALTY_TIERS: PenaltyTier[] = [
   {
@@ -164,6 +167,7 @@ export function getProtocolConstants(): ProtocolConstants {
       minDurationDays: envInt("COMMITLABS_MIN_DURATION_DAYS", DEFAULT_MIN_DURATION_DAYS),
       maxDurationDays: envInt("COMMITLABS_MAX_DURATION_DAYS", DEFAULT_MAX_DURATION_DAYS),
       maxLossPercentCeiling: envInt("COMMITLABS_MAX_LOSS_PERCENT_CEILING", DEFAULT_MAX_LOSS_PERCENT_CEILING),
+      earlyExitGracePeriodDays: envInt("COMMITLABS_EARLY_EXIT_GRACE_PERIOD_DAYS", DEFAULT_EARLY_EXIT_GRACE_PERIOD_DAYS),
     },
     cachedAt: new Date().toISOString(),
   };

--- a/src/utils/__tests__/protocol.test.ts
+++ b/src/utils/__tests__/protocol.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { fetchProtocolConstants, type ProtocolConstants } from '../protocol';
+import {
+  fetchProtocolConstants,
+  getEarlyExitGracePeriodDays,
+  type ProtocolConstants,
+} from '../protocol';
 
 const protocolConstantsFixture = {
   protocolVersion: '1.0.0',
@@ -27,6 +31,7 @@ const protocolConstantsFixture = {
     minDurationDays: 7,
     maxDurationDays: 365,
     maxLossPercentCeiling: 50,
+    earlyExitGracePeriodDays: 7,
   },
   cachedAt: '2026-06-27T08:00:00.000Z',
 } satisfies ProtocolConstants;
@@ -65,6 +70,7 @@ describe('fetchProtocolConstants', () => {
       minDurationDays: 7,
       maxDurationDays: 365,
       maxLossPercentCeiling: 50,
+      earlyExitGracePeriodDays: 7,
     });
   });
 
@@ -82,5 +88,16 @@ describe('fetchProtocolConstants', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith('/api/protocol/constants');
+  });
+});
+
+describe('getEarlyExitGracePeriodDays', () => {
+  it('returns the normalized grace-period constant', () => {
+    expect(getEarlyExitGracePeriodDays(protocolConstantsFixture)).toBe(7);
+  });
+
+  it('falls back to 0 when constants are unavailable', () => {
+    expect(getEarlyExitGracePeriodDays(null)).toBe(0);
+    expect(getEarlyExitGracePeriodDays(undefined)).toBe(0);
   });
 });

--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -15,6 +15,7 @@ export interface CommitmentLimits {
   minDurationDays: number;
   maxDurationDays: number;
   maxLossPercentCeiling: number;
+  earlyExitGracePeriodDays: number;
 }
 
 export interface ProtocolConstants {
@@ -32,4 +33,16 @@ export async function fetchProtocolConstants(): Promise<ProtocolConstants> {
     throw new Error(`Failed to fetch protocol constants: ${response.statusText}`);
   }
   return response.json();
+}
+
+export function getEarlyExitGracePeriodDays(
+  constants: ProtocolConstants | null | undefined,
+): number {
+  const value = constants?.commitmentLimits.earlyExitGracePeriodDays;
+
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor(value));
 }

--- a/tests/api/protocol-constants.test.ts
+++ b/tests/api/protocol-constants.test.ts
@@ -84,6 +84,7 @@ describe("GET /api/protocol/constants — response shape", () => {
     expect(typeof commitmentLimits.minDurationDays).toBe("number");
     expect(typeof commitmentLimits.maxDurationDays).toBe("number");
     expect(typeof commitmentLimits.maxLossPercentCeiling).toBe("number");
+    expect(typeof commitmentLimits.earlyExitGracePeriodDays).toBe("number");
 
     // Sanity: min < max
     expect(commitmentLimits.minAmountXlm).toBeLessThan(commitmentLimits.maxAmountXlm);
@@ -142,6 +143,14 @@ describe("GET /api/protocol/constants — default values", () => {
 
     expect(data.data.fees.platformFeePercent).toBe(0);
   });
+
+  it("should default early exit grace period to 7 days", async () => {
+    const req = createMockRequest("http://localhost:3000/api/protocol/constants");
+    const res = await GET(req, { params: {} });
+    const { data } = await parseResponse(res);
+
+    expect(data.data.commitmentLimits.earlyExitGracePeriodDays).toBe(7);
+  });
 });
 
 // ─── Environment variable overrides ──────────────────────────────────────────
@@ -165,6 +174,16 @@ describe("GET /api/protocol/constants — env overrides", () => {
     const { data } = await parseResponse(res);
 
     expect(data.data.commitmentLimits.minAmountXlm).toBe(50);
+  });
+
+  it("should respect COMMITLABS_EARLY_EXIT_GRACE_PERIOD_DAYS override", async () => {
+    vi.stubEnv("COMMITLABS_EARLY_EXIT_GRACE_PERIOD_DAYS", "5");
+
+    const req = createMockRequest("http://localhost:3000/api/protocol/constants");
+    const res = await GET(req, { params: {} });
+    const { data } = await parseResponse(res);
+
+    expect(data.data.commitmentLimits.earlyExitGracePeriodDays).toBe(5);
   });
 
   it("should respect COMMITLABS_PENALTY_TIERS_JSON override", async () => {

--- a/tests/lib/backend/protocolConstants.service.test.ts
+++ b/tests/lib/backend/protocolConstants.service.test.ts
@@ -35,6 +35,7 @@ describe("getProtocolConstants() — defaults", () => {
     expect(commitmentLimits.minDurationDays).toBe(1);
     expect(commitmentLimits.maxDurationDays).toBe(365);
     expect(commitmentLimits.maxLossPercentCeiling).toBe(100);
+    expect(commitmentLimits.earlyExitGracePeriodDays).toBe(7);
   });
 
   it("returns the 3 default penalty tiers with correct percents", () => {
@@ -88,6 +89,11 @@ describe("getProtocolConstants() — env overrides", () => {
   it("respects COMMITLABS_MAX_LOSS_PERCENT_CEILING", () => {
     vi.stubEnv("COMMITLABS_MAX_LOSS_PERCENT_CEILING", "50");
     expect(getProtocolConstants().commitmentLimits.maxLossPercentCeiling).toBe(50);
+  });
+
+  it("respects COMMITLABS_EARLY_EXIT_GRACE_PERIOD_DAYS", () => {
+    vi.stubEnv("COMMITLABS_EARLY_EXIT_GRACE_PERIOD_DAYS", "5");
+    expect(getProtocolConstants().commitmentLimits.earlyExitGracePeriodDays).toBe(5);
   });
 
   it("respects NEXT_PUBLIC_ACTIVE_CONTRACT_VERSION for protocolVersion", () => {
@@ -156,6 +162,11 @@ describe("getProtocolConstants() — invalid env values", () => {
     vi.stubEnv("COMMITLABS_MAX_AMOUNT_XLM", "");
     // parseInt("") is NaN → falls back to default
     expect(getProtocolConstants().commitmentLimits.maxAmountXlm).toBe(1_000_000);
+  });
+
+  it("falls back to default early exit grace period when env is non-numeric", () => {
+    vi.stubEnv("COMMITLABS_EARLY_EXIT_GRACE_PERIOD_DAYS", "soon");
+    expect(getProtocolConstants().commitmentLimits.earlyExitGracePeriodDays).toBe(7);
   });
 
   it("throws on malformed COMMITLABS_PENALTY_TIERS_JSON (bad JSON)", () => {


### PR DESCRIPTION
## Summary
- adds a protocol-driven early-exit grace-period constant and typed client helper
- adds an accessible grace countdown banner in the early-exit modal
- updates the timing preview so projected penalties reach zero once the grace window starts
- documents the feature and links the new guide from the existing docs index

## Verification
- `pnpm vitest run src/components/CommitmentEarlyExitModal/GraceCountdown.test.tsx src/components/CommitmentEarlyExitModal/ExitTimingPreview.test.tsx src/utils/__tests__/protocol.test.ts tests/lib/backend/protocolConstants.service.test.ts tests/api/protocol-constants.test.ts` passed, 78 tests
- `pnpm exec eslint <changed files>` passed
- `pnpm typecheck` is still blocked by pre-existing syntax errors in `src/app/commitments/overview/page.tsx`

Closes #967