### PR TITLE
feat: add commitment share link action

### DIFF
--- a/docs/SHARE_LINK.md
+++ b/docs/SHARE_LINK.md
@@ -1,0 +1,15 @@
+# Commitment Share Link
+
+Commitment detail pages expose a share action in `src/components/Commitmentdetailheader.tsx`.
+
+The share action uses `src/hooks/useShareLink.ts` to build a canonical URL from the current origin and commitment id:
+
+```text
+/commitments/[id]
+```
+
+When `navigator.share` is available, the hook opens the native share sheet with the commitment title and URL. If Web Share is unavailable or fails, it falls back to `navigator.clipboard.writeText`.
+
+Success and failure messages go through the existing `ToastProvider`, so users get visible feedback and screen readers receive the toast announcement through the provider live regions. Unsupported browsers do not throw; they show an error toast if neither Web Share nor clipboard copy succeeds.
+
+The share button remains a native button with a visible `focus-visible` ring for keyboard users.

--- a/src/app/commitments/[id]/page.tsx
+++ b/src/app/commitments/[id]/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import React, { useCallback, useRef, useState } from 'react';
-import Link from 'next/link';
-import { notFound } from 'next/navigation';
+import { notFound, useRouter } from 'next/navigation';
+import CommitmentDetailHeader from '@/components/Commitmentdetailheader';
 import CommitmentHealthMetrics from '@/components/dashboard/CommitmentHealthMetrics';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import CommitmentDetailAllocationConstraints from '@/components/CommitmentDetailAllocationConstraints';
@@ -16,6 +16,7 @@ import DisputeModal from '@/components/modals/DisputeModal';
 import DisputeStatusTracker, { type DisputeInfo } from '@/components/dispute/DisputeStatusTracker';
 import { openExplorerUrl } from '@/utils/explorerLinks';
 import { CommitmentStatusProvider, useCommitmentStatus } from '@/context/CommitmentStatusContext';
+import { useShareLink } from '@/hooks/useShareLink';
 
 // Mock Commitments
 const MOCK_COMMITMENTS: Record<
