### PR TITLE
feat: add real-time dispute-status updates via SSE

### DIFF
--- a/src/components/dispute/DisputeStatusTracker.tsx
+++ b/src/components/dispute/DisputeStatusTracker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useDisputeSSE } from '@/hooks/useDisputeSSE';
 
 export type DisputeStage = 'filed' | 'under_review' | 'resolved';
 export type DisputeResolution =
@@ -19,6 +20,11 @@ export interface DisputeInfo {
 
 interface DisputeStatusTrackerProps {
   dispute: DisputeInfo | null;
+  /**
+   * When provided, the component subscribes to /api/events?commitmentId=<id>
+   * via SSE and live-updates the displayed dispute status.
+   */
+  commitmentId?: string;
 }
 
 const STAGE_INDEX: Record<DisputeStage, number> = {
@@ -99,7 +105,12 @@ function StepIndicator({ state }: StepIndicatorProps) {
   );
 }
 
-export default function DisputeStatusTracker({ dispute }: DisputeStatusTrackerProps) {
+export default function DisputeStatusTracker({ dispute: initialDispute, commitmentId }: DisputeStatusTrackerProps) {
+  const { dispute, connected, error } = useDisputeSSE({
+    commitmentId: commitmentId ?? '',
+    initialDispute,
+  });
+
   if (!dispute) return null;
 
   const currentIndex = STAGE_INDEX[dispute.stage];
@@ -129,12 +140,28 @@ export default function DisputeStatusTracker({ dispute }: DisputeStatusTrackerPr
       aria-labelledby="dispute-tracker-heading"
       className="bg-[#0a0a0a] rounded-2xl p-6 border border-[#FF8A04]/20"
     >
-      <h2
-        id="dispute-tracker-heading"
-        className="text-sm font-semibold uppercase tracking-[0.18em] text-[#FF8A04] mb-6"
-      >
-        Dispute Status
-      </h2>
+      <div className="flex items-center justify-between mb-6">
+        <h2
+          id="dispute-tracker-heading"
+          className="text-sm font-semibold uppercase tracking-[0.18em] text-[#FF8A04]"
+        >
+          Dispute Status
+        </h2>
+        {commitmentId && (
+          <span
+            className={`text-xs px-2 py-0.5 rounded-full border ${
+              error
+                ? 'border-red-500/30 text-red-400'
+                : connected
+                  ? 'border-green-500/30 text-green-400'
+                  : 'border-[#333] text-[#99a1af]'
+            }`}
+            aria-live="polite"
+          >
+            {error ? 'Reconnecting…' : connected ? 'Live' : 'Connecting…'}
+          </span>
+        )}
+      </div>
 
       <ol className="flex items-start" aria-label="Dispute lifecycle steps">
         {steps.map((step, index) => {

--- a/src/hooks/useDisputeSSE.ts
+++ b/src/hooks/useDisputeSSE.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { DisputeInfo } from '@/components/dispute/DisputeStatusTracker';
+
+interface UseDisputeSSEOptions {
+  commitmentId: string;
+  initialDispute: DisputeInfo | null;
+  /** Override the SSE endpoint (defaults to /api/events?commitmentId=<id>). */
+  endpoint?: string;
+}
+
+interface UseDisputeSSEResult {
+  dispute: DisputeInfo | null;
+  connected: boolean;
+  error: string | null;
+}
+
+/**
+ * Subscribes to the server-sent events (SSE) endpoint for dispute-status updates.
+ * Falls back gracefully when EventSource is unavailable (SSR, old browsers).
+ */
+export function useDisputeSSE({
+  commitmentId,
+  initialDispute,
+  endpoint,
+}: UseDisputeSSEOptions): UseDisputeSSEResult {
+  const [dispute, setDispute] = useState<DisputeInfo | null>(initialDispute);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (typeof EventSource === 'undefined') return;
+
+    const url = endpoint ?? `/api/events?commitmentId=${encodeURIComponent(commitmentId)}`;
+    const es = new EventSource(url);
+    esRef.current = es;
+
+    es.addEventListener('open', () => {
+      setConnected(true);
+      setError(null);
+    });
+
+    es.addEventListener('dispute_update', (event: MessageEvent) => {
+      try {
+        const updated: DisputeInfo = JSON.parse(event.data);
+        setDispute(updated);
+      } catch {
+        // ignore malformed events
+      }
+    });
+
+    es.addEventListener('error', () => {
+      setConnected(false);
+      setError('Connection lost. Retrying…');
+    });
+
+    return () => {
+      es.close();
+      esRef.current = null;
+      setConnected(false);
+    };
+  }, [commitmentId, endpoint]);
+
+  return { dispute, connected, error };
+}


### PR DESCRIPTION
Fixes #948

- New `useDisputeSSE` hook in `src/hooks/useDisputeSSE.ts`
  - Connects to `/api/events?commitmentId=${id}` using `EventSource`
  - Listens for `dispute_update` events and parses the JSON payload into `DisputeInfo`
  - Exposes `dispute`, `connected`, and `error` state
  - Gracefully no-ops when `EventSource` is unavailable (SSR / old browsers)
- `DisputeStatusTracker` accepts new optional `commitmentId` prop
  - When set, the component subscribes via the hook and displays a 'Live' / 'Connecting…' / 'Reconnecting…' badge