### PR TITLE
Add recently viewed commitments rail

### DIFF
--- a/docs/RECENTLY_VIEWED.md
+++ b/docs/RECENTLY_VIEWED.md
@@ -1,24 +1,72 @@
-# Recently viewed commitments
+# Recently-Viewed Listings Rail
 
-The My Commitments page can show a local "Recently viewed commitments" rail. It is a device-local shortcut list for commitments the current browser has opened.
+This document describes the design, architecture, and implementation of the "Recently Viewed" listings rail added to the marketplace.
 
-## Contract
+## Overview
+To improve user continuity across marketplace browsing sessions, a client-side "Recently Viewed" rail tracks which listings the user has opened details for. It displays these recently viewed items in a compact, accessible, horizontal rail above the main listings grid.
 
-- Detail pages call `recordRecentlyViewedCommitment(commitmentId)` after loading a valid commitment.
-- IDs are stored in `localStorage` under `commitlabs:recently-viewed-commitments`.
-- The list is deduplicated, newest-first, and bounded to six entries.
-- The rail receives the current user's commitment list and silently skips IDs that are no longer present.
-
-## Accessibility
-
-- The rail is a labelled `section`.
-- Entries are regular links, so tab navigation and standard browser link behavior work without custom key handling.
-- Each link has an explicit `aria-label` with the commitment id.
-
-## Usage
-
-```tsx
-<RecentlyViewedCommitments commitments={commitmentsList} />
+```
++---------------------------------------------------------------+
+|                        Marketplace Header                     |
++---------------------------------------------------------------+
+|  (R) Recently Viewed                                 [Clear]  |
+|  [<]  [ #CMT-001 ]  [ #CMT-002 ]  [ #CMT-003 ]           [>]  |
++---------------------------------------------------------------+
+|  Filters             |  Marketplace Grid                      |
+|                      |  [ Card ]  [ Card ]  [ Card ]          |
+|                      |  [ Card ]  [ Card ]  [ Card ]          |
++---------------------------------------------------------------+
 ```
 
-Use the full current-user commitment list, not the filtered search result, so recently viewed entries remain available even while the grid is filtered.
+## Architecture
+
+The feature consists of three main parts:
+1. **State Management Hook (`src/hooks/useRecentlyViewed.ts`)**: Manages the persistence, eviction, and deduplication of viewed listing IDs.
+2. **UI Component (`src/components/marketplace/RecentlyViewedRail.tsx`)**: Renders a compact scrollable list of viewed items with horizontal navigation controls.
+3. **Integration (`src/app/marketplace/page.tsx` & `src/components/MarketplaceCard.tsx`)**: Listens to detail modal openings to track views and renders the rail.
+
+---
+
+## 1. The state hook: `useRecentlyViewed`
+Located at `src/hooks/useRecentlyViewed.ts`, this hook:
+- **Persists views**: Uses `localStorage` to persist listing IDs across page refreshes and filter/sort modifications.
+- **Limits history**: Capped at `10` listings by default (`MAX_RECENT_LISTINGS`). If the cap is reached, the oldest viewed item is evicted.
+- **Deduplicates repeat views**: If a user views a listing they've already viewed, the ID is moved to the front (beginning) of the history rail, rather than creating a duplicate entry.
+- **Hydration safety**: Avoids hydration mismatch errors in Next.js by waiting until the component is mounted on the client (`isHydrated = true`) before reading or writing to `localStorage`.
+
+---
+
+## 2. The component: `RecentlyViewedRail`
+Located at `src/components/marketplace/RecentlyViewedRail.tsx`, this component:
+- **Survives filter changes**: Resolves listing metadata by mapping stored IDs against the static mock listings list. Therefore, even if the active filters hide a listing in the main grid, it remains visible in the recently viewed rail.
+- **Accessible keyboard navigation**:
+  - The scroll container is focusable via keyboard (`tabIndex={0}`) and responds to `ArrowLeft` and `ArrowRight` keystrokes.
+  - Individual cards are `<button>` elements that can be focused and clicked using `Enter`/`Space` keys. Focus states automatically scroll the focused card into view.
+- **Horizontal Scroll Controls**:
+  - Automatically checks if content overflows the view container.
+  - Dynamically displays and enables smooth-scrolling `ChevronLeft` and `ChevronRight` buttons.
+- **Integrated Details Modal**: Clicking a rail card launches the `CommitmentDetailsModal` for that listing, making it easy for users to pick up where they left off.
+- **Clear Action**: A "Clear" button empties the rail and resets the client storage.
+
+---
+
+## 3. Integration
+- **`src/components/MarketplaceCard.tsx`**: Triggers the `onView` prop inside a `useEffect` hooked to the `isModalOpen` state.
+- **`src/components/MarketplaceGrid.tsx`**: Passes the `onView` prop from the page down to each marketplace card.
+- **`src/app/marketplace/page.tsx`**: Initializes `useRecentlyViewed` and renders `<RecentlyViewedRail />` above the grid inside the main content area.
+
+---
+
+## Coverage and Tests
+Comprehensive test suites cover:
+- Hook functionality (`src/hooks/useRecentlyViewed.test.ts`):
+  - Storage restoration.
+  - Deduplication and re-ordering on repeat view.
+  - History capping and eviction.
+  - Rail clearing.
+- Component accessibility & interaction (`src/components/marketplace/RecentlyViewedRail.test.tsx`):
+  - Empty-state rendering (renders nothing).
+  - Accurate card rendering.
+  - Clear button action.
+  - Modal opening and closing on card click.
+  - Arrow key scrolling keyboard interaction.

--- a/docs/RECENTLY_VIEWED.md
+++ b/docs/RECENTLY_VIEWED.md
@@ -1,72 +1,24 @@
-# Recently-Viewed Listings Rail
+# Recently viewed commitments
 
-This document describes the design, architecture, and implementation of the "Recently Viewed" listings rail added to the marketplace.
+The My Commitments page can show a local "Recently viewed commitments" rail. It is a device-local shortcut list for commitments the current browser has opened.
 
-## Overview
-To improve user continuity across marketplace browsing sessions, a client-side "Recently Viewed" rail tracks which listings the user has opened details for. It displays these recently viewed items in a compact, accessible, horizontal rail above the main listings grid.
+## Contract
 
+- Detail pages call `recordRecentlyViewedCommitment(commitmentId)` after loading a valid commitment.
+- IDs are stored in `localStorage` under `commitlabs:recently-viewed-commitments`.
+- The list is deduplicated, newest-first, and bounded to six entries.
+- The rail receives the current user's commitment list and silently skips IDs that are no longer present.
+
+## Accessibility
+
+- The rail is a labelled `section`.
+- Entries are regular links, so tab navigation and standard browser link behavior work without custom key handling.
+- Each link has an explicit `aria-label` with the commitment id.
+
+## Usage
+
+```tsx
+<RecentlyViewedCommitments commitments={commitmentsList} />
 ```
-+---------------------------------------------------------------+
-|                        Marketplace Header                     |
-+---------------------------------------------------------------+
-|  (R) Recently Viewed                                 [Clear]  |
-|  [<]  [ #CMT-001 ]  [ #CMT-002 ]  [ #CMT-003 ]           [>]  |
-+---------------------------------------------------------------+
-|  Filters             |  Marketplace Grid                      |
-|                      |  [ Card ]  [ Card ]  [ Card ]          |
-|                      |  [ Card ]  [ Card ]  [ Card ]          |
-+---------------------------------------------------------------+
-```
 
-## Architecture
-
-The feature consists of three main parts:
-1. **State Management Hook (`src/hooks/useRecentlyViewed.ts`)**: Manages the persistence, eviction, and deduplication of viewed listing IDs.
-2. **UI Component (`src/components/marketplace/RecentlyViewedRail.tsx`)**: Renders a compact scrollable list of viewed items with horizontal navigation controls.
-3. **Integration (`src/app/marketplace/page.tsx` & `src/components/MarketplaceCard.tsx`)**: Listens to detail modal openings to track views and renders the rail.
-
----
-
-## 1. The state hook: `useRecentlyViewed`
-Located at `src/hooks/useRecentlyViewed.ts`, this hook:
-- **Persists views**: Uses `localStorage` to persist listing IDs across page refreshes and filter/sort modifications.
-- **Limits history**: Capped at `10` listings by default (`MAX_RECENT_LISTINGS`). If the cap is reached, the oldest viewed item is evicted.
-- **Deduplicates repeat views**: If a user views a listing they've already viewed, the ID is moved to the front (beginning) of the history rail, rather than creating a duplicate entry.
-- **Hydration safety**: Avoids hydration mismatch errors in Next.js by waiting until the component is mounted on the client (`isHydrated = true`) before reading or writing to `localStorage`.
-
----
-
-## 2. The component: `RecentlyViewedRail`
-Located at `src/components/marketplace/RecentlyViewedRail.tsx`, this component:
-- **Survives filter changes**: Resolves listing metadata by mapping stored IDs against the static mock listings list. Therefore, even if the active filters hide a listing in the main grid, it remains visible in the recently viewed rail.
-- **Accessible keyboard navigation**:
-  - The scroll container is focusable via keyboard (`tabIndex={0}`) and responds to `ArrowLeft` and `ArrowRight` keystrokes.
-  - Individual cards are `<button>` elements that can be focused and clicked using `Enter`/`Space` keys. Focus states automatically scroll the focused card into view.
-- **Horizontal Scroll Controls**:
-  - Automatically checks if content overflows the view container.
-  - Dynamically displays and enables smooth-scrolling `ChevronLeft` and `ChevronRight` buttons.
-- **Integrated Details Modal**: Clicking a rail card launches the `CommitmentDetailsModal` for that listing, making it easy for users to pick up where they left off.
-- **Clear Action**: A "Clear" button empties the rail and resets the client storage.
-
----
-
-## 3. Integration
-- **`src/components/MarketplaceCard.tsx`**: Triggers the `onView` prop inside a `useEffect` hooked to the `isModalOpen` state.
-- **`src/components/MarketplaceGrid.tsx`**: Passes the `onView` prop from the page down to each marketplace card.
-- **`src/app/marketplace/page.tsx`**: Initializes `useRecentlyViewed` and renders `<RecentlyViewedRail />` above the grid inside the main content area.
-
----
-
-## Coverage and Tests
-Comprehensive test suites cover:
-- Hook functionality (`src/hooks/useRecentlyViewed.test.ts`):
-  - Storage restoration.
-  - Deduplication and re-ordering on repeat view.
-  - History capping and eviction.
-  - Rail clearing.
-- Component accessibility & interaction (`src/components/marketplace/RecentlyViewedRail.test.tsx`):
-  - Empty-state rendering (renders nothing).
-  - Accurate card rendering.
-  - Clear button action.
-  - Modal opening and closing on card click.
-  - Arrow key scrolling keyboard interaction.
+Use the full current-user commitment list, not the filtered search result, so recently viewed entries remain available even while the grid is filtered.

--- a/docs/RECENTLY_VIEWED_COMMITMENTS.md
+++ b/docs/RECENTLY_VIEWED_COMMITMENTS.md
@@ -1,0 +1,21 @@
+# Recently viewed commitments
+
+The My Commitments page shows a local-only rail of recently opened commitments.
+
+## Behavior
+
+- Viewing a commitment records its id in `localStorage` under `commitlabs:recently-viewed-commitments`.
+- The list is most-recent-first, deduplicated, and capped at six ids.
+- Missing commitments are ignored, so stale local ids do not create broken cards.
+- The rail is rendered only when at least one recently viewed commitment is present in the current commitments list.
+
+## Files
+
+- `src/lib/recentlyViewedCommitments.ts` owns storage parsing, normalization, writes, and recording.
+- `src/components/RecentlyViewedCommitments.tsx` renders the horizontal rail.
+- `src/app/commitments/page.tsx` records list-card detail clicks and renders the rail.
+- `src/app/commitments/[id]/page.tsx` records direct detail-page views.
+
+## Accessibility
+
+The rail is a labelled region with keyboard-focusable links and visible focus rings.

--- a/src/app/commitments/[id]/page.tsx
+++ b/src/app/commitments/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { notFound, useRouter } from 'next/navigation';
 import CommitmentDetailHeader from '@/components/Commitmentdetailheader';
 import CommitmentHealthMetrics from '@/components/dashboard/CommitmentHealthMetrics';
@@ -18,6 +18,7 @@ import { openExplorerUrl } from '@/utils/explorerLinks';
 import { computeCommitmentExposure } from '@/utils/exposure';
 import { CommitmentStatusProvider, useCommitmentStatus } from '@/context/CommitmentStatusContext';
 import { useShareLink } from '@/hooks/useShareLink';
+import { recordRecentlyViewedCommitment } from '@/lib/recentlyViewedCommitments';
 
 // Mock Commitments
 const MOCK_COMMITMENTS: Record<
@@ -153,6 +154,10 @@ export default function CommitmentDetailPage({
     const commitmentTypeLabel = commitment.type
     const earlyExitPenaltyLabel = `${commitment.earlyExitPenaltyPercent ?? 3}%`
     const { canEarlyExit } = commitment
+
+    useEffect(() => {
+        recordRecentlyViewedCommitment(commitment.id);
+    }, [commitment.id]);
 
     const exposure = computeCommitmentExposure({
         valueHistory: MOCK_VALUE_HISTORY_DATA,

--- a/src/app/commitments/page.tsx
+++ b/src/app/commitments/page.tsx
@@ -8,6 +8,7 @@ import MyCommitmentsStats from '@/components/MyCommitmentsStats/MyCommitmentsSta
 import MyCommitmentsFilters from '@/components/MyCommitmentsFilters/MyCommitmentsFilters'
 import MyCommitmentsGrid from '@/components/MyCommitmentsGrid'
 import MyCommitmentsGridSkeleton from '@/components/MyCommitmentsGridSkeleton'
+import RecentlyViewedCommitments from '@/components/RecentlyViewedCommitments'
 import CommitmentEarlyExitModal from '@/components/CommitmentEarlyExitModal/CommitmentEarlyExitModal'
 import ExportCommitmentsModal from '@/components/export/ExportCommitmentsModal'
 import ListForSaleModal from '@/components/modals/ListForSaleModal'
@@ -16,6 +17,7 @@ import { Commitment, CommitmentStats } from '@/types/commitment'
 import { listCommitments } from '@/lib/backend/mocks/contracts'
 import { fetchProtocolConstants, ProtocolConstants } from '@/utils/protocol'
 import { getValidatedClientEnv } from '@/lib/clientEnv'
+import { recordRecentlyViewedCommitment } from '@/lib/recentlyViewedCommitments'
 import { AppShellLayout } from '@/components/shell/AppShellLayout'
 import { sortCommitments, SortOption } from '@/utils/sortCommitments'
 
@@ -256,7 +258,10 @@ export default function MyCommitments() {
   // Stable callbacks so the memoized MyCommitmentCard only re-renders when its
   // own commitment changes, not on every filter/sort that re-runs this page.
   const handleViewDetails = useCallback(
-    (id: string) => router.push(`/commitments/${id}`),
+    (id: string) => {
+      recordRecentlyViewedCommitment(id)
+      router.push(`/commitments/${id}`)
+    },
     [router]
   )
 
@@ -328,6 +333,8 @@ export default function MyCommitments() {
               avgComplianceScore={mockStats.avgComplianceScore}
               totalFeesGenerated={mockStats.totalFeesGenerated}
             />
+
+            <RecentlyViewedCommitments commitments={commitmentsList} />
 
             <MyCommitmentsFilters
               searchQuery={searchQuery}

--- a/src/components/RecentlyViewedCommitments.test.tsx
+++ b/src/components/RecentlyViewedCommitments.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, beforeEach } from 'vitest';
+import RecentlyViewedCommitments from './RecentlyViewedCommitments';
+import type { Commitment } from '@/types/commitment';
+import {
+  normalizeRecentlyViewedCommitmentIds,
+  readRecentlyViewedCommitmentIds,
+  recordRecentlyViewedCommitment,
+  RECENTLY_VIEWED_COMMITMENTS_KEY,
+} from '@/lib/recentlyViewedCommitments';
+
+const commitments = [
+  {
+    id: 'CMT-ABC123',
+    type: 'Safe',
+    status: 'Active',
+    asset: 'XLM',
+    amount: '50,000',
+    currentValue: '52,600',
+    changePercent: 5.2,
+    durationProgress: 75,
+    daysRemaining: 15,
+    complianceScore: 95,
+    maxLoss: '2%',
+    currentDrawdown: '0.8%',
+    createdDate: 'Jan 10, 2026',
+    expiryDate: 'Feb 9, 2026',
+  },
+  {
+    id: 'CMT-XYZ789',
+    type: 'Balanced',
+    status: 'Settled',
+    asset: 'USDC',
+    amount: '100,000',
+    currentValue: '112,500',
+    changePercent: 12.5,
+    durationProgress: 100,
+    daysRemaining: 0,
+    complianceScore: 88,
+    maxLoss: '8%',
+    currentDrawdown: '0%',
+    createdDate: 'Dec 15, 2025',
+    expiryDate: 'Feb 13, 2026',
+  },
+] satisfies Commitment[];
+
+function createStorage(initialValue?: string) {
+  const values = new Map<string, string>();
+  if (initialValue) {
+    values.set(RECENTLY_VIEWED_COMMITMENTS_KEY, initialValue);
+  }
+
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+}
+
+describe('recently viewed commitment helpers', () => {
+  it('normalizes ids by trimming, deduping, and bounding the list', () => {
+    expect(
+      normalizeRecentlyViewedCommitmentIds(
+        [' CMT-ABC123 ', 'CMT-ABC123', '', null, 'CMT-XYZ789', 'CMT-DEF456'],
+        2,
+      ),
+    ).toEqual(['CMT-ABC123', 'CMT-XYZ789']);
+  });
+
+  it('reads invalid storage as an empty list', () => {
+    expect(readRecentlyViewedCommitmentIds(createStorage('{bad json'))).toEqual([]);
+  });
+
+  it('records the newest id first and keeps previous ids deduped', () => {
+    const storage = createStorage(JSON.stringify(['CMT-ABC123', 'CMT-XYZ789']));
+
+    expect(recordRecentlyViewedCommitment('CMT-XYZ789', storage)).toEqual([
+      'CMT-XYZ789',
+      'CMT-ABC123',
+    ]);
+  });
+});
+
+describe('RecentlyViewedCommitments', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('does not render when there is no local history', () => {
+    const { container } = render(<RecentlyViewedCommitments commitments={commitments} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders stored commitments in recent order and skips missing ids', async () => {
+    window.localStorage.setItem(
+      RECENTLY_VIEWED_COMMITMENTS_KEY,
+      JSON.stringify(['CMT-MISSING', 'CMT-XYZ789', 'CMT-ABC123']),
+    );
+
+    render(<RecentlyViewedCommitments commitments={commitments} />);
+
+    expect(
+      await screen.findByRole('heading', { name: 'Recently viewed commitments' }),
+    ).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Open commitment CMT-XYZ789' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Open commitment CMT-ABC123' })).toBeTruthy();
+    expect(screen.queryByText('CMT-MISSING')).toBeNull();
+  });
+});

--- a/src/components/RecentlyViewedCommitments.tsx
+++ b/src/components/RecentlyViewedCommitments.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import type { Commitment } from '@/types/commitment';
+import {
+  readRecentlyViewedCommitmentIds,
+  RECENTLY_VIEWED_COMMITMENTS_KEY,
+  RECENTLY_VIEWED_COMMITMENTS_LIMIT,
+} from '@/lib/recentlyViewedCommitments';
+
+interface RecentlyViewedCommitmentsProps {
+  commitments: Commitment[];
+  maxItems?: number;
+}
+
+export default function RecentlyViewedCommitments({
+  commitments,
+  maxItems = RECENTLY_VIEWED_COMMITMENTS_LIMIT,
+}: RecentlyViewedCommitmentsProps) {
+  const [recentIds, setRecentIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    const refreshRecentIds = () => setRecentIds(readRecentlyViewedCommitmentIds());
+
+    refreshRecentIds();
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === null || event.key === RECENTLY_VIEWED_COMMITMENTS_KEY) {
+        refreshRecentIds();
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  const commitmentsById = useMemo(() => {
+    return new Map(commitments.map((commitment) => [commitment.id, commitment]));
+  }, [commitments]);
+
+  const recentCommitments = useMemo(() => {
+    return recentIds
+      .map((id) => commitmentsById.get(id))
+      .filter((commitment): commitment is Commitment => Boolean(commitment))
+      .slice(0, maxItems);
+  }, [commitmentsById, maxItems, recentIds]);
+
+  if (recentCommitments.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-labelledby="recently-viewed-commitments-title"
+      className="rounded-2xl border border-white/10 bg-white/[0.03] p-4 shadow-lg shadow-black/20"
+    >
+      <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-300">
+            Quick return
+          </p>
+          <h2
+            id="recently-viewed-commitments-title"
+            className="text-lg font-semibold text-white"
+          >
+            Recently viewed commitments
+          </h2>
+        </div>
+        <p className="text-sm text-slate-400">
+          Stored locally on this device.
+        </p>
+      </div>
+
+      <div
+        role="list"
+        aria-label="Recently viewed commitment shortcuts"
+        className="flex gap-3 overflow-x-auto pb-1"
+      >
+        {recentCommitments.map((commitment) => (
+          <div key={commitment.id} role="listitem" className="min-w-[220px]">
+            <Link
+              href={`/commitments/${encodeURIComponent(commitment.id)}`}
+              aria-label={`Open commitment ${commitment.id}`}
+              className="block rounded-xl border border-white/10 bg-[#101217] p-4 text-left transition hover:-translate-y-0.5 hover:border-blue-400/60 hover:bg-blue-500/10 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-[#050505]"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <span className="font-mono text-sm font-semibold text-white">
+                  {commitment.id}
+                </span>
+                <span className="rounded-full border border-white/10 px-2 py-0.5 text-xs text-slate-300">
+                  {commitment.status}
+                </span>
+              </div>
+              <div className="mt-3 flex items-center justify-between text-sm">
+                <span className="text-slate-400">{commitment.type}</span>
+                <span className="font-semibold text-blue-200">
+                  {commitment.currentValue} {commitment.asset}
+                </span>
+              </div>
+              <div className="mt-2 text-xs text-slate-500">
+                {commitment.daysRemaining > 0
+                  ? `${commitment.daysRemaining} days remaining`
+                  : 'Completed commitment'}
+              </div>
+            </Link>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/recentlyViewedCommitments.ts
+++ b/src/lib/recentlyViewedCommitments.ts
@@ -1,0 +1,88 @@
+const DEFAULT_LIMIT = 6;
+
+export const RECENTLY_VIEWED_COMMITMENTS_KEY = 'commitlabs:recently-viewed-commitments';
+export const RECENTLY_VIEWED_COMMITMENTS_LIMIT = DEFAULT_LIMIT;
+
+type RecentlyViewedStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
+function getBrowserStorage(): RecentlyViewedStorage | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return window.localStorage;
+}
+
+export function normalizeRecentlyViewedCommitmentIds(
+  ids: readonly unknown[],
+  limit = RECENTLY_VIEWED_COMMITMENTS_LIMIT,
+): string[] {
+  const normalized: string[] = [];
+
+  for (const id of ids) {
+    if (typeof id !== 'string') {
+      continue;
+    }
+
+    const trimmedId = id.trim();
+    if (!trimmedId || normalized.includes(trimmedId)) {
+      continue;
+    }
+
+    normalized.push(trimmedId);
+    if (normalized.length >= limit) {
+      break;
+    }
+  }
+
+  return normalized;
+}
+
+export function readRecentlyViewedCommitmentIds(
+  storage: RecentlyViewedStorage | null = getBrowserStorage(),
+): string[] {
+  if (!storage) {
+    return [];
+  }
+
+  try {
+    const rawValue = storage.getItem(RECENTLY_VIEWED_COMMITMENTS_KEY);
+    if (!rawValue) {
+      return [];
+    }
+
+    const parsedValue: unknown = JSON.parse(rawValue);
+    return Array.isArray(parsedValue)
+      ? normalizeRecentlyViewedCommitmentIds(parsedValue)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeRecentlyViewedCommitmentIds(
+  ids: readonly unknown[],
+  storage: RecentlyViewedStorage | null = getBrowserStorage(),
+): string[] {
+  const normalizedIds = normalizeRecentlyViewedCommitmentIds(ids);
+
+  if (!storage) {
+    return normalizedIds;
+  }
+
+  try {
+    storage.setItem(RECENTLY_VIEWED_COMMITMENTS_KEY, JSON.stringify(normalizedIds));
+  } catch {
+    // localStorage can be unavailable in private browsing or strict iframe contexts.
+  }
+
+  return normalizedIds;
+}
+
+export function recordRecentlyViewedCommitment(
+  commitmentId: string,
+  storage: RecentlyViewedStorage | null = getBrowserStorage(),
+): string[] {
+  const currentIds = readRecentlyViewedCommitmentIds(storage);
+  return writeRecentlyViewedCommitmentIds([commitmentId, ...currentIds], storage);
+}


### PR DESCRIPTION
Closes #968
/claim #968

Summary:
- add localStorage-backed helpers for recently viewed commitment ids
- render a keyboard-focusable recently viewed commitments rail on My Commitments
- record direct detail-page views and list-card detail navigation
- add focused unit coverage for storage normalization and rail rendering

Validation:
- Not run locally in this pass.

Notes:
- The rail is local-only and ignores stale ids that are not present in the current commitments list.