@@ -209,28 +210,11 @@ export default function CommitmentDetailPage({
             <main id="main-content" className="min-h-screen bg-[#050505] text-[#f5f5f7] p-4 sm:p-8 lg:p-12">
                 <div className="max-w-7xl mx-auto space-y-8">
                     
-                    <header className="flex flex-col gap-4">
-                        <Link
-                            href="/commitments"
-                            className="text-[#666] hover:text-[#0ff0fc] transition-colors text-sm w-fit"
-                            aria-label="Back to My Commitments"
-                        >
-                            ← Back to My Commitments
-                        </Link>
-                        <div className="flex items-center justify-between">
-                            <div>
-                                <h1 className="text-3xl sm:text-4xl font-bold bg-clip-text text-transparent bg-linear-to-b from-white to-[#99a1af]">
-                                    {commitment.type} Commitment #{commitment.id}
-                                </h1>
-                                <p className="text-[#99a1af] mt-2">
-                                    {commitment.type} Strategy
-                                </p>
-                            </div>
-                            <div className="hidden sm:block">
-                                <StatusBadge statusOverride={commitmentStatusOverride ?? undefined} />
-                            </div>
-                        </div>
-                    </header>
+                    <CommitmentDetailHeaderWithStatus
+                        commitmentId={commitment.id}
+                        commitmentType={commitment.type}
+                        statusOverride={commitmentStatusOverride ?? undefined}
+                    />
 
                     <div className="bg-[#0a0a0a] rounded-2xl p-6 border border-[#222]">
                         <CommitmentDetailParameters
@@ -333,37 +317,37 @@ export default function CommitmentDetailPage({
             </main>
         </CommitmentStatusProvider>
     );
+}
 
-function StatusBadge({ statusOverride }: { statusOverride?: string }) {
+function CommitmentDetailHeaderWithStatus({
+    commitmentId,
+    commitmentType,
+    statusOverride,
+}: {
+    commitmentId: string;
+    commitmentType: string;
+    statusOverride?: string;
+}) {
+    const router = useRouter();
     const { status, isLoading } = useCommitmentStatus();
-    if (isLoading || !status) {
-        return (
-            <span className="px-4 py-2 bg-[#1a1a1a] border border-[#222] rounded-lg text-[#99a1af] text-sm font-medium">
-                Loading...
-            </span>
-        );
-    }
-    const visibleStatus = statusOverride ?? status.status;
-    const getStatusColor = (label: string) => {
-        switch (label.toLowerCase()) {
-            case 'active':
-                return 'text-[#0ff0fc] border-[#0ff0fc]/30';
-            case 'settled':
-                return 'text-[#4ade80] border-[#4ade80]/30';
-            case 'violated':
-            case 'disputed':
-                return 'text-[#f87171] border-[#f87171]/30';
-            case 'early exit':
-            case 'under review':
-                return 'text-[#fbbf24] border-[#fbbf24]/30';
-            default:
-                return 'text-[#99a1af] border-[#222]';
-        }
-    };
+    const title = `${commitmentType} Commitment #${commitmentId}`;
+    const visibleStatus = statusOverride ?? status?.status ?? (isLoading ? 'Loading' : 'Active');
+    const { shareLink } = useShareLink({
+        commitmentId,
+        title,
+        text: `${commitmentType} commitment details on Commitlabs.`,
+    });
+
+    const statusVariant = visibleStatus.toLowerCase().replace(/\s+/g, '_');
+
     return (
-        <span className={`px-4 py-2 bg-[#1a1a1a] border rounded-lg text-sm font-medium ${getStatusColor(visibleStatus)}`}>
-            {visibleStatus}
-        </span>
+        <CommitmentDetailHeader
+            commitmentId={title}
+            statusLabel={visibleStatus}
+            statusVariant={statusVariant}
+            onBack={() => router.push('/commitments')}
+            onShare={shareLink}
+        />
     );
 }
 
@@ -398,5 +382,4 @@ function CommitmentDetailActionsUsingContext({
             previewRefreshTrigger={previewRefreshTrigger}
         />
     );
-}
 }

--- a/src/components/Commitmentdetailheader.test.tsx
+++ b/src/components/Commitmentdetailheader.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import CommitmentDetailHeader from './Commitmentdetailheader';
+
+describe('CommitmentDetailHeader', () => {
+  it('keeps the share action keyboard-focusable and wired to the handler', () => {
+    const onBack = vi.fn();
+    const onShare = vi.fn();
+
+    render(
+      <CommitmentDetailHeader
+        commitmentId="Balanced Commitment #42"
+        statusLabel="Active"
+        statusVariant="active"
+        onBack={onBack}
+        onShare={onShare}
+      />,
+    );
+
+    const shareButton = screen.getByRole('button', { name: 'Share commitment' });
+
+    fireEvent.click(shareButton);
+
+    expect(onShare).toHaveBeenCalledTimes(1);
+    expect(shareButton).toHaveClass('focus-visible:ring-2');
+    expect(screen.getByRole('heading', { name: 'Balanced Commitment #42' })).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+});

--- a/src/components/Commitmentdetailheader.tsx
+++ b/src/components/Commitmentdetailheader.tsx
@@ -8,7 +8,7 @@ interface CommitmentDetailHeaderProps {
     statusLabel: string;
     statusVariant: 'active' | 'settled' | 'violated' | 'early_exit' | string;
     onBack: () => void;
-    onShare: () => void;
+    onShare: () => void | Promise<unknown>;
 }
 
 const statusConfig = {
@@ -80,7 +80,7 @@ export default function CommitmentDetailHeader({
                 {/* Right Section: Share Button */}
                 <button
                     onClick={onShare}
-                    className="group flex items-center gap-2 px-4 py-2.5 bg-[#0a0a0a] border border-[#222] rounded-full text-[#f5f5f7] text-sm font-medium hover:border-[#0ff0fc]/40 hover:bg-[#0ff0fc]/5 hover:shadow-[0_0_20px_rgba(15,240,252,0.15)] hover:-translate-y-0.5 transition-all duration-200 focus:outline-none focus:border-[#0ff0fc]/60 focus:shadow-[0_0_24px_rgba(15,240,252,0.25)] w-full sm:w-auto justify-center sm:justify-start"
+                    className="group flex items-center gap-2 px-4 py-2.5 bg-[#0a0a0a] border border-[#222] rounded-full text-[#f5f5f7] text-sm font-medium hover:border-[#0ff0fc]/40 hover:bg-[#0ff0fc]/5 hover:shadow-[0_0_20px_rgba(15,240,252,0.15)] hover:-translate-y-0.5 transition-all duration-200 focus:outline-none focus:border-[#0ff0fc]/60 focus:shadow-[0_0_24px_rgba(15,240,252,0.25)] focus-visible:ring-2 focus-visible:ring-[#0ff0fc] focus-visible:ring-offset-2 focus-visible:ring-offset-[#050505] w-full sm:w-auto justify-center sm:justify-start"
                     aria-label="Share commitment"
                 >
                     <Share2 className="w-4 h-4 group-hover:rotate-6 transition-transform" />

--- a/src/hooks/__tests__/useShareLink.test.ts
+++ b/src/hooks/__tests__/useShareLink.test.ts
@@ -1,0 +1,113 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useShareLink } from '../useShareLink';
+
+const toast = {
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  dismiss: vi.fn(),
+  dismissAll: vi.fn(),
+};
+
+vi.mock('@/components/toast/ToastProvider', () => ({
+  useToast: () => toast,
+}));
+
+function setNavigatorShare(share?: ReturnType<typeof vi.fn>, canShare?: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, 'share', {
+    configurable: true,
+    value: share,
+  });
+  Object.defineProperty(navigator, 'canShare', {
+    configurable: true,
+    value: canShare,
+  });
+}
+
+function setClipboard(writeText?: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: writeText ? { writeText } : undefined,
+  });
+}
+
+describe('useShareLink', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, '', '/commitments/old');
+    setNavigatorShare(undefined, undefined);
+    setClipboard(undefined);
+  });
+
+  it('builds a canonical commitment URL from the current origin', () => {
+    const { result } = renderHook(() => useShareLink({ commitmentId: 'abc-123' }));
+
+    expect(result.current.shareUrl).toBe(`${window.location.origin}/commitments/abc-123`);
+  });
+
+  it('uses the Web Share API when available', async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    const canShare = vi.fn().mockReturnValue(true);
+    setNavigatorShare(share, canShare);
+
+    const { result } = renderHook(() =>
+      useShareLink({
+        commitmentId: '42',
+        title: 'Balanced Commitment #42',
+      }),
+    );
+
+    await act(async () => {
+      await expect(result.current.shareLink()).resolves.toEqual({
+        ok: true,
+        method: 'web-share',
+      });
+    });
+
+    expect(share).toHaveBeenCalledWith({
+      title: 'Balanced Commitment #42',
+      text: 'View this Commitlabs commitment.',
+      url: `${window.location.origin}/commitments/42`,
+    });
+    expect(toast.success).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Share sheet opened' }),
+    );
+  });
+
+  it('falls back to clipboard copy when Web Share is unavailable', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard(writeText);
+
+    const { result } = renderHook(() => useShareLink({ commitmentId: '99' }));
+
+    await act(async () => {
+      await expect(result.current.shareLink()).resolves.toEqual({
+        ok: true,
+        method: 'clipboard',
+      });
+    });
+
+    expect(writeText).toHaveBeenCalledWith(`${window.location.origin}/commitments/99`);
+    expect(toast.success).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Link copied' }),
+    );
+  });
+
+  it('announces failure without throwing when share and clipboard are unavailable', async () => {
+    const share = vi.fn().mockRejectedValue(new Error('blocked'));
+    setNavigatorShare(share, vi.fn().mockReturnValue(true));
+    setClipboard(vi.fn().mockRejectedValue(new Error('denied')));
+
+    const { result } = renderHook(() => useShareLink({ commitmentId: '100' }));
+
+    await act(async () => {
+      await expect(result.current.shareLink()).resolves.toEqual({ ok: false });
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Share unavailable' }),
+    );
+  });
+});

