### PR TITLE
fix: destructure size in StatsIcons so width/height respect the prop

### DIFF
--- a/src/components/icons/StatsIcons.tsx
+++ b/src/components/icons/StatsIcons.tsx
@@ -1,33 +1,29 @@
 import React from 'react';
 
-export const ActivityIcon: React.FC<{ size?: number; className?: string }> = () => (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+export const ActivityIcon: React.FC<{ size?: number; className?: string }> = ({ size = 24, className }) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
         <path d="M21.9942 6.99805L13.4967 15.4956L8.49812 10.497L2 16.9952" stroke="#0FF0FC" stroke-width="1.99942" stroke-linecap="round" stroke-linejoin="round" />
         <path d="M15.9961 6.99805H21.9944V12.9963" stroke="#0FF0FC" stroke-width="1.99942" stroke-linecap="round" stroke-linejoin="round" />
     </svg>
-
 );
 
-export const DollarIcon: React.FC<{ size?: number; className?: string }> = () => (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+export const DollarIcon: React.FC<{ size?: number; className?: string }> = ({ size = 24, className }) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
         <path d="M11.9961 1.99951V21.9937" stroke="#05DF72" stroke-width="1.99942" stroke-linecap="round" stroke-linejoin="round" />
         <path d="M16.9949 4.99854H9.49703C8.56905 4.99854 7.67906 5.36718 7.02288 6.02337C6.36669 6.67955 5.99805 7.56953 5.99805 8.49752C5.99805 9.42551 6.36669 10.3155 7.02288 10.9717C7.67906 11.6279 8.56905 11.9965 9.49703 11.9965H14.4956C15.4236 11.9965 16.3136 12.3652 16.9697 13.0213C17.6259 13.6775 17.9946 14.5675 17.9946 15.4955C17.9946 16.4235 17.6259 17.3135 16.9697 17.9697C16.3136 18.6258 15.4236 18.9945 14.4956 18.9945H5.99805" stroke="#05DF72" stroke-width="1.99942" stroke-linecap="round" stroke-linejoin="round" />
     </svg>
-
-
-
 );
 
-export const TargetIcon: React.FC<{ size?: number; className?: string }> = () => (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+export const TargetIcon: React.FC<{ size?: number; className?: string }> = ({ size = 24, className }) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
         <path d="M15.4723 12.8862L16.9869 21.4098C17.0039 21.5101 16.9898 21.6133 16.9465 21.7054C16.9033 21.7976 16.833 21.8743 16.7449 21.9254C16.6569 21.9765 16.5553 21.9995 16.4539 21.9913C16.3524 21.9831 16.2559 21.9442 16.1771 21.8796L12.5982 19.1934C12.4254 19.0643 12.2155 18.9946 11.9999 18.9946C11.7842 18.9946 11.5743 19.0643 11.4015 19.1934L7.81656 21.8786C7.7379 21.943 7.64147 21.9819 7.54014 21.9901C7.4388 21.9983 7.33737 21.9754 7.24939 21.9245C7.16141 21.8735 7.09105 21.797 7.0477 21.705C7.00436 21.613 6.99009 21.5101 7.0068 21.4098L8.52036 12.8862" stroke="#51A2FF" stroke-width="1.99942" stroke-linecap="round" stroke-linejoin="round" />
         <path d="M11.9963 13.996C15.3091 13.996 17.9946 11.3105 17.9946 7.99778C17.9946 4.68503 15.3091 1.99951 11.9963 1.99951C8.68356 1.99951 5.99805 4.68503 5.99805 7.99778C5.99805 11.3105 8.68356 13.996 11.9963 13.996Z" stroke="#51A2FF" stroke-width="1.99942" stroke-linecap="round" stroke-linejoin="round" />
     </svg>
 
 );
 
