### PR TITLE
fix(not-found): wire search to /marketplace?q= and add accessible label

### DIFF
--- a/src/app/not-found.module.css
+++ b/src/app/not-found.module.css
@@ -44,14 +44,38 @@
 
 .searchBox {
   margin-bottom: 3rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.searchLabel {
+  /* Visually hidden but accessible to screen readers */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.searchRow {
+  display: flex;
+  width: 100%;
+  max-width: 480px;
+  gap: 0;
 }
 
 .searchInput {
-  width: 100%;
-  max-width: 400px;
+  flex: 1;
   padding: 0.875rem 1.25rem;
-  border-radius: 8px;
+  border-radius: 8px 0 0 8px;
   border: 2px solid rgba(255, 255, 255, 0.3);
+  border-right: none;
   background: rgba(255, 255, 255, 0.1);
   color: white;
   font-size: 1rem;
@@ -67,6 +91,29 @@
   border-color: white;
   background: rgba(255, 255, 255, 0.15);
   box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.1);
+}
+
+.searchButton {
+  padding: 0.875rem 1.25rem;
+  border-radius: 0 8px 8px 0;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  white-space: nowrap;
+}
+
+.searchButton:hover {
+  background: rgba(255, 255, 255, 0.3);
+  border-color: white;
+}
+
+.searchButton:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.3);
 }
 
 .actions {
@@ -95,6 +142,14 @@
 
   .searchInput {
     max-width: 100%;
+  }
+
+  .searchRow {
+    width: 100%;
+  }
+
+  .searchButton {
+    padding: 0.875rem 1rem;
   }
 
   .actions {

--- a/src/app/not-found.test.tsx
+++ b/src/app/not-found.test.tsx
@@ -6,9 +6,11 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import NotFound from './not-found'
 
 const mockRouterBack = vi.fn()
+const mockRouterPush = vi.fn()
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     back: mockRouterBack,
+    push: mockRouterPush,
   }),
 }))
 
@@ -19,30 +21,55 @@ describe('404 Not Found Page (src/app/not-found.tsx)', () => {
 
   it('renders the 404 page with basic elements', () => {
     render(<NotFound />)
-    
+
     expect(screen.getByText('404')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /Page Not Found/i })).toBeInTheDocument()
     expect(screen.getByText(/doesn't exist or has been moved/i)).toBeInTheDocument()
   })
 
-  it('has a search input with placeholder', () => {
+  it('has a search input with placeholder and type=search', () => {
     render(<NotFound />)
-    
+
     const searchInput = screen.getByPlaceholderText('Search the site...')
     expect(searchInput).toBeInTheDocument()
-    expect(searchInput).toHaveAttribute('type', 'text')
+    expect(searchInput).toHaveAttribute('type', 'search')
+  })
+
+  it('has an accessible label for the search input', () => {
+    render(<NotFound />)
+
+    // getByLabelText confirms the <label> is properly associated via htmlFor
+    expect(screen.getByLabelText(/search the site/i)).toBeInTheDocument()
+  })
+
+  it('navigates to /marketplace?q= when a query is submitted', () => {
+    render(<NotFound />)
+
+    const searchInput = screen.getByLabelText(/search the site/i)
+    fireEvent.change(searchInput, { target: { value: 'escrow status' } })
+    fireEvent.submit(searchInput.closest('form')!)
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/marketplace?q=escrow%20status')
+  })
+
+  it('does not navigate when the search query is blank', () => {
+    render(<NotFound />)
+
+    fireEvent.submit(screen.getByLabelText(/search the site/i).closest('form')!)
+
+    expect(mockRouterPush).not.toHaveBeenCalled()
   })
 
   it('has a Go Home link that points to /', () => {
     render(<NotFound />)
-    
+
     const goHomeButton = screen.getByRole('link', { name: /Go Home/i })
     expect(goHomeButton).toHaveAttribute('href', '/')
   })
 
   it('calls router.back() when Go Back button is clicked', () => {
     render(<NotFound />)
-    
+
     fireEvent.click(screen.getByRole('button', { name: /Go Back/i }))
     expect(mockRouterBack).toHaveBeenCalledTimes(1)
   })

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -40,19 +40,32 @@ export default function NotFound() {
         </p>
 
         {/* Search Bar */}
-        <div className={styles.searchBox}>
-          <input
-            type="text"
-            placeholder="Search the site..."
-            className={styles.searchInput}
-            onKeyPress={(e) => {
-              if (e.key === 'Enter') {
-                // You can implement search functionality here
-                console.log('Search:', e.currentTarget.value)
-              }
-            }}
-          />
-        </div>
+        <form
+          className={styles.searchBox}
+          onSubmit={(e) => {
+            e.preventDefault()
+            const query = (e.currentTarget.elements.namedItem('q') as HTMLInputElement).value.trim()
+            if (query) {
+              router.push(`/marketplace?q=${encodeURIComponent(query)}`)
+            }
+          }}
+        >
+          <label htmlFor="not-found-search" className={styles.searchLabel}>
+            Search the site
+          </label>
+          <div className={styles.searchRow}>
+            <input
+              id="not-found-search"
+              type="search"
+              name="q"
+              placeholder="Search the site..."
+              className={styles.searchInput}
+            />
+            <button type="submit" className={styles.searchButton}>
+              Search
+            </button>
+          </div>
+        </form>
 
         {/* Action Buttons */}
         <div className={styles.actions}>

--- a/tests/not-found-page.test.tsx
+++ b/tests/not-found-page.test.tsx
@@ -8,10 +8,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import NotFound from '@/app/not-found'
 
 const routerBack = vi.fn()
+const routerPush = vi.fn()
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     back: routerBack,
+    push: routerPush,
   }),
 }))
 
@@ -30,6 +32,7 @@ vi.mock('next/link', () => ({
 describe('not found page', () => {
   beforeEach(() => {
     routerBack.mockClear()
+    routerPush.mockClear()
   })
 
   it('renders the 404 message, search input, and recovery links', () => {
@@ -56,5 +59,29 @@ describe('not found page', () => {
     fireEvent.change(search, { target: { value: 'escrow status' } })
 
     expect(search).toHaveValue('escrow status')
+  })
+
+  it('search input has an accessible label associated via htmlFor', () => {
+    render(React.createElement(NotFound))
+
+    expect(screen.getByLabelText(/search the site/i)).toBeInTheDocument()
+  })
+
+  it('navigates to /marketplace?q= on form submit with a non-empty query', () => {
+    render(React.createElement(NotFound))
+
+    const search = screen.getByLabelText(/search the site/i)
+    fireEvent.change(search, { target: { value: 'escrow status' } })
+    fireEvent.submit(search.closest('form')!)
+
+    expect(routerPush).toHaveBeenCalledWith('/marketplace?q=escrow%20status')
+  })
+
+  it('does not navigate when form is submitted with an empty query', () => {
+    render(React.createElement(NotFound))
+
+    fireEvent.submit(screen.getByLabelText(/search the site/i).closest('form')!)
+
+    expect(routerPush).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
- Replace stub div+input with a <form> that navigates to /marketplace?q= on submit; empty queries are silently ignored
- Change input type from text to search
- Add visually-hidden <label htmlFor> + id for screen reader support
- Add explicit Search submit button with joined border-radius styling
- Remove console.log stub
- Update both test files: add routerPush mock, test accessible label, test navigation and empty-query guard

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Closes # (issue number)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Please review the [Developer Guide](https://github.com/Commitlabs-Org/Commitlabs-Frontend/blob/master/DEVELOPER_GUIDE.md) before checking the items below:

- [ ] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [ ] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [ ] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

Please add screenshots, screen recordings, or GIFs showcasing the user interface changes.

## Join the Discussion

Need help or want to chat? Join our [CommitLabs Discord](https://discord.gg/WV7tdYkJk) server.

closes #1250