### PR TITLE
feat: add benchmark overlay line to CommitmentHealthMetrics

### DIFF
--- a/src/components/dashboard/CommitmentHealthMetrics.tsx
+++ b/src/components/dashboard/CommitmentHealthMetrics.tsx
@@ -45,6 +45,11 @@ export interface TimeSeriesPoint {
   complianceScore?: number;
 }
 
+export interface BenchmarkPoint {
+  date: string;
+  benchmarkValue: number;
+}
+
 type TabType = "value" | "drawdown" | "fee" | "compliance";
 
 const tabIcons: Record<TabType, React.ReactNode> = {
@@ -90,6 +95,10 @@ interface CommitmentHealthMetricsProps {
   thresholdPercent?: number;
   volatilityPercent?: number;
   isLoading?: boolean;
+  /** Optional benchmark series for the value-history chart (e.g. portfolio average). */
+  benchmarkData?: BenchmarkPoint[];
+  /** Label for the benchmark overlay line. */
+  benchmarkLabel?: string;
 }
 
 export default function CommitmentHealthMetrics({
@@ -101,9 +110,12 @@ export default function CommitmentHealthMetrics({
   thresholdPercent,
   volatilityPercent,
   isLoading = false,
+  benchmarkData,
+  benchmarkLabel = "Portfolio Average",
 }: CommitmentHealthMetricsProps) {
   const [activeTab, setActiveTab] = useState<TabType>("value");
   const { selectedRange, setRange, filterByRange } = useHealthMetricsRange();
+  const [showBenchmark, setShowBenchmark] = useState(true);
 
   const valueChartRef = useRef<HTMLDivElement>(null);
   const drawdownChartRef = useRef<HTMLDivElement>(null);
@@ -137,6 +149,8 @@ export default function CommitmentHealthMetrics({
     feeGenerationData,
   };
 
+  const hasBenchmark = benchmarkData && benchmarkData.length > 0;
+
   return (
     <div className="w-full bg-[#0a0a0a] rounded-2xl p-6 border border-[#222]">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
@@ -144,6 +158,24 @@ export default function CommitmentHealthMetrics({
 
         <div className="flex flex-col sm:flex-row sm:items-center gap-3">
           <HealthMetricsRangeSelector selected={selectedRange} onChange={setRange} />
+
+          {/* Benchmark toggle — only shown on value tab when benchmark data is available */}
+          {activeTab === "value" && hasBenchmark && (
+            <button
+              type="button"
+              aria-pressed={showBenchmark}
+              onClick={() => setShowBenchmark((v) => !v)}
+              className={cn(
+                "flex items-center gap-2 px-3 py-1.5 text-xs font-medium rounded-md border transition-colors",
+                showBenchmark
+                  ? "bg-[#f5a623]/10 border-[#f5a623]/40 text-[#f5a623]"
+                  : "bg-transparent border-[#333] text-[#8892a0] hover:border-[#555]"
+              )}
+            >
+              <span className="w-2 h-2 rounded-full bg-[#f5a623]" aria-hidden="true" />
+              {showBenchmark ? "Hide" : "Show"} {benchmarkLabel}
+            </button>
+          )}
 
           <div className="flex flex-wrap gap-2 p-1 bg-[#111] rounded-lg border border-[#222]">
             {TABS.map((tab) => (
@@ -183,6 +215,8 @@ export default function CommitmentHealthMetrics({
               <HealthMetricsValueHistoryChart
                 data={filteredValueHistory as Array<{ date: string; currentValue: number; initialAmount?: number }>}
                 volatilityPercent={volatilityPercent}
+                benchmarkData={showBenchmark && hasBenchmark ? benchmarkData : undefined}
+                benchmarkLabel={benchmarkLabel}
               />
             )}
           </div>

--- a/src/components/dashboard/HealthMetricsValueHistoryChart.tsx
+++ b/src/components/dashboard/HealthMetricsValueHistoryChart.tsx
@@ -18,6 +18,10 @@ import { useReducedMotion } from '@/lib/a11y/useReducedMotion';
 interface HealthMetricsValueHistoryChartProps {
     data: Array<{ date: string; currentValue: number; initialAmount?: number }>;
     volatilityPercent?: number;
+    /** Optional benchmark series keyed by date. Values merged onto the data points. */
+    benchmarkData?: Array<{ date: string; benchmarkValue: number }>;
+    /** Label shown in legend and tooltip for the benchmark line. */
+    benchmarkLabel?: string;
 }
 
 interface TooltipPayload {
@@ -38,8 +42,8 @@ const CustomTooltip = ({ active, payload, label }: TooltipPayload) => {
                 <p className="text-[#99a1af] text-sm mb-2">{label}</p>
                 {payload.map((entry, index) => (
                     <div key={index} className="flex items-center gap-2 mb-1 last:mb-0">
-                        <div 
-                            className="w-2 h-2 rounded-full" 
+                        <div
+                            className="w-2 h-2 rounded-full"
                             style={{ backgroundColor: entry.color }}
                         />
                         <span className="text-gray-300 text-sm font-medium">
@@ -56,14 +60,32 @@ const CustomTooltip = ({ active, payload, label }: TooltipPayload) => {
 export const HealthMetricsValueHistoryChart: React.FC<HealthMetricsValueHistoryChartProps> = ({
     data,
     volatilityPercent,
+    benchmarkData,
+    benchmarkLabel = 'Benchmark',
 }) => {
     const reducedMotion = useReducedMotion();
+
+    // Merge benchmark values by date so Recharts can render them on the same chart.
+    const hasBenchmark = benchmarkData && benchmarkData.length > 0;
+    const benchmarkByDate = React.useMemo(() => {
+        if (!hasBenchmark) return {};
+        return Object.fromEntries(benchmarkData!.map((p) => [p.date, p.benchmarkValue]));
+    }, [benchmarkData, hasBenchmark]);
+
+    const mergedData = React.useMemo(() => {
+        if (!hasBenchmark) return data;
+        return data.map((point) => ({
+            ...point,
+            benchmarkValue: benchmarkByDate[point.date] ?? null,
+        }));
+    }, [data, hasBenchmark, benchmarkByDate]);
+
     return (
         <>
             <div className="w-full h-full min-h-[350px] bg-[#111] rounded-xl p-4 sm:p-6 border border-[#222] shadow-sm">
                 <ResponsiveContainer width="100%" height={300}>
                     <LineChart
-                        data={data}
+                        data={mergedData}
                         margin={{ top: 10, right: 10, left: -10, bottom: 0 }}
                     >
                         <CartesianGrid
@@ -91,19 +113,21 @@ export const HealthMetricsValueHistoryChart: React.FC<HealthMetricsValueHistoryC
                             verticalAlign="bottom"
                             height={36}
                             content={() => (
-                                <div className="flex items-center justify-center gap-6 mt-4">
+                                <div className="flex items-center justify-center gap-6 mt-4 flex-wrap">
                                     <div className="flex items-center gap-2">
                                         <div className="w-3 h-3 rounded-full bg-[#0ff0fc]" />
-                                        <span className="text-[#0ff0fc] text-sm">
-                                            Current Value
-                                        </span>
+                                        <span className="text-[#0ff0fc] text-sm">Current Value</span>
                                     </div>
                                     <div className="flex items-center gap-2">
                                         <div className="w-3 h-3 rounded-full border-2 border-[#666] border-dashed" />
-                                        <span className="text-[#8892a0] text-sm">
-                                            Initial Amount
-                                        </span>
+                                        <span className="text-[#8892a0] text-sm">Initial Amount</span>
                                     </div>
+                                    {hasBenchmark && (
+                                        <div className="flex items-center gap-2" aria-label={`${benchmarkLabel} overlay`}>
+                                            <div className="w-3 h-3 rounded-full bg-[#f5a623]" />
+                                            <span className="text-[#f5a623] text-sm">{benchmarkLabel}</span>
+                                        </div>
+                                    )}
                                 </div>
                             )}
                         />
@@ -130,11 +154,27 @@ export const HealthMetricsValueHistoryChart: React.FC<HealthMetricsValueHistoryC
                             activeDot={{ r: 6, fill: '#0ff0fc', stroke: '#111', strokeWidth: 2 }}
                             isAnimationActive={!reducedMotion}
                         />
+                        {/* Benchmark overlay line — only rendered when data is provided */}
+                        {hasBenchmark && (
+                            <Line
+                                type="monotone"
+                                dataKey="benchmarkValue"
+                                name={benchmarkLabel}
+                                stroke="#f5a623"
+                                strokeWidth={2}
+                                strokeDasharray="4 2"
+                                dot={false}
+                                activeDot={{ r: 5, fill: '#f5a623', stroke: '#111', strokeWidth: 2 }}
+                                isAnimationActive={!reducedMotion}
+                                connectNulls
+                            />
+                        )}
                     </LineChart>
                 </ResponsiveContainer>
                 <div className="mt-4 pt-4 border-t border-[#222]">
                     <p className="text-[#99a1af] text-sm leading-relaxed text-center sm:text-left">
                         Track how your commitment value has changed over time compared to the initial amount.
+                        {hasBenchmark && ` The ${benchmarkLabel} overlay provides a reference for comparison.`}
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #940

- Added `benchmarkData` and `benchmarkLabel` props to `CommitmentHealthMetrics`
- `HealthMetricsValueHistoryChart` merges benchmark points by date and renders a dashed overlay line in amber
- Toggle button on the value tab shows/hides the benchmark line (`aria-pressed` for accessibility)
- Benchmark is hidden when no data is supplied or when not on the value tab