### PR TITLE
feat: add explorerLinks helper with testnet/mainnet/futurenet selector

### DIFF
--- a/src/lib/explorerLinks.ts
+++ b/src/lib/explorerLinks.ts
@@ -1,0 +1,20 @@
+export type ExplorerNetwork = 'mainnet' | 'testnet' | 'futurenet';
+
+const BASE_URLS: Record<ExplorerNetwork, string> = {
+  mainnet: 'https://stellar.expert/explorer/public',
+  testnet: 'https://stellar.expert/explorer/testnet',
+  futurenet: 'https://stellar.expert/explorer/futurenet',
+};
+
+export function explorerLinks(network: ExplorerNetwork = 'mainnet') {
+  const base = BASE_URLS[network];
+  return {
+    network,
+    transaction: (hash: string) => `${base}/tx/${hash}`,
+    account: (address: string) => `${base}/account/${address}`,
+    contract: (contractId: string) => `${base}/contract/${contractId}`,
+    ledger: (sequence: number) => `${base}/ledger/${sequence}`,
+  };
+}
+
+export type ExplorerLinksReturnType = ReturnType<typeof explorerLinks>;


### PR DESCRIPTION
Closes #929

Adds src/lib/explorerLinks.ts: typed explorerLinks(network) factory returning URL builders for transaction, account, contract, and ledger for all three Stellar networks (mainnet, testnet, futurenet).