### PR TITLE
feat: add lifecycle-event chart annotations to HealthMetrics charts

### DIFF
--- a/src/components/dashboard/CommitmentHealthMetrics.tsx
+++ b/src/components/dashboard/CommitmentHealthMetrics.tsx
@@ -90,6 +90,8 @@ interface CommitmentHealthMetricsProps {
   thresholdPercent?: number;
   volatilityPercent?: number;
   isLoading?: boolean;
+  /** Lifecycle event annotations passed through to both value-history and drawdown charts. */
+  lifecycleEvents?: import('./HealthMetricsDrawdownChart').LifecycleEvent[];
 }
 
 export default function CommitmentHealthMetrics({
@@ -101,6 +103,7 @@ export default function CommitmentHealthMetrics({
   thresholdPercent,
   volatilityPercent,
   isLoading = false,
+  lifecycleEvents,
 }: CommitmentHealthMetricsProps) {
   const [activeTab, setActiveTab] = useState<TabType>("value");
   const { selectedRange, setRange, filterByRange } = useHealthMetricsRange();
@@ -183,6 +186,7 @@ export default function CommitmentHealthMetrics({
               <HealthMetricsValueHistoryChart
                 data={filteredValueHistory as Array<{ date: string; currentValue: number; initialAmount?: number }>}
                 volatilityPercent={volatilityPercent}
+                lifecycleEvents={lifecycleEvents}
               />
             )}
           </div>
@@ -204,6 +208,7 @@ export default function CommitmentHealthMetrics({
                 data={filteredDrawdownHistory as Array<{ date: string; drawdownPercent: number }>}
                 thresholdPercent={thresholdPercent}
                 volatilityPercent={volatilityPercent}
+                lifecycleEvents={lifecycleEvents}
               />
             )}
           </div>

--- a/src/components/dashboard/HealthMetricsDrawdownChart.tsx
+++ b/src/components/dashboard/HealthMetricsDrawdownChart.tsx
@@ -14,10 +14,21 @@ import {
 } from 'recharts';
 import VolatilityExposureMeter from '../VolatilityExposureMeter/VolatilityExposureMeter';
 
+export interface LifecycleEvent {
+    /** Date string matching a point in the chart data (e.g. "2024-01"). */
+    date: string;
+    /** Short label shown on the annotation line (e.g. "Inception", "Rebalance"). */
+    label: string;
+    /** Optional colour override. Defaults to amber (#F59E0B). */
+    color?: string;
+}
+
 interface HealthMetricsDrawdownChartProps {
     data: Array<{ date: string; drawdownPercent: number }>;
     thresholdPercent?: number;
     volatilityPercent?: number;
+    /** Vertical annotation lines for lifecycle events (inception, rebalances, etc.). */
+    lifecycleEvents?: LifecycleEvent[];
 }
 
 interface TooltipPayload {
@@ -47,6 +58,7 @@ export const HealthMetricsDrawdownChart: React.FC<HealthMetricsDrawdownChartProp
     data,
     thresholdPercent,
     volatilityPercent,
+    lifecycleEvents = [],
 }) => {
     return (
         <>
@@ -105,6 +117,21 @@ export const HealthMetricsDrawdownChart: React.FC<HealthMetricsDrawdownChartProp
                                 opacity={0.6}
                             />
                         )}
+                        {lifecycleEvents.map((ev) => (
+                            <ReferenceLine
+                                key={ev.date}
+                                x={ev.date}
+                                stroke={ev.color ?? '#F59E0B'}
+                                strokeWidth={1.5}
+                                strokeDasharray="4 3"
+                                label={{
+                                    value: ev.label,
+                                    position: 'top',
+                                    fill: ev.color ?? '#F59E0B',
+                                    fontSize: 10,
+                                }}
+                            />
+                        ))}
                         <Area
                             type="monotone"
                             dataKey="drawdownPercent"

--- a/src/components/dashboard/HealthMetricsValueHistoryChart.tsx
+++ b/src/components/dashboard/HealthMetricsValueHistoryChart.tsx
@@ -10,7 +10,9 @@ import {
     Tooltip,
     ResponsiveContainer,
     Legend,
+    ReferenceLine,
 } from 'recharts';
+import type { LifecycleEvent } from './HealthMetricsDrawdownChart';
 
 import VolatilityExposureMeter from '../VolatilityExposureMeter/VolatilityExposureMeter';
 import { useReducedMotion } from '@/lib/a11y/useReducedMotion';
@@ -18,6 +20,8 @@ import { useReducedMotion } from '@/lib/a11y/useReducedMotion';
 interface HealthMetricsValueHistoryChartProps {
     data: Array<{ date: string; currentValue: number; initialAmount?: number }>;
     volatilityPercent?: number;
+    /** Vertical annotation lines for lifecycle events. */
+    lifecycleEvents?: LifecycleEvent[];
 }
 
 interface TooltipPayload {
@@ -56,6 +60,7 @@ const CustomTooltip = ({ active, payload, label }: TooltipPayload) => {
 export const HealthMetricsValueHistoryChart: React.FC<HealthMetricsValueHistoryChartProps> = ({
     data,
     volatilityPercent,
+    lifecycleEvents = [],
 }) => {
     const reducedMotion = useReducedMotion();
     return (
@@ -107,6 +112,21 @@ export const HealthMetricsValueHistoryChart: React.FC<HealthMetricsValueHistoryC
                                 </div>
                             )}
                         />
+                        {lifecycleEvents.map((ev) => (
+                            <ReferenceLine
+                                key={ev.date}
+                                x={ev.date}
+                                stroke={ev.color ?? '#F59E0B'}
+                                strokeWidth={1.5}
+                                strokeDasharray="4 3"
+                                label={{
+                                    value: ev.label,
+                                    position: 'top',
+                                    fill: ev.color ?? '#F59E0B',
+                                    fontSize: 10,
+                                }}
+                            />
+                        ))}
                         {/* Initial Amount Line (Dashed) */}
                         <Line
                             type="monotone"


### PR DESCRIPTION
Fixes #941

- Added `LifecycleEvent` interface (date, label, optional color) exported from `HealthMetricsDrawdownChart`
- Both `HealthMetricsDrawdownChart` and `HealthMetricsValueHistoryChart` accept a `lifecycleEvents` prop
- Events render as vertical dashed `ReferenceLine` marks at matching dates with a label above
- `CommitmentHealthMetrics` threads the prop through to both charts