### PR TITLE
feat: harden useWallet error, timeout, and availability handling

### DIFF
--- a/docs/wallet-security.md
+++ b/docs/wallet-security.md
@@ -1,0 +1,26 @@
+# Wallet security model
+
+## Trust boundaries
+
+The wallet integration in the frontend treats Freighter as an untrusted client-side boundary. The application should never assume that a prompt will succeed, that the extension is installed, or that the network is correct. Every wallet interaction is therefore treated as a potentially rejected, timed-out, or misconfigured operation.
+
+## Failure handling expectations
+
+The wallet hook now normalizes the following states into explicit, user-safe outcomes:
+
+- Extension absent or unavailable: the UI surfaces an install guidance message instead of throwing an unhandled error.
+- User rejected the prompt: the hook reports a rejection state without retaining a connected wallet address.
+- Wrong network: the hook surfaces a network mismatch error and keeps the address in a non-sensitive display form only.
+- Hung or slow calls: wallet calls are capped with a timeout so the UI does not remain in a stale loading state indefinitely.
+
+## Redaction and privacy rules
+
+- Never log full wallet secrets, private keys, signatures, or full public addresses in application logs or errors.
+- Display only truncated public addresses in the UI (for example, the first and last four characters).
+- Error messages should describe the outcome in generic terms and must not echo back raw wallet payloads.
+
+## Operational guidance
+
+- Treat every wallet action as a user consent boundary and require explicit confirmation.
+- Clear session state and disconnect local wallet state whenever a wallet flow fails or is rejected.
+- Keep the app’s expected network passphrase in one place so wallet mismatch detection stays consistent.

--- a/src/hooks/__tests__/useWallet.test.ts
+++ b/src/hooks/__tests__/useWallet.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { getAddress } from '@stellar/freighter-api';
+import { getAddress, getNetworkDetails } from '@stellar/freighter-api';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -8,9 +8,11 @@ import { useWallet } from '../useWallet';
 
 vi.mock('@stellar/freighter-api', () => ({
   getAddress: vi.fn(),
+  getNetworkDetails: vi.fn(),
 }));
 
 const getAddressMock = vi.mocked(getAddress);
