### PR TITLE
docs: correct listing edit price error handling behavior for create A…

### DIFF
--- a/docs/RELIST_EDIT_PRICE.md
+++ b/docs/RELIST_EDIT_PRICE.md
@@ -102,7 +102,7 @@ pnpm test -- src/components/marketplace/RelistPriceEditor.test.tsx
 | Scenario | Behaviour |
 |----------|-----------|
 | Cancel API returns 4xx/5xx | Error toast with server message; price rolled back. |
-| Create API returns 4xx/5xx | Error toast with server message; price rolled back. |
+| Create API returns 4xx/5xx | Error toast with server message; listing cancelled, no new listing created (user must manually relist). |
 | Network failure | Error toast with generic message; price rolled back. |
 | Invalid input (client-side) | Inline validation error, no API call made. |
 


### PR DESCRIPTION
## Description

Corrected the error handling table in [RELIST_EDIT_PRICE.md](file:///c:/Users/USER/OneDrive/Documents/Github%20Projects/Commitlabs-Frontend/docs/RELIST_EDIT_PRICE.md) (line 105). 

Previously, the documentation stated that when the listing creation API fails (Create API returns 4xx/5xx) during the edit-price flow, the price is "rolled back." However, because the cancellation (DELETE) call completes successfully before the create (POST) is attempted, a failure at this stage actually leaves the listing cancelled with no active listing remaining (and resetting the local input text state does not restore it). 

This PR updates the table row to accurately describe this failure state: "listing cancelled, no new listing created (user must manually relist)."

Closes #1412

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [ ] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [x] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

N/A (Documentation change only)