--- a/src/hooks/useShareLink.ts
+++ b/src/hooks/useShareLink.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useToast } from '@/components/toast/ToastProvider';
+
+interface UseShareLinkOptions {
+  commitmentId: string;
+  title?: string;
+  text?: string;
+}
+
+type ShareMethod = 'web-share' | 'clipboard';
+
+interface ShareResult {
+  ok: boolean;
+  method?: ShareMethod;
+}
+
+function getCommitmentShareUrl(commitmentId: string): string {
+  const path = `/commitments/${encodeURIComponent(commitmentId)}`;
+
+  if (typeof window === 'undefined') {
+    return path;
+  }
+
+  return new URL(path, window.location.origin).toString();
+}
+
+async function copyToClipboard(url: string): Promise<void> {
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+    throw new Error('Clipboard API unavailable');
+  }
+
+  await navigator.clipboard.writeText(url);
+}
+
+export function useShareLink({
+  commitmentId,
+  title,
+  text,
+}: UseShareLinkOptions) {
+  const toast = useToast();
+
+  const shareLink = useCallback(async (): Promise<ShareResult> => {
+    const url = getCommitmentShareUrl(commitmentId);
+    const shareData: ShareData = {
+      title: title ?? `Commitment ${commitmentId}`,
+      text: text ?? 'View this Commitlabs commitment.',
+      url,
+    };
+
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      try {
+        if (!navigator.canShare || navigator.canShare(shareData)) {
+          await navigator.share(shareData);
+          toast.success({
+            title: 'Share sheet opened',
+            description: 'Choose where to send this commitment link.',
+          });
+
+          return { ok: true, method: 'web-share' };
+        }
+      } catch {
+        // Fall through to clipboard so unsupported or failed share attempts still work.
+      }
+    }
+
+    try {
+      await copyToClipboard(url);
+      toast.success({
+        title: 'Link copied',
+        description: 'Commitment link copied to clipboard.',
+      });
+
+      return { ok: true, method: 'clipboard' };
+    } catch {
+      toast.error({
+        title: 'Share unavailable',
+        description: 'Could not share or copy this commitment link.',
+      });
+
+      return { ok: false };
+    }
+  }, [commitmentId, text, title, toast]);
+
+  return {
+    shareLink,
+    shareUrl: getCommitmentShareUrl(commitmentId),
+  };
+}


### PR DESCRIPTION
Closes #685

## Summary
- Adds `useShareLink` to build canonical `/commitments/[id]` links and use Web Share when available
- Falls back to clipboard copy with ToastProvider success/error feedback so unsupported browsers do not throw
- Wires the share behavior into the commitment detail header and keeps the share button keyboard-focusable with a visible focus ring
- Adds focused hook/header tests and share-link documentation

## Validation
- `../repo/node_modules/.bin/vitest run src/hooks/__tests__/useShareLink.test.ts src/components/Commitmentdetailheader.test.tsx`
- `git diff --check`

Note: `tsc --noEmit --pretty false` currently stops on an existing unrelated syntax error in `src/app/commitments/overview/page.tsx` before reaching these files.