### PR TITLE
Fix Trade link in marketplace list and grid view pointing to 404 route

### DIFF
--- a/src/app/marketplace/__tests__/MarketplaceRow.test.tsx
+++ b/src/app/marketplace/__tests__/MarketplaceRow.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { MarketplaceRow, type Listing } from "@/app/marketplace/page";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+    "aria-label": ariaLabel,
+    ...rest
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) =>
+    React.createElement("a", { href, className, "aria-label": ariaLabel, ...rest }, children),
+}));
+
+vi.mock("@/components/TrustBadge", () => ({
+  TrustBadge: () => <div data-testid="trust-badge" />,
+}));
+
+const mockItem: Listing = {
+  id: "123",
+  type: "Safe",
+  score: 95,
+  amount: "$50,000",
+  duration: "25 days",
+  yield: "5.2%",
+  maxLoss: "2%",
+  owner: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+  price: "$52,000",
+  forSale: true,
+  trustLevel: "verified",
+};
+
+describe("MarketplaceRow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a Trade link that resolves to the commitment details page", () => {
+    render(<MarketplaceRow item={mockItem} />);
+    const tradeLink = screen.getByRole("link", { name: "Trade" });
+    expect(tradeLink).toBeInTheDocument();
+    
+    // Test asserting the Trade action navigates somewhere that actually resolves
+    expect(tradeLink).toHaveAttribute("href", "/commitments/123");
+  });
+
+  it("renders a Details link that resolves to the commitment details page", () => {
+    render(<MarketplaceRow item={mockItem} />);
+    const detailsLink = screen.getByRole("link", { name: "Details" });
+    expect(detailsLink).toBeInTheDocument();
+    
+    expect(detailsLink).toHaveAttribute("href", "/commitments/123");
+  });
+
+  it("does not render Trade link when not for sale", () => {
+    const notForSaleItem = { ...mockItem, forSale: false };
+    render(<MarketplaceRow item={notForSaleItem} />);
+    
+    const tradeLink = screen.queryByRole("link", { name: "Trade" });
+    expect(tradeLink).not.toBeInTheDocument();
+  });
+});

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -19,7 +19,7 @@ import { RecentlyViewedRail } from '@/components/marketplace/RecentlyViewedRail'
 
 
 // Listing type for marketplace items
-interface Listing {
+export interface Listing {
   id: string
   type: 'Safe' | 'Balanced' | 'Aggressive'
   score: number
@@ -238,7 +238,7 @@ function ListTypeIcon({ type }: { type: 'Safe' | 'Balanced' | 'Aggressive' }) {
   )
 }
 
-function MarketplaceRow({ item }: { item: Listing }) {
+export function MarketplaceRow({ item }: { item: Listing }) {
   const badgeClass =
     item.type === "Safe"
       ? "bg-[#0f2a1d] text-[#00C950]"
@@ -308,14 +308,14 @@ function MarketplaceRow({ item }: { item: Listing }) {
       {/* Actions */}
       <div className="flex items-center gap-3 pt-4 sm:pt-0 border-t border-white/5 sm:border-0">
         <Link
-          href={`/commitments?id=${item.id}`}
+          href={`/commitments/${item.id}`}
           className="flex-1 sm:flex-none text-center rounded-xl border border-white/15 bg-white/5 px-6 py-3.5 sm:px-4 sm:py-2.5 text-sm font-semibold transition-colors hover:bg-white/10"
         >
           Details
         </Link>
         {item.forSale && (
           <Link
-            href={`/marketplace/trade?id=${item.id}`}
+            href={`/commitments/${item.id}`}
             className="flex-1 sm:flex-none text-center rounded-xl border border-[#0FF0FC]/40 bg-[#0FF0FC]/10 px-6 py-3.5 sm:px-4 sm:py-2.5 text-sm font-bold text-[#0FF0FC] transition-colors hover:bg-[#0FF0FC]/20"
           >
             Trade

--- a/src/components/MarketplaceCard.tsx
+++ b/src/components/MarketplaceCard.tsx
@@ -248,7 +248,7 @@ function MarketplaceCardComponent({
         : "bg-[#2b1c10] text-[#FF8904]";
 
   const resolvedTradeHref =
-    tradeHref ?? `/marketplace/trade?id=${encodeURIComponent(id)}`;
+    tradeHref ?? `/commitments/${encodeURIComponent(id)}`;
 
   async function handleTrade() {
     if (onPurchase) {

--- a/src/components/__tests__/MarketplaceCard.test.tsx
+++ b/src/components/__tests__/MarketplaceCard.test.tsx
@@ -306,7 +306,7 @@ describe("MarketplaceCard", () => {
       const link = screen.getByRole("link", { name: /Trade/ });
       expect(link).toHaveAttribute(
         "href",
-        `/marketplace/trade?id=${encodeURIComponent("abc def")}`,
+        `/commitments/${encodeURIComponent("abc def")}`,
       );
     });
 
@@ -475,7 +475,7 @@ describe("MarketplaceCard", () => {
       renderCard({ forSale: true, id: "a b&c" });
       const link = screen.getByRole("link", { name: /Trade/ });
       expect(link.getAttribute("href")).toBe(
-        `/marketplace/trade?id=${encodeURIComponent("a b&c")}`,
+        `/commitments/${encodeURIComponent("a b&c")}`,
       );
     });
   });


### PR DESCRIPTION
This PR resolves the issue where the "Trade" links in the Marketplace grid and list views were pointing to a non-existent `/marketplace/trade` route, resulting in 404 errors. 
**Changes included:**
- Updated the `MarketplaceRow` (list view) in `src/app/marketplace/page.tsx` to point the "Trade" link to the correct existing route: `/commitments/${item.id}`.
- Fixed the "Details" link in `MarketplaceRow` to correctly resolve to `/commitments/${item.id}` (previously it incorrectly pointed to `/commitments?id=${item.id}`).
- Updated the fallback `tradeHref` in `src/components/MarketplaceCard.tsx` (grid view) to also direct users to the `/commitments/${id}` page if no custom `tradeHref` is supplied.
- Exported the `MarketplaceRow` component and `Listing` interface from `page.tsx` to make them testable.
- Added a new unit test for `MarketplaceRow` (`src/app/marketplace/__tests__/MarketplaceRow.test.tsx`) to assert that the Trade and Details links navigate to routes that actually resolve.
- Updated the existing assertions in `MarketplaceCard.test.tsx` to expect the corrected default fallback URL.
Closes #1225 
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
## Checklist
- [x] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [x] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [x] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [x] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [x] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes. *(Please attach if necessary before submitting)*
## Visual Changes (if applicable)
N/A - Navigation routing fix.
## Join the Discussion