### PR TITLE
fix(marketplace): add aria-expanded/aria-controls to mobile filter toggle

### DIFF
--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -440,6 +440,8 @@ export default function Marketplace() {
         <div className="md:hidden mb-6">
           <button
             onClick={() => setShowMobileFilters(!showMobileFilters)}
+            aria-expanded={showMobileFilters}
+            aria-controls="marketplace-filters"
             className="w-full flex items-center justify-center gap-2 py-4 bg-white/5 border border-white/10 rounded-xl hover:bg-white/10 transition-colors active:scale-[0.98]"
           >
             <span className="text-base font-semibold">{showMobileFilters ? 'Hide Filters' : 'Show Filters'}</span>
@@ -449,7 +451,7 @@ export default function Marketplace() {
         {/* Main Content: Two Columns */}
         <div className="flex flex-col gap-6 md:flex-row items-start">
           {/* Sidebar Filters */}
-          <aside className={`
+          <aside id="marketplace-filters" className={`
             md:w-[280px] lg:w-[320px] md:shrink-0 md:sticky md:top-[120px] 
             md:max-h-[calc(100vh-140px)] md:overflow-y-auto custom-scrollbar
             ${showMobileFilters ? 'block' : 'hidden md:block'}


### PR DESCRIPTION
## What
The marketplace mobile filter toggle only swapped its visible label between Show Filters and Hide Filters, so screen reader users had no way to know it is a disclosure control or which region it affects (audit finding F-03-01, WCAG 4.1.2).

- The toggle button now exposes `aria-expanded={showMobileFilters}` and `aria-controls="marketplace-filters"`.
- The filters `<aside>` gets the stable `marketplace-filters` id. It stays in the DOM when visually hidden (`hidden md:block`), so the aria-controls reference is always valid.

## Testing
Three-line change following the standard disclosure pattern; verified against the acceptance criteria by inspection. With aria-expanded bound to state, VoiceOver/NVDA announce expanded/collapsed on toggle; I could not run a screen reader in my environment, so a quick VO/NVDA pass on review is welcome.

Closes #1414
