### PR TITLE
feat: add historical trend sparkline to VolatilityExposureMeter

### DIFF
--- a/src/components/VolatilityExposureMeter/VolatilityExposureMeter.tsx
+++ b/src/components/VolatilityExposureMeter/VolatilityExposureMeter.tsx
@@ -8,6 +8,11 @@ export interface VolatilityExposureMeterProps {
   valuePercent: number
   /** Optional short description of what the exposure means. */
   description?: string
+  /**
+   * Historical exposure values (0–100 each) shown as a mini sparkline trend.
+   * Should be ordered oldest → newest; at least 2 values required to render.
+   */
+  historyData?: number[]
 }
 
 function clamp(value: number): number {
@@ -21,14 +26,55 @@ function exposureLevel(percent: number): 'low' | 'medium' | 'high' {
   return 'high'
 }
 
+interface SparklineProps {
+  data: number[]
+}
+
+function TrendSparkline({ data }: SparklineProps) {
+  const W = 80
+  const H = 24
+  const min = Math.min(...data)
+  const max = Math.max(...data)
+  const range = max - min || 1
+  const pts = data
+    .map((v, i) => {
+      const x = (i / (data.length - 1)) * W
+      const y = H - ((v - min) / range) * H
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(' ')
+  const trend = data[data.length - 1] >= data[0]
+  const stroke = trend ? '#ef4444' : '#22c55e' // higher volatility = red; lower = green
+  return (
+    <svg
+      width={W}
+      height={H}
+      viewBox={`0 0 ${W} ${H}`}
+      aria-hidden="true"
+      style={{ overflow: 'visible' }}
+    >
+      <polyline
+        points={pts}
+        fill="none"
+        stroke={stroke}
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
 export default function VolatilityExposureMeter({
   valuePercent,
   description,
+  historyData,
 }: VolatilityExposureMeterProps) {
   const percent = clamp(valuePercent)
   const level = exposureLevel(percent)
   const ariaLabel = `Volatility exposure: ${percent}%, ${level} range.`
   const reducedMotion = useReducedMotion()
+  const hasHistory = historyData && historyData.length >= 2
 
   return (
     <section
@@ -40,7 +86,12 @@ export default function VolatilityExposureMeter({
         <h2 id="volatility-exposure-title" className={styles.title}>
           Volatility Exposure
         </h2>
-        <span className={styles.percentLabel}>{Math.round(percent)}%</span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          {hasHistory && !reducedMotion && (
+            <TrendSparkline data={historyData!} />
+          )}
+          <span className={styles.percentLabel}>{Math.round(percent)}%</span>
+        </div>
       </div>
 
       <div
@@ -56,11 +107,10 @@ export default function VolatilityExposureMeter({
           className={styles.barMask}
           style={{
             width: `${percent}%`,
-            // Honor the motion policy: live updates still apply, just without animation.
             transition: reducedMotion ? 'none' : undefined,
           }}
         >
-             <div className={styles.barGradient} />
+          <div className={styles.barGradient} />
         </div>
       </div>
 


### PR DESCRIPTION
Fixes #944

- Added `historyData?: number[]` prop (ordered oldest→newest, 0–100 range)
- When ≥2 values are provided a mini `TrendSparkline` SVG is rendered beside the percentage label
- Sparkline is red when trend is rising (higher volatility) and green when falling
- Hidden when user prefers reduced motion (`useReducedMotion`)