### PR TITLE
fix(security): replace placeholder vulnerability contact with GitHub …

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,8 +14,8 @@ We are committed to resolving security vulnerabilities quickly and carefully. Cu
 
 We take the security of CommitLabs very seriously. If you discover a security vulnerability, please do **not** open a public issue.
 
-Instead, please report it privately to our security team via email:
-**[placeholder: security@commitlabs.com]**
+Instead, please report it privately to our security team through GitHub Security Advisories:
+[Report a vulnerability](https://github.com/Commitlabs-Org/Commitlabs-Frontend/security/advisories/new)
 
 When reporting a vulnerability, please include:
 - A detailed description of the vulnerability and its potential impact.


### PR DESCRIPTION
Close #1423 

# PR description

## Summary
Updated the vulnerability reporting guidance in SECURITY.md to replace the placeholder contact with a real, monitored reporting channel.

## What changed
- Replaced the placeholder email with a direct GitHub Security Advisories link.
- Ensured the new reporting path is a practical and publicly usable channel for private vulnerability disclosure.

## Verification
- Confirmed the GitHub Security Advisories URL resolves successfully via an HTTP request.