-export const FeesIcon: React.FC<{ size?: number; className?: string }> = () => (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+export const FeesIcon: React.FC<{ size?: number; className?: string }> = ({ size = 24, className }) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
         <path d="M7.99826 13.996C11.311 13.996 13.9965 11.3105 13.9965 7.99778C13.9965 4.68503 11.311 1.99951 7.99826 1.99951C4.68551 1.99951 2 4.68503 2 7.99778C2 11.3105 4.68551 13.996 7.99826 13.996Z" stroke="#C27AFF" stroke-width="1.99942" stroke-linecap="round" stroke-linejoin="round" />
         <path d="M18.0856 10.3672C19.0307 10.7195 19.8716 11.3044 20.5307 12.0679C21.1898 12.8313 21.6457 13.7487 21.8563 14.735C22.0669 15.7213 22.0254 16.7449 21.7356 17.7109C21.4459 18.677 20.9172 19.5544 20.1985 20.2619C19.4798 20.9695 18.5942 21.4845 17.6238 21.7591C16.6533 22.0338 15.6293 22.0593 14.6463 21.8333C13.6634 21.6073 12.7533 21.1372 12.0002 20.4663C11.2472 19.7954 10.6754 18.9454 10.3379 17.995" stroke="#C27AFF" stroke-width="1.99942" stroke-linecap="round" stroke-linejoin="round" />
         <path d="M6.99805 5.99805H7.99776V9.99689" stroke="#C27AFF" stroke-width="1.99942" stroke-linecap="round" stroke-linejoin="round" />

--- a/tests/components/StatsIcons.test.ts
+++ b/tests/components/StatsIcons.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * StatsIcons render tests.
+ *
+ * Because this project uses `jsx: "preserve"` in tsconfig.json (Next.js
+ * convention), vitest cannot parse/import `.tsx` source files.  Instead we
+ * verify the structural fix directly by reading the source and asserting the
+ * destructuring + JSX output patterns that the acceptance criteria require.
+ */
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, '../../src/components/icons/StatsIcons.tsx'),
+  'utf-8',
+)
+
+describe('StatsIcons', () => {
+  describe('ActivityIcon', () => {
+    it('destructures size with default 24', () => {
+      // Look for: ({ size = 24, className })
+      expect(SOURCE).toMatch(/ActivityIcon[^)]*\(\{\s*size\s*=\s*24/)
+    })
+
+    it('uses size for SVG width and height', () => {
+      // Within ActivityIcon's body the svg should use width={size} height={size}
+      const afterActivity = SOURCE.split('ActivityIcon')[1]
+      const beforeNextExport = afterActivity.split(/export const/)[0]
+      expect(beforeNextExport).toMatch(/width=\{size\}/)
+      expect(beforeNextExport).toMatch(/height=\{size\}/)
+    })
+
+    it('passes className to the SVG element', () => {
+      const afterActivity = SOURCE.split('ActivityIcon')[1]
+      const beforeNextExport = afterActivity.split(/export const/)[0]
+      expect(beforeNextExport).toMatch(/className=\{className\}/)
+    })
+  })
+
+  describe('DollarIcon', () => {
+    it('destructures size with default 24', () => {
+      expect(SOURCE).toMatch(/DollarIcon[^)]*\(\{\s*size\s*=\s*24/)
+    })
+
+    it('uses size for SVG width and height', () => {
+      const afterDollar = SOURCE.split('DollarIcon')[1]
+      const beforeNextExport = afterDollar.split(/export const/)[0]
+      expect(beforeNextExport).toMatch(/width=\{size\}/)
+      expect(beforeNextExport).toMatch(/height=\{size\}/)
+    })
+
+    it('passes className to the SVG element', () => {
+      const afterDollar = SOURCE.split('DollarIcon')[1]
+      const beforeNextExport = afterDollar.split(/export const/)[0]
+      expect(beforeNextExport).toMatch(/className=\{className\}/)
+    })
+  })
+
+  describe('TargetIcon', () => {
+    it('destructures size with default 24', () => {
+      expect(SOURCE).toMatch(/TargetIcon[^)]*\(\{\s*size\s*=\s*24/)
+    })
+
+    it('uses size for SVG width and height', () => {
+      const afterTarget = SOURCE.split('TargetIcon')[1]
+      const beforeNextExport = afterTarget.split(/export const/)[0]
+      expect(afterTarget).toMatch(/width=\{size\}/)
+      expect(afterTarget).toMatch(/height=\{size\}/)
+    })
+  })
+
+  describe('FeesIcon', () => {
+    it('destructures size with default 24', () => {
+      expect(SOURCE).toMatch(/FeesIcon[^)]*\(\{\s*size\s*=\s*24/)
+    })
+
+    it('uses size for SVG width and height', () => {
+      const afterFees = SOURCE.split('FeesIcon')[1]
+      const beforeNextExport = afterFees.split(/export const/)[0]
+      expect(afterFees).toMatch(/width=\{size\}/)
+      expect(afterFees).toMatch(/height=\{size\}/)
+    })
+  })
+})


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Closes # (issue number)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Please review the [Developer Guide](https://github.com/Commitlabs-Org/Commitlabs-Frontend/blob/master/DEVELOPER_GUIDE.md) before checking the items below:

- [ ] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [ ] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [ ] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

Closes #1420