### PR TITLE
fix: exclude localhost origins from first-party CORS in production

### DIFF
--- a/src/lib/backend/cors.test.ts
+++ b/src/lib/backend/cors.test.ts
@@ -326,4 +326,31 @@ describe('cors helper', () => {
 
         expect(response.headers.get('Vary')).toBe('Accept-Encoding, Origin');
     });
+    it('excludes localhost origins in production mode', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    Object.defineProperty(process.env, 'NODE_ENV', {
+        value: 'production',
+        writable: true,
+        configurable: true,
+    });
+
+    const policy = {
+        POST: { access: 'first-party' },
+    } satisfies CorsRoutePolicy;
+
+    const request = new NextRequest('http://localhost:3000/api/auth', {
+        method: 'POST',
+        headers: { Origin: 'http://localhost:3000' },
+    });
+
+    expect(() => enforceCorsRequestPolicy(request, policy)).toThrowError(
+        /Origin is not allowed/
+    );
+
+    Object.defineProperty(process.env, 'NODE_ENV', {
+        value: originalNodeEnv,
+        writable: true,
+        configurable: true,
+    });
+});
 });

--- a/src/lib/backend/cors.ts
+++ b/src/lib/backend/cors.ts
@@ -67,8 +67,11 @@ function getConfiguredFirstPartyOrigins(): string[] {
 
     const configuredOrigins = configured ? splitOriginList(configured) : [];
 
-    return uniqueOrigins([...DEFAULT_FIRST_PARTY_ORIGINS, ...envOrigins, ...configuredOrigins]);
-}
+    const isProduction = process.env.NODE_ENV === 'production';
+    const localhostOrigins = isProduction ? [] : DEFAULT_FIRST_PARTY_ORIGINS;
+
+    return uniqueOrigins([...localhostOrigins, ...envOrigins, ...configuredOrigins]);
+    }
 
 function getConfiguredPublicOrigins(): AllowedOrigins {
     const configured = process.env.COMMITLABS_PUBLIC_API_ORIGINS?.trim();


### PR DESCRIPTION
## Description
`getConfiguredFirstPartyOrigins` in `src/lib/backend/cors.ts` unconditionally included `http://localhost:3000` and `http://127.0.0.1:3000` in the allowed origins list, meaning production deployments treated localhost as a valid credentialed first-party origin. This fix excludes the default localhost origins when `NODE_ENV === 'production'` and adds a test asserting that a production-mode request from localhost is rejected unless explicitly configured.

Closes #1311

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the code style and standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated or added documentation where relevant
- [x] I have added unit/integration tests that prove my fix is effective
- [ ] Any new or modified logic has at least 95% test coverage
- [ ] I have ran the project linter and fixed all error diagnostics
- [x] I have verified that this change fits within the 96-hour campaign timeframe
- [ ] I have attached screenshots/videos showing the before and after states

## Visual Changes (if applicable)
No visual changes — this is a backend security fix.