### PR TITLE
fix: replace dead key-counting duplicate detection in validateErrorCo…

### DIFF
--- a/src/lib/backend/errorCodes.ts
+++ b/src/lib/backend/errorCodes.ts
@@ -248,6 +248,10 @@ export function getErrorCodesByStatus(): Record<number, ErrorCodeDefinition[]> {
 
 /**
  * Validate that all error codes in the registry are unique (no duplicates).
+ * Duplicate detection checks the `.code` field on each definition value, not
+ * the object key. JavaScript object literals silently discard duplicate keys,
+ * so key-counting can never find a collision; two distinct keys that both carry
+ * the same `.code` string represent a real, detectable duplicate.
  * Call this in tests to enforce registry integrity.
  */
 export function validateErrorCodeRegistry(): {
@@ -255,12 +259,18 @@ export function validateErrorCodeRegistry(): {
   duplicates: string[];
   errors: string[];
 } {
-  const codes = Object.keys(ERROR_CODE_REGISTRY);
-  const uniqueCodes = new Set(codes);
-  const duplicates = codes.filter((code) => {
-    const count = codes.filter((c) => c === code).length;
-    return count > 1;
-  });
+  const definitions = Object.values(ERROR_CODE_REGISTRY);
+  const codeValues = definitions.map((def) => def.code);
+  const seen = new Set<string>();
+  const duplicateSet = new Set<string>();
+  for (const codeValue of codeValues) {
+    if (seen.has(codeValue)) {
+      duplicateSet.add(codeValue);
+    } else {
+      seen.add(codeValue);
+    }
+  }
+  const duplicates = [...duplicateSet];
 
   const errors: string[] = [];
 
@@ -272,37 +282,36 @@ export function validateErrorCodeRegistry(): {
   }
 
   // Check for empty code strings
-  codes.forEach((code) => {
-    if (!code || code.trim() === "") {
+  Object.values(ERROR_CODE_REGISTRY).forEach((def) => {
+    if (!def.code || def.code.trim() === "") {
       errors.push(`Empty error code found`);
     }
   });
 
   // Check for required fields in each definition
-  codes.forEach((code) => {
-    const def = ERROR_CODE_REGISTRY[code];
-    if (!def.code) errors.push(`Missing 'code' field in ${code}`);
-    if (!def.meaning) errors.push(`Missing 'meaning' field in ${code}`);
+  Object.entries(ERROR_CODE_REGISTRY).forEach(([key, def]) => {
+    if (!def.code) errors.push(`Missing 'code' field in ${key}`);
+    if (!def.meaning) errors.push(`Missing 'meaning' field in ${key}`);
     if (!def.clientHandling)
-      errors.push(`Missing 'clientHandling' field in ${code}`);
+      errors.push(`Missing 'clientHandling' field in ${key}`);
     if (def.description === undefined || def.description === null) {
-      errors.push(`Missing 'description' field in ${code}`);
+      errors.push(`Missing 'description' field in ${key}`);
     }
     if (typeof def.retriable !== "boolean") {
-      errors.push(`Invalid 'retriable' field in ${code}`);
+      errors.push(`Invalid 'retriable' field in ${key}`);
     }
     if (
       typeof def.statusCode !== "number" ||
       def.statusCode < 400 ||
       def.statusCode >= 600
     ) {
-      errors.push(`Invalid 'statusCode' in ${code}`);
+      errors.push(`Invalid 'statusCode' in ${key}`);
     }
   });
 
   return {
     valid: errors.length === 0,
-    duplicates: [...new Set(duplicates)],
+    duplicates,
     errors,
   };
 }

--- a/tests/lib/backend/errorCodes.test.ts
+++ b/tests/lib/backend/errorCodes.test.ts
@@ -49,10 +49,12 @@ describe("ERROR_CODE_REGISTRY", () => {
       });
     });
 
-    it("should not have duplicate error codes", () => {
-      const codes = Object.keys(ERROR_CODE_REGISTRY);
-      const uniqueCodes = new Set(codes);
-      expect(codes.length).toBe(uniqueCodes.size);
+    it("should have each entry's .code field match its registry key", () => {
+      // Ensures no entry's .code string silently diverges from its key, which
+      // is the form of duplication that validateErrorCodeRegistry detects.
+      Object.entries(ERROR_CODE_REGISTRY).forEach(([key, def]) => {
+        expect(def.code).toBe(key);
+      });
     });
   });
 
@@ -83,7 +85,7 @@ describe("ERROR_CODE_REGISTRY", () => {
     });
 
     it("should have meaningful descriptions for each code", () => {
-      Object.entries(ERROR_CODE_REGISTRY).forEach(([key, definition]) => {
+      Object.entries(ERROR_CODE_REGISTRY).forEach(([_key, definition]) => {
         // Description should be substantial (at least 20 characters)
         expect(definition.description.length).toBeGreaterThan(20);
 
@@ -227,6 +229,32 @@ describe("ERROR_CODE_REGISTRY", () => {
       expect(validation.errors).toHaveLength(0);
     });
 
+    it("should detect duplicate .code values when two entries share the same code string", () => {
+      // Temporarily inject a second entry whose .code field duplicates an
+      // existing one. JS object literals silently drop duplicate keys, so a
+      // genuine collision can only arise via a distinct key with a reused
+      // .code string — exactly what validateErrorCodeRegistry detects.
+      const injectedKey = "__TEST_DUPLICATE__";
+      (ERROR_CODE_REGISTRY as Record<string, (typeof ERROR_CODE_REGISTRY)[keyof typeof ERROR_CODE_REGISTRY]>)[injectedKey] = {
+        code: "BAD_REQUEST", // intentional duplicate of the real BAD_REQUEST .code
+        statusCode: 400,
+        meaning: "Test duplicate entry",
+        clientHandling: "Test",
+        retriable: false,
+        description: "Triggered only in tests to verify duplicate detection.",
+      };
+      try {
+        const validation = validateErrorCodeRegistry();
+        expect(validation.valid).toBe(false);
+        expect(validation.duplicates).toContain("BAD_REQUEST");
+        expect(
+          validation.errors.some((e) => e.includes("Duplicate error codes")),
+        ).toBe(true);
+      } finally {
+        delete (ERROR_CODE_REGISTRY as Record<string, unknown>)[injectedKey];
+      }
+    });
+
     it("should validate structure in detail", () => {
       const validation = validateErrorCodeRegistry();
 
@@ -335,7 +363,7 @@ describe("ERROR_CODE_REGISTRY", () => {
 
   describe("Documentation Completeness", () => {
     it("should have meaningful meanings for all codes", () => {
-      Object.entries(ERROR_CODE_REGISTRY).forEach(([code, def]) => {
+      Object.entries(ERROR_CODE_REGISTRY).forEach(([_code, def]) => {
         expect(def.meaning.length).toBeGreaterThan(10);
         expect(def.meaning).not.toMatch(/^[a-z]/); // Should start with capital letter
       });
@@ -372,7 +400,7 @@ describe("ERROR_CODE_REGISTRY", () => {
     });
 
     it("should have description that starts with trigger condition", () => {
-      Object.entries(ERROR_CODE_REGISTRY).forEach(([code, def]) => {
+      Object.entries(ERROR_CODE_REGISTRY).forEach(([_code, def]) => {
         expect(def.description.toLowerCase()).toMatch(
           /triggered|thrown|returned/,
         );


### PR DESCRIPTION

closes #1297 

…deRegistry

JS object literals cannot have duplicate keys, so counting how many times a key appeared in Object.keys() could never produce a count > 1. The duplicate branch was permanently unreachable dead code.

Replace with value-based detection: collect the .code string from every definition value, track seen values in a Set, and flag any value that appears more than once. Two distinct registry keys whose definitions share the same .code string are a real, detectable collision.

Tests updated:
- Replace trivially-true Object.keys length == Set.size check with a structural assertion that def.code === key for every entry.
- Add a test that injects a duplicate .code entry at runtime and asserts validateErrorCodeRegistry returns valid=false with the correct duplicate listed.

Closes #1297

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Closes # (issue number)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Please review the [Developer Guide](https://github.com/Commitlabs-Org/Commitlabs-Frontend/blob/master/DEVELOPER_GUIDE.md) before checking the items below:

- [ ] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [ ] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [ ] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

Please add screenshots, screen recordings, or GIFs showcasing the user interface changes.

## Join the Discussion

Need help or want to chat? Join our [CommitLabs Discord](https://discord.gg/WV7tdYkJk) server.
