### PR TITLE
fix: drop synthetic bearer token in useGuidedTour and rely on cookie …

### DIFF
--- a/src/hooks/__tests__/useGuidedTour.test.ts
+++ b/src/hooks/__tests__/useGuidedTour.test.ts
@@ -13,6 +13,7 @@ function makeProps(overrides = {}) {
 
 beforeEach(() => {
   localStorage.clear();
+  document.cookie = 'session=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'; // clear cookies
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
 });
 
@@ -92,5 +93,23 @@ describe('useGuidedTour — tour-progress store (replayable + dismissible)', () 
     const { result } = renderHook(() => useGuidedTour(makeProps()));
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.totalSteps).toBe(TOUR_STEPS.length);
+  });
+
+  it('skipTour only attempts API PUT if document.cookie contains a real session', async () => {
+    // 1. Without session
+    const { result, unmount } = renderHook(() => useGuidedTour(makeProps({ walletAddress: '0x123' })));
+    await waitFor(() => expect(result.current.isActive).toBe(true));
+    act(() => result.current.skipTour());
+    // Should not call fetch because session= is missing
+    expect(global.fetch).not.toHaveBeenCalledWith('/api/user/preferences', expect.objectContaining({ method: 'PUT' }));
+    unmount();
+
+    // 2. With session
+    document.cookie = 'session=real_token_123';
+    const { result: result2 } = renderHook(() => useGuidedTour(makeProps({ walletAddress: '0x123' })));
+    await waitFor(() => expect(result2.current.isActive).toBe(true));
+    act(() => result2.current.skipTour());
+    // Should call fetch
+    expect(global.fetch).toHaveBeenCalledWith('/api/user/preferences', expect.objectContaining({ method: 'PUT' }));
   });
 });

--- a/src/hooks/useGuidedTour.ts
+++ b/src/hooks/useGuidedTour.ts
@@ -120,14 +120,13 @@ export function useGuidedTour({
       localStorage.setItem('commitlabs:seen-wizard-tour', 'true');
     }
 
-    if (walletAddress) {
-      const token = localStorage.getItem('sessionToken') || `session_${walletAddress}_${Date.now()}`;
+    const hasRealSession = typeof document !== 'undefined' && document.cookie.includes('session=');
+    if (walletAddress && hasRealSession) {
       try {
         await fetch('/api/user/preferences', {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
           },
           body: JSON.stringify({ seenWizardTour: true }),
         });
@@ -150,14 +149,10 @@ export function useGuidedTour({
         seen = localStorage.getItem('commitlabs:seen-wizard-tour') === 'true';
       }
 
-      if (walletAddress) {
-        const token = localStorage.getItem('sessionToken') || `session_${walletAddress}_${Date.now()}`;
+      const hasRealSession = typeof document !== 'undefined' && document.cookie.includes('session=');
+      if (walletAddress && hasRealSession) {
         try {
-          const res = await fetch('/api/user/preferences', {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          });
+          const res = await fetch('/api/user/preferences');
           if (res.ok) {
             const data = await res.json();
             if (data?.data?.preferences?.seenWizardTour) {


### PR DESCRIPTION
Closes #1405

This PR resolves an issue where `useGuidedTour` would fabricate a synthetic bearer token (e.g. `session_0x123_172...`) when a real session token was not found in `localStorage`, which caused preference sync (the `seenWizardTour` flag) to silently fail with a `401 Unauthorized` on the backend.

### Changes Made
* **Removed Authorization Headers**: Dropped the fallback token generation and the `Authorization: Bearer` header on API requests in `src/hooks/useGuidedTour.ts`. This aligns it with the existing pattern used elsewhere in the application, which correctly relies on the `HttpOnly` session cookie sent seamlessly by the browser.
* **Added Real Session Check**: Ensure that `fetch('/api/user/preferences')` is strictly called *only* if the user has a valid authenticated session by verifying `document.cookie.includes('session=')`. This prevents pointless backend requests that will always fail for unauthenticated or solely wallet-connected users.
* **Updated Tests**: Added cases in `src/hooks/__tests__/useGuidedTour.test.ts` to strictly assert that `skipTour` only attempts a `PUT` operation if `document.cookie` actually contains a `session=`.