### PR TITLE
fix/recently-viewed-string-validation 

### DIFF
--- a/src/hooks/useRecentlyViewed.test.ts
+++ b/src/hooks/useRecentlyViewed.test.ts
@@ -25,6 +25,21 @@ describe('useRecentlyViewed', () => {
     expect(result.current.recentIds).toEqual(['001', '002']);
   });
 
+  it('filters out non-string entries from corrupted local storage', async () => {
+    localStorage.setItem(
+      'marketplace-recently-viewed',
+      JSON.stringify(['001', 1, { evil: true }, null, '002'])
+    );
+
+    const { result } = renderHook(() => useRecentlyViewed());
+
+    await vi.waitFor(() => {
+      expect(result.current.isHydrated).toBe(true);
+    });
+
+    expect(result.current.recentIds).toEqual(['001', '002']);
+  });
+
   it('adds views with deduplication (moves to front)', async () => {
     const { result } = renderHook(() => useRecentlyViewed());
 

--- a/src/hooks/useRecentlyViewed.ts
+++ b/src/hooks/useRecentlyViewed.ts
@@ -11,7 +11,8 @@ function readStoredRecentIds(): string[] {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.slice(0, MAX_RECENT_LISTINGS) : [];
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((item): item is string => typeof item === 'string').slice(0, MAX_RECENT_LISTINGS);
   } catch {
     return [];
   }


### PR DESCRIPTION
Corrupted or manually-edited localStorage values (e.g. [1, {"evil":true}, null]) previously bypassed validation and reached consumers expecting string data.

## Description

`readStoredRecentIds` in `src/hooks/useRecentlyViewed.ts` parsed `localStorage['marketplace-recently-viewed']` and checked `Array.isArray(parsed)`, but never validated that array elements were actually strings. Corrupted or manually-edited localStorage values could bypass validation and reach consumers expecting `string[]`, producing garbage like `"[object Object]"` downstream when used to build URLs or lookup keys.

This PR filters the parsed array to only `typeof item === 'string'` entries before slicing to `MAX_RECENT_LISTINGS`, and adds test coverage for corrupted arrays containing non-string elements.

Closes #1333

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Please review the [Developer Guide](https://github.com/Commitlabs-Org/Commitlabs-Frontend/blob/master/DEVELOPER_GUIDE.md) before checking the items below:

- [x] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [x] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [x] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

N/A — logic-only change, no UI impact.

## Join the Discussion

Need help or want to chat? Join our [CommitLabs Discord](https://discord.gg/WV7tdYkJk) server.