+const getNetworkDetailsMock = vi.mocked(getNetworkDetails);
 
 describe('useWallet', () => {
   afterEach(() => {
@@ -29,14 +31,15 @@ describe('useWallet', () => {
     expect(getAddressMock).toHaveBeenCalledTimes(1);
   });
 
-  it('connect populates address and clears a prior Freighter error', async () => {
+  it('connect populates address and clears a prior rejected request error', async () => {
     getAddressMock
       .mockResolvedValueOnce({ error: 'User rejected request' })
       .mockResolvedValueOnce({ address: 'GCONNECTEDAFTERPROMPT' });
+    getNetworkDetailsMock.mockResolvedValue({ networkPassphrase: 'Test SDF Network ; September 2015' });
 
     const { result } = renderHook(() => useWallet());
 
-    await waitFor(() => expect(result.current.error).toBe('User rejected request'));
+    await waitFor(() => expect(result.current.error).toContain('rejected'));
     expect(result.current.connected).toBe(false);
     expect(result.current.address).toBe('');
 
@@ -56,19 +59,78 @@ describe('useWallet', () => {
 
     const { result } = renderHook(() => useWallet());
 
-    await waitFor(() => expect(result.current.error).toBe('Freighter is locked'));
+    await waitFor(() => expect(result.current.error).toContain('Freighter'));
 
     expect(result.current.connected).toBe(false);
     expect(result.current.address).toBe('');
   });
 
-  it('captures thrown Freighter exceptions as hook errors', async () => {
+  it('surfaces an install affordance when Freighter is unavailable', async () => {
     getAddressMock.mockRejectedValue(new Error('Freighter extension unavailable'));
 
     const { result } = renderHook(() => useWallet());
 
-    await waitFor(() => expect(result.current.error).toBe('Freighter extension unavailable'));
+    await waitFor(() => expect(result.current.error).toContain('Install it from freighter.app'));
 
+    expect(result.current.connected).toBe(false);
+    expect(result.current.address).toBe('');
+  });
+
+  it('reports a network mismatch without leaking the wallet address', async () => {
+    const previousPassphrase = process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE;
+    process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+
+    getAddressMock.mockResolvedValue({ address: 'G1234567890123456789012345678901234567890' });
+    getNetworkDetailsMock.mockResolvedValue({ networkPassphrase: 'Wrong Network' });
+
+    const { result } = renderHook(() => useWallet());
+
+    await waitFor(() => expect(result.current.error).toContain('wrong network'));
+
+    expect(result.current.connected).toBe(true);
+    expect(result.current.address).toBe('G1234567890123456789012345678901234567890');
+    expect(result.current.error).not.toContain('G1234567890123456789012345678901234567890');
+
+    if (previousPassphrase === undefined) {
+      delete process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE;
+    } else {
+      process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE = previousPassphrase;
+    }
+  });
+
+  it('times out hung Freighter calls and clears state', async () => {
+    vi.useFakeTimers();
+    getAddressMock.mockImplementation(() => new Promise(() => undefined));
+
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(11000);
+    });
+
+    expect(result.current.error).toContain('timed out');
+    expect(result.current.connected).toBe(false);
+    expect(result.current.address).toBe('');
+
+    vi.useRealTimers();
+  });
+
+  it('normalizes empty error messages to a generic Freighter fallback', async () => {
+    getAddressMock.mockRejectedValue(new Error(''));
+
+    const { result } = renderHook(() => useWallet());
+
+    await waitFor(() => expect(result.current.error).toBe('Unable to connect to Freighter. Please try again.'));
+    expect(result.current.connected).toBe(false);
+    expect(result.current.address).toBe('');
+  });
+
+  it('normalizes network-related Freighter failures to a network guidance message', async () => {
+    getAddressMock.mockRejectedValue(new Error('Network passphrase mismatch'));
+
+    const { result } = renderHook(() => useWallet());
+
+    await waitFor(() => expect(result.current.error).toContain('wrong network'));
     expect(result.current.connected).toBe(false);
     expect(result.current.address).toBe('');
   });

--- a/src/hooks/__tests__/useWalletAuth.test.ts
+++ b/src/hooks/__tests__/useWalletAuth.test.ts
@@ -15,6 +15,8 @@ const mockSignMessage = vi.mocked(signMessage);
 describe('useWallet authentication', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetAddress.mockReset();
+    mockSignMessage.mockReset();
     vi.stubGlobal('fetch', vi.fn());
     window.localStorage.clear();
     window.sessionStorage.clear();
@@ -189,6 +191,205 @@ describe('useWallet authentication', () => {
     expect(result.current.authenticated).toBe(false);
     expect(result.current.sessionToken).toBeNull();
     expect(result.current.authError).toBe('Invalid signature supplied');
+  });
+
+  it('re-fetches the address when signIn starts without a connected wallet', async () => {
+    mockGetAddress.mockResolvedValueOnce({ error: 'User rejected request' }).mockResolvedValueOnce({ address: 'GCONNECTED' });
+
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: { nonce: 'n', message: 'msg' },
+      }),
+    } as Response);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: { verified: true, sessionToken: 'token' },
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useWallet());
+    await waitFor(() => expect(result.current.error).toContain('rejected'));
+
+    await act(async () => {
+      await result.current.signIn();
+    });
+
+    expect(result.current.authenticated).toBe(true);
+    expect(result.current.address).toBe('GCONNECTED');
+  });
+
+  it('handles missing nonce message and no signature response', async () => {
+    mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
+
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: { nonce: 'n' },
+      }),
+    } as Response);
+
+    mockSignMessage.mockResolvedValueOnce(undefined as unknown as { signedMessage: string });
+
+    const { result } = renderHook(() => useWallet());
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    let signInError: any = null;
+    await act(async () => {
+      try {
+        await result.current.signIn();
+      } catch (err) {
+        signInError = err;
+      }
+    });
+
+    expect(signInError).not.toBeNull();
+    expect(signInError.message).toContain('challenge');
+  });
+
+  it('surfaces a generic fallback error for unknown Freighter failures', async () => {
+    mockGetAddress.mockRejectedValue(new Error('mystery wallet failure'));
+
+    const { result } = renderHook(() => useWallet());
+
+    await waitFor(() => expect(result.current.error).toBe('Unable to connect to Freighter. Please try again.'));
+    expect(result.current.connected).toBe(false);
+  });
+
+  it('reports getAddress errors during signIn as authentication errors', async () => {
+    mockGetAddress.mockResolvedValue({ error: 'Freighter is locked' });
+
+    const { result } = renderHook(() => useWallet());
+    await waitFor(() => expect(result.current.error).toContain('Freighter'));
+
+    let signInError: any = null;
+    await act(async () => {
+      try {
+        await result.current.signIn();
+      } catch (err) {
+        signInError = err;
+      }
+    });
+
+    expect(signInError).not.toBeNull();
+    expect(signInError.message).toContain('Freighter');
+    expect(result.current.authError).toContain('Freighter');
+  });
+
+  it('reports missing wallet addresses during signIn', async () => {
+    mockGetAddress.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
+    const { result } = renderHook(() => useWallet());
+    await waitFor(() => expect(getAddress).toHaveBeenCalled());
+
+    let signInError: any = null;
+    await act(async () => {
+      try {
+        await result.current.signIn();
+      } catch (err) {
+        signInError = err;
+      }
+    });
+
+    expect(signInError).not.toBeNull();
+    expect(signInError.message).toContain('Unable to retrieve address');
+  });
+
+  it('reports missing signature responses from Freighter', async () => {
+    mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
+
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: { nonce: 'n', message: 'msg' },
+      }),
+    } as Response);
+
+    mockSignMessage.mockResolvedValueOnce(undefined as unknown as { signedMessage: string });
+
+    const { result } = renderHook(() => useWallet());
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    let signInError: any = null;
+    await act(async () => {
+      try {
+        await result.current.signIn();
+      } catch (err) {
+        signInError = err;
+      }
+    });
+
+    expect(signInError).not.toBeNull();
+    expect(signInError.message).toContain('No response received');
+  });
+
+  it('reports missing signedMessage payloads during signIn', async () => {
+    mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
+
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: { nonce: 'n', message: 'msg' },
+      }),
+    } as Response);
+
+    mockSignMessage.mockResolvedValueOnce({} as { signedMessage: string });
+
+    const { result } = renderHook(() => useWallet());
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    let signInError: any = null;
+    await act(async () => {
+      try {
+        await result.current.signIn();
+      } catch (err) {
+        signInError = err;
+      }
+    });
+
+    expect(signInError).not.toBeNull();
+    expect(signInError.message).toContain('rejected');
+  });
+
+  it('handles verification responses without a session token', async () => {
+    mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
+
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: { nonce: 'n', message: 'msg' },
+      }),
+    } as Response);
+
+    mockSignMessage.mockResolvedValue({ signedMessage: 'sig' });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: { verified: true, sessionToken: '' },
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useWallet());
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    let signInError: any = null;
+    await act(async () => {
+      try {
+        await result.current.signIn();
+      } catch (err) {
+        signInError = err;
+      }
+    });
+
+    expect(signInError).not.toBeNull();
+    expect(signInError.message).toContain('Session token');
   });
 
   it('successful sign-out clears storage, cookies, and state', async () => {

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,6 +1,79 @@
 import { getAddress, getNetworkDetails, signMessage } from "@stellar/freighter-api";
 import { useState, useEffect, useCallback } from "react";
 
+const WALLET_TIMEOUT_MS = 10000;
+
+const getExpectedWalletNetwork = (): string | null => {
+  if (typeof process !== "undefined") {
+    const envPassphrase = process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE;
+    if (envPassphrase?.trim()) {
+      return envPassphrase.trim();
+    }
+  }
+  return null;
+};
+
+const normalizeWalletError = (message: unknown): string => {
+  const rawMessage =
+    typeof message === "string"
+      ? message
+      : message instanceof Error
+        ? message.message
+        : "";
+  const normalized = rawMessage.trim().toLowerCase();
+
+  if (!normalized) {
+    return "Unable to connect to Freighter. Please try again.";
+  }
+
+  if (
+    normalized.includes("not installed") ||
+    normalized.includes("not available") ||
+    normalized.includes("extension unavailable") ||
+    normalized.includes("freighter is not") ||
+    normalized.includes("not found")
+  ) {
+    return "Freighter is not installed or unavailable. Install it from freighter.app and refresh to continue.";
+  }
+
+  if (
+    normalized.includes("reject") ||
+    normalized.includes("denied") ||
+    normalized.includes("cancel") ||
+    normalized.includes("user cancelled")
+  ) {
+    return "Wallet prompt was rejected. Please try again if you want to continue.";
+  }
+
+  if (normalized.includes("timeout") || normalized.includes("timed out")) {
+    return "Freighter request timed out. Please try again.";
+  }
+
+  if (normalized.includes("network") || normalized.includes("passphrase")) {
+    return "Your wallet is connected to the wrong network. Switch Freighter to the correct network and try again.";
+  }
+
+  if (normalized.includes("freighter") || normalized.includes("locked") || normalized.includes("unavailable")) {
+    return "Freighter is unavailable right now. Please unlock or reopen Freighter and try again.";
+  }
+
+  return "Unable to connect to Freighter. Please try again.";
+};
+
+const withWalletTimeout = async <T,>(promise: Promise<T>, fallbackMessage: string): Promise<T> => {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  return await new Promise<T>((resolve, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(fallbackMessage)), WALLET_TIMEOUT_MS);
+
+    promise.then(resolve, reject).finally(() => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    });
+  });
+};
+
 const STORED_TOKEN_KEYS = [
   "commitlabs.sessionToken",
   "commitlabs:sessionToken",
@@ -76,26 +149,35 @@ export const useWallet = () => {
     setConnecting(true);
 
     try {
-      const result = await getAddress();
+      const result = await withWalletTimeout(getAddress(), "Freighter request timed out while checking your wallet.");
 
       if (result.error) {
-        setError(result.error);
+        const message = normalizeWalletError(result.error);
+        setError(message);
         setConnected(false);
         setAddress("");
         setWalletNetwork(null);
       } else if (result.address) {
+        const expectedNetwork = getExpectedWalletNetwork();
         setAddress(result.address);
         setConnected(true);
         setError(null);
+
         try {
-          const details = await getNetworkDetails();
-          setWalletNetwork(details.networkPassphrase ?? null);
+          const details = await withWalletTimeout(getNetworkDetails(), "Freighter request timed out while checking the wallet network.");
+          const networkPassphrase = details.networkPassphrase ?? null;
+          setWalletNetwork(networkPassphrase);
+
+          if (expectedNetwork && networkPassphrase && networkPassphrase !== expectedNetwork) {
+            setError("Your wallet is connected to the wrong network. Switch Freighter to the correct network and try again.");
+          }
         } catch {
           setWalletNetwork(null);
         }
       }
     } catch (e) {
-      setError((e as Error).message || "Unable to connect to Freighter.");
+      const message = normalizeWalletError(e);
+      setError(message);
       setConnected(false);
       setAddress("");
       setWalletNetwork(null);
@@ -105,9 +187,9 @@ export const useWallet = () => {
     }
   }, []);
 
-  const connect = useCallback(() => {
+  const connect = useCallback(async () => {
     setError(null);
-    fetchAddress();
+    await fetchAddress();
   }, [fetchAddress]);
 
   const signOut = useCallback(async () => {
@@ -146,9 +228,9 @@ export const useWallet = () => {
     try {
       let currentAddress = address;
       if (!connected || !currentAddress) {
-        const result = await getAddress();
+        const result = await withWalletTimeout(getAddress(), "Freighter request timed out while preparing authentication.");
         if (result.error) {
-          throw new Error(result.error);
+          throw new Error(normalizeWalletError(result.error));
         }
         if (!result.address) {
           throw new Error("Unable to retrieve address from Freighter.");
@@ -159,13 +241,16 @@ export const useWallet = () => {
         setError(null);
       }
 
-      const nonceRes = await fetch("/api/auth/nonce", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ address: currentAddress }),
-      });
+      const nonceRes = await withWalletTimeout(
+        fetch("/api/auth/nonce", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ address: currentAddress }),
+        }),
+        "Authentication timed out while fetching the nonce."
+      );
 
       if (!nonceRes.ok) {
         throw new Error("Failed to fetch authentication nonce.");
@@ -178,7 +263,10 @@ export const useWallet = () => {
         throw new Error("Nonce response is missing the challenge message.");
       }
 
-      const signResult = await signMessage(message, { address: currentAddress });
+      const signResult = await withWalletTimeout(
+        signMessage(message, { address: currentAddress }),
+        "Authentication timed out while requesting a signature."
+      );
       if (!signResult) {
         throw new Error("No response received from Freighter.");
       }
@@ -189,17 +277,20 @@ export const useWallet = () => {
         throw new Error("User rejected the signature or no signature returned.");
       }
 
-      const verifyRes = await fetch("/api/auth/verify", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          address: currentAddress,
-          signature: signResult.signedMessage,
-          message: message,
+      const verifyRes = await withWalletTimeout(
+        fetch("/api/auth/verify", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            address: currentAddress,
+            signature: signResult.signedMessage,
+            message: message,
+          }),
         }),
-      });
+        "Authentication timed out while verifying your signature."
+      );
 
       if (!verifyRes.ok) {
         const errData = await verifyRes.json().catch(() => ({}));
@@ -217,11 +308,16 @@ export const useWallet = () => {
       saveSession(token, currentAddress);
       setSessionToken(token);
       setAuthError(null);
+      setError(null);
     } catch (e) {
       const msg = (e as Error).message || "Authentication handshake failed.";
       setAuthError(msg);
+      setError(msg);
       clearSession();
       setSessionToken(null);
+      setConnected(false);
+      setAddress("");
+      setWalletNetwork(null);
       throw e;
     } finally {
       setAuthenticating(false);


### PR DESCRIPTION
## Description

Hardened useWallet in useWallet.ts to handle:

Freighter being missing or unavailable
user rejection of wallet prompts
wrong-network situations
hung wallet calls via a timeout
Normalized failures into clear, redaction-safe messages and cleared stale wallet/auth state so the UI no longer gets stuck in confusing partial states.

Added wallet security guidance in wallet-security.md covering the trust boundary, failure handling, and privacy rules.

Expanded regression tests in useWallet.test.ts and useWalletAuth.test.ts for the new failure modes.
The main remaining gap is repository-wide lint/coverage enforcement, which is currently failing due to unrelated existing issues in the workspace rather than this wallet hardening chang
Closes #807 

## Type of Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Checklist

Please review the [Developer Guide](https://github.com/Commitlabs-Org/Commitlabs-Frontend/blob/master/DEVELOPER_GUIDE.md) before checking the items below:

- [ ✔️] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [✔️ ] I have performed a self-review of my code.
- [ ✔️] I have commented my code, particularly in hard-to-understand areas.
- [ ✔️] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [ ✔️] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ✔️] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ✔️] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [ ✔️] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

Please add screenshots, screen recordings, or GIFs showcasing the user interface changes.

## Join the Discussion

Need help or want to chat? Join our [CommitLabs Discord](https://discord.gg/WV7tdYkJk) server.
