### PR TITLE
fix(auth): secure requireWalletAuth to reject unsigned session tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.6.1",
         "@commitlint/config-conventional": "^19.6.0",
+        "@next/bundle-analyzer": "^16.2.9",
         "@playwright/test": "^1.61.1",
         "@size-limit/file": "^12.1.0",
         "@testing-library/dom": "^10.4.1",
@@ -1773,6 +1774,16 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.2.11.tgz",
+      "integrity": "sha512-C5228wy1RC0g7uOSvmQhrZXCuEeLIPureKkqramAkySmqY2Y0yw6K+TyAxXXvtrYe4uehnZs3YMFfJcorBRwpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "14.2.35",
       "resolved": "https://registry.npmmirror.com/@next/env/-/env-14.2.35.tgz",
@@ -2687,7 +2698,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
       "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.61.1"
@@ -3796,14 +3807,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmmirror.com/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.31",
       "resolved": "https://registry.npmmirror.com/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4739,6 +4750,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -5907,7 +5931,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -6138,6 +6162,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -6499,6 +6530,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -8119,6 +8157,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/happy-dom": {
       "version": "20.10.6",
       "resolved": "https://registry.npmmirror.com/happy-dom/-/happy-dom-20.10.6.tgz",
@@ -8780,6 +8834,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -10820,6 +10884,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmmirror.com/optionator/-/optionator-0.9.4.tgz",
@@ -11230,7 +11304,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
       "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.61.1"
@@ -11249,7 +11323,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -11262,7 +11336,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11578,7 +11651,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -14355,6 +14427,91 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/src/lib/backend/preferences.ts
+++ b/src/lib/backend/preferences.ts
@@ -206,24 +206,13 @@ export function requireWalletAuth(authHeader: string | null): string {
 
     const token = parts[1];
 
-    // 1. Try to verify session token via the session store first
+    // Try to verify session token via the session store
     const session = verifySessionToken(token);
-    if (session.valid && session.address) {
-        return session.address;
-    }
-
-    // 2. Fall back to placeholder token: session_<address>_<timestamp>
-    const match = token.match(/^session_([A-Z0-9]+)_\d+$/);
-    if (!match) {
+    if (!session.valid || !session.address) {
         throw new UnauthorizedError('Invalid or expired session token.');
     }
 
-    const address = match[1];
-    if (!address) {
-        throw new UnauthorizedError('Could not resolve wallet address from token.');
-    }
-
-    return address;
+    return session.address;
 }        
 
 

--- a/tests/api/user-preferences.test.ts
+++ b/tests/api/user-preferences.test.ts
@@ -12,7 +12,7 @@
  *   - Edge cases (empty payload, unknown fields ignored, concurrent writes)
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
     GET,
     PUT,
@@ -24,6 +24,7 @@ import {
     type UserPreferences,
     type PreferencesStore,
 } from '@/lib/backend/preferences';
+import { createSessionToken } from '@/lib/backend/auth';
 import { createMockRequest, parseResponse } from './helpers';
 
 // ─── Test store factory ──────────────────────────────────────────────────────
@@ -70,8 +71,8 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 
 const BASE_URL = 'http://localhost:3000/api/user/preferences';
 const VALID_ADDRESS = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDE';
-/** Mirrors `createSessionToken` placeholder format. */
-const VALID_TOKEN = `session_${VALID_ADDRESS}_1714000000000`;
+/** Generate a real valid session token via the backend's auth store. */
+const VALID_TOKEN = createSessionToken(VALID_ADDRESS);
 const AUTH_HEADER = { authorization: `Bearer ${VALID_TOKEN}` };
 
 function getReq(headers: Record<string, string> = AUTH_HEADER) {
@@ -125,16 +126,25 @@ describe('GET /api/user/preferences', () => {
 
     it('returns 401 when Authorization header is empty string', async () => {
         const res = await GET(getReq({ authorization: '' }), { params: {} });
-        const { status, data } = await parseResponse(res);
+        const { status } = await parseResponse(res);
 
         expect(status).toBe(401);
     });
 
     it('returns 401 when token has no address segment', async () => {
         const res = await GET(getReq({ authorization: 'Bearer session__1234567890' }), { params: {} });
+        const { status } = await parseResponse(res);
+
+        expect(status).toBe(401);
+    });
+
+    it('returns 401 when an unsigned forged token (matching the old fallback format) is used', async () => {
+        const forgedToken = `session_${VALID_ADDRESS}_1714000000000`;
+        const res = await GET(getReq({ authorization: `Bearer ${forgedToken}` }), { params: {} });
         const { status, data } = await parseResponse(res);
 
         expect(status).toBe(401);
+        expect(data.error.code).toBe('UNAUTHORIZED');
     });
 
     // ── Default preferences ──────────────────────────────────────────────────
@@ -170,7 +180,7 @@ describe('GET /api/user/preferences', () => {
 
     it('preferences for different wallets are isolated', async () => {
         const otherAddress = 'GOTHER0000000000000000000000000000000000000';
-        const otherToken = `session_${otherAddress}_9999999999999`;
+        createSessionToken(otherAddress);
         store._data[otherAddress] = { displayCurrency: 'GBP' };
 
         const res = await GET(getReq(), { params: {} });
@@ -201,7 +211,7 @@ describe('PUT /api/user/preferences', () => {
 
     it('returns 401 when token format is invalid', async () => {
         const res = await PUT(putReq({ displayCurrency: 'EUR' }, { authorization: 'Bearer garbage' }), { params: {} });
-        const { status, data } = await parseResponse(res);
+        const { status } = await parseResponse(res);
 
         expect(status).toBe(401);
     });
@@ -239,7 +249,7 @@ describe('PUT /api/user/preferences', () => {
 
     it('returns 400 when notifications.email is not boolean', async () => {
         const res = await PUT(putReq({ notifications: { email: 'yes' } }), { params: {} });
-        const { status, data } = await parseResponse(res);
+        const { status } = await parseResponse(res);
 
         expect(status).toBe(400);
     });


### PR DESCRIPTION
Closes  #1287 
This PR resolves a security vulnerability in requireWalletAuth within src/lib/backend/preferences.ts where unauthenticated requests containing a forged placeholder token (session_<address>_<timestamp>) were accepted without signature or server-side store verification.

The insecure regex-based fallback has been removed. The function now strictly relies on session validation via verifySessionToken.

Additionally, the preferences route tests have been updated to register their sessions properly, and a test has been added to guarantee that unsigned forged tokens matching the old fallback format are correctly rejected with 401 Unauthorized.

Key Changes
Security hardening: Removed pattern-matching fallback auth from requireWalletAuth.
Test coverage: Added test case validating rejection of forged tokens.
Linting: Fixed ESLint errors concerning unused imports and destructures in the test suite.
Verification Steps
Run npx vitest run tests/api/user-preferences.test.ts to confirm that all 27 preferences tests pass successfully.
Run npx eslint tests/api/user-preferences.test.ts to ensure no linting warnings exist.
5:57 PM
