### PR TITLE
feat: add compare-commitments tray to MyCommitmentsGrid

### DIFF
--- a/src/components/CompareCommitmentsTray.tsx
+++ b/src/components/CompareCommitmentsTray.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import type { Commitment } from '@/types/commitment';
+
+interface CompareCommitmentsTrayProps {
+  selected: Commitment[];
+  onRemove: (id: string) => void;
+  onClear: () => void;
+}
+
+const MAX_COMPARE = 3;
+
+export function CompareCommitmentsTray({
+  selected,
+  onRemove,
+  onClear,
+}: CompareCommitmentsTrayProps) {
+  if (selected.length === 0) return null;
+
+  const compareHref = `/marketplace/compare?ids=${selected.map((c) => c.id).join(',')}`;
+
+  return (
+    <div
+      role="complementary"
+      aria-label="Compare tray"
+      className="fixed bottom-0 left-0 right-0 z-50 border-t border-[#222] bg-[#0a0a0a]/95 backdrop-blur px-4 py-3 shadow-2xl"
+    >
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-4">
+        <div className="flex items-center gap-3 flex-wrap">
+          <span className="text-xs font-semibold text-[#99a1af] shrink-0">
+            Compare ({selected.length}/{MAX_COMPARE}):
+          </span>
+          {selected.map((c) => (
+            <span
+              key={c.id}
+              className="flex items-center gap-1.5 rounded-lg bg-[#1a1a1a] border border-[#333] px-3 py-1 text-xs text-white"
+            >
+              #{String(c.id).padStart(3, '0')}
+              <button
+                type="button"
+                onClick={() => onRemove(c.id)}
+                aria-label={`Remove commitment #${c.id} from compare`}
+                className="text-[#99a1af] hover:text-white focus:outline-none"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-3 shrink-0">
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-xs text-[#99a1af] hover:text-white focus:outline-none focus:underline"
+          >
+            Clear all
+          </button>
+          <Link
+            href={compareHref}
+            className={`rounded-lg px-4 py-2 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-[#51A2FF] ${
+              selected.length < 2
+                ? 'pointer-events-none bg-[#1a1a1a] text-[#555] border border-[#333]'
+                : 'bg-[#51A2FF] text-black hover:bg-[#3d8ee8]'
+            }`}
+            aria-disabled={selected.length < 2}
+          >
+            Compare {selected.length >= 2 ? `(${selected.length})` : '—'}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+CompareCommitmentsTray.MAX = MAX_COMPARE;

--- a/src/components/MyCommitmentsGrid.tsx
+++ b/src/components/MyCommitmentsGrid.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import MyCommitmentCard from './MyCommitmentCard';
 import { Commitment } from '@/types/commitment';
 import { EmptyState } from '@/components/ui/EmptyState';
+import { CompareCommitmentsTray } from './CompareCommitmentsTray';
 
 interface MyCommitmentsGridProps {
   commitments: Commitment[];
@@ -20,34 +21,72 @@ const MyCommitmentsGrid: React.FC<MyCommitmentsGridProps> = ({
   onEarlyExit,
   onListForSale,
 }) => {
+  const [compareIds, setCompareIds] = useState<Set<string>>(new Set());
+
+  const toggleCompare = (id: string) => {
+    setCompareIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else if (next.size < CompareCommitmentsTray.MAX) {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const selectedCommitments = commitments.filter((c) => compareIds.has(c.id));
+
   return (
-    <div className="flex flex-col gap-4">
-      <div className="text-[14px] text-[#94A3B8]">
-        <span className="text-[16px] font-semibold text-white">{commitments.length}</span>{' '}
-        commitments found
-      </div>
-      
-      {commitments.length > 0 ? (
-        <div className="grid grid-cols-3 gap-6 max-[1200px]:grid-cols-2 max-[768px]:grid-cols-1">
-          {commitments.map((commitment) => (
-            <MyCommitmentCard
-              key={commitment.id}
-              commitment={commitment}
-              onDetails={onDetails}
-              onAttestations={onAttestations}
-              onEarlyExit={onEarlyExit}
-              onListForSale={onListForSale}
-            />
-          ))}
+    <>
+      <div className="flex flex-col gap-4">
+        <div className="text-[14px] text-[#94A3B8]">
+          <span className="text-[16px] font-semibold text-white">{commitments.length}</span>{' '}
+          commitments found
         </div>
-      ) : (
-        <EmptyState
-          title="No commitments found"
-          description="No commitments found matching your filters."
-          cta={{ label: 'Create your first commitment', href: '/create' }}
-        />
-      )}
-    </div>
+
+        {commitments.length > 0 ? (
+          <div className="grid grid-cols-3 gap-6 max-[1200px]:grid-cols-2 max-[768px]:grid-cols-1">
+            {commitments.map((commitment) => (
+              <div key={commitment.id} className="relative">
+                <MyCommitmentCard
+                  commitment={commitment}
+                  onDetails={onDetails}
+                  onAttestations={onAttestations}
+                  onEarlyExit={onEarlyExit}
+                  onListForSale={onListForSale}
+                />
+                <button
+                  type="button"
+                  onClick={() => toggleCompare(commitment.id)}
+                  aria-pressed={compareIds.has(commitment.id)}
+                  aria-label={`${compareIds.has(commitment.id) ? 'Remove from' : 'Add to'} compare`}
+                  className={`absolute top-3 left-3 rounded-md border px-2 py-0.5 text-[10px] font-semibold transition-colors focus:outline-none focus:ring-1 focus:ring-[#51A2FF] ${
+                    compareIds.has(commitment.id)
+                      ? 'border-[#51A2FF] bg-[#51A2FF]/20 text-[#51A2FF]'
+                      : 'border-[#333] bg-[#1a1a1a] text-[#99a1af] hover:border-[#51A2FF]/50 hover:text-white'
+                  }`}
+                >
+                  {compareIds.has(commitment.id) ? '✓ Comparing' : '+ Compare'}
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <EmptyState
+            title="No commitments found"
+            description="No commitments found matching your filters."
+            cta={{ label: 'Create your first commitment', href: '/create' }}
+          />
+        )}
+      </div>
+
+      <CompareCommitmentsTray
+        selected={selectedCommitments}
+        onRemove={(id) => toggleCompare(id)}
+        onClear={() => setCompareIds(new Set())}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
Fixes #969

- New `CompareCommitmentsTray` fixed bottom bar: shows selected items with remove buttons, 'Clear all', and a 'Compare (N)' link (disabled until ≥2 selected)
- `MyCommitmentsGrid` gains per-card '+ Compare' toggle buttons (max 3 items)
- Compare link targets `/marketplace/compare?ids=id1,id2,...`
- Tray is `role="complementary"` with `aria-label`; toggle buttons use `aria-pressed`