### PR TITLE
fix(perf): add FCP/TTFB/FID thresholds to WEB_VITALS_BUDGET

### DIFF
--- a/docs/PERFORMANCE_BUDGET.md
+++ b/docs/PERFORMANCE_BUDGET.md
@@ -20,6 +20,9 @@ Field targets use Google's "good" thresholds, encoded in `WEB_VITALS_BUDGET` in
 | **LCP** (Largest Contentful Paint) | ≤ 2500 ms | Main content rendered |
 | **INP** (Interaction to Next Paint) | ≤ 200 ms | Responsiveness to input |
 | **CLS** (Cumulative Layout Shift) | ≤ 0.1 | Visual stability |
+| **FCP** (First Contentful Paint) | ≤ 1800 ms | Time until first content is painted |
+| **TTFB** (Time to First Byte) | ≤ 800 ms | Server/network responsiveness |
+| **FID** (First Input Delay) | ≤ 100 ms | Legacy input latency (prefer INP for new work) |
 
 ### Key routes
 

--- a/src/lib/perf/__tests__/webVitals.test.ts
+++ b/src/lib/perf/__tests__/webVitals.test.ts
@@ -79,11 +79,28 @@ describe('webVitals reporter', () => {
   })
 
   it('evaluates values against the documented budget', () => {
+    // LCP
     expect(isWithinBudget('LCP', WEB_VITALS_BUDGET.LCP)).toBe(true)
     expect(isWithinBudget('LCP', WEB_VITALS_BUDGET.LCP + 1)).toBe(false)
+
+    // INP
+    expect(isWithinBudget('INP', WEB_VITALS_BUDGET.INP)).toBe(true)
+    expect(isWithinBudget('INP', WEB_VITALS_BUDGET.INP + 1)).toBe(false)
+
+    // CLS
     expect(isWithinBudget('CLS', 0.05)).toBe(true)
     expect(isWithinBudget('CLS', 0.2)).toBe(false)
-    // Metrics without a budget are treated as within budget.
-    expect(isWithinBudget('TTFB', 99999)).toBe(true)
+
+    // FCP
+    expect(isWithinBudget('FCP', WEB_VITALS_BUDGET.FCP)).toBe(true)
+    expect(isWithinBudget('FCP', WEB_VITALS_BUDGET.FCP + 1)).toBe(false)
+
+    // TTFB
+    expect(isWithinBudget('TTFB', WEB_VITALS_BUDGET.TTFB)).toBe(true)
+    expect(isWithinBudget('TTFB', WEB_VITALS_BUDGET.TTFB + 1)).toBe(false)
+
+    // FID
+    expect(isWithinBudget('FID', WEB_VITALS_BUDGET.FID)).toBe(true)
+    expect(isWithinBudget('FID', WEB_VITALS_BUDGET.FID + 1)).toBe(false)
   })
 })

--- a/src/lib/perf/webVitals.ts
+++ b/src/lib/perf/webVitals.ts
@@ -40,6 +40,12 @@ export const WEB_VITALS_BUDGET = {
   INP: 200,
   /** Cumulative Layout Shift — unitless. */
   CLS: 0.1,
+  /** First Contentful Paint — milliseconds. */
+  FCP: 1800,
+  /** Time to First Byte — milliseconds. */
+  TTFB: 800,
+  /** First Input Delay — milliseconds (legacy; prefer INP for new work). */
+  FID: 100,
 } as const
 
 export type WebVitalsSink = (record: WebVitalRecord) => void


### PR DESCRIPTION
isWithinBudget() returned true for any metric without a budget entry, silently masking FCP, TTFB, and FID regressions.

- Add FCP ≤ 1800 ms, TTFB ≤ 800 ms, FID ≤ 100 ms to WEB_VITALS_BUDGET (Google 'good' thresholds, matching the existing LCP/INP/CLS entries)
- Update docs/PERFORMANCE_BUDGET.md table with the three new rows
- Replace the misleading 'treated as within budget' test assertion with at-threshold (true) and one-over-threshold (false) checks for all six metrics

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Closes # (issue number)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Please review the [Developer Guide](https://github.com/Commitlabs-Org/Commitlabs-Frontend/blob/master/DEVELOPER_GUIDE.md) before checking the items below:

- [ ] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [ ] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [ ] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

Please add screenshots, screen recordings, or GIFs showcasing the user interface changes.

## Join the Discussion

Need help or want to chat? Join our [CommitLabs Discord](https://discord.gg/WV7tdYkJk) server.

closes #1319