### PR TITLE
docs(openapi): add missing entries for session list and revoke-others…

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -663,6 +663,70 @@ paths:
               schema:
                 $ref: '#/components/schemas/SuccessEnvelope'
 
+  /api/auth/sessions:
+    get:
+      summary: List active sessions
+      description: Returns the list of active sessions for the authenticated user. The current session is marked with isCurrent true.
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          description: List of sessions retrieved.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          sessions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                id:
+                                  type: string
+                                userAgent:
+                                  type: string
+                                ipAddress:
+                                  type: string
+                                createdAt:
+                                  type: string
+                                  format: date-time
+                                isCurrent:
+                                  type: boolean
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /api/auth/sessions/revoke-others:
+    post:
+      summary: Revoke other sessions
+      description: Revokes all other active sessions belonging to the authenticated user, preserving only the current session.
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          description: Other sessions revoked successfully.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                          revokedCount:
+                            type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
   /api/auth/nonce:
     post:
       summary: Request auth nonce


### PR DESCRIPTION
… routes

Add path entries for two implemented but undocumented API routes:
- GET /api/auth/sessions — list active sessions
- POST /api/auth/sessions/revoke-others — revoke all other sessions

Schemas inferred directly from the route handler implementations. Both routes require cookieAuth and return the standard SuccessEnvelope.

Closes #1433 