### PR TITLE
fix: omit undefined optional props for SettlementEligibilityChecklist

### DIFF
--- a/src/components/CommitmentDetailActions.tsx
+++ b/src/components/CommitmentDetailActions.tsx
@@ -34,6 +34,12 @@ export function CommitmentDetailActions ({
   const focusRing =
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC] focus-visible:ring-offset-2 focus-visible:ring-offset-[#050505]';
 
+  const settlementChecklistProps = {
+    ...(onSettle !== undefined ? { onSettle } : {}),
+    ...(settleDisabledReason !== undefined ? { disabledReason: settleDisabledReason } : {}),
+    ...(previewRefreshTrigger !== undefined ? { refreshTrigger: previewRefreshTrigger } : {}),
+  };
+
   return (
     <div className="w-full">
       {/* Section Heading */}
@@ -74,9 +80,7 @@ export function CommitmentDetailActions ({
         <div className="mb-8">
           <SettlementEligibilityChecklist
             commitmentId={commitmentId}
-            onSettle={onSettle}
-            disabledReason={settleDisabledReason}
-            refreshTrigger={previewRefreshTrigger}
+            {...settlementChecklistProps}
           />
         </div>
       ) : null}

--- a/src/components/__tests__/CommitmentDetailActions.test.tsx
+++ b/src/components/__tests__/CommitmentDetailActions.test.tsx
@@ -9,20 +9,25 @@ import { CommitmentDetailActions } from '@/components/CommitmentDetailActions';
 
 const fetchMock = vi.fn();
 
-function renderActions(
-  overrides: Partial<{
-    canEarlyExit: boolean;
-    onEarlyExit: () => void;
-    onViewAttestations: () => void;
-    onExportData: () => void;
-    onReportIssue: () => void;
-    earlyExitDisabledReason: string;
-    commitmentId: string;
-    onSettle: () => void;
-    settleDisabledReason: string;
-  }> = {},
-) {
-  const props = {
+interface ActionsOverrides {
+  canEarlyExit?: boolean;
+  onEarlyExit?: () => void;
+  onViewAttestations?: () => void;
+  onExportData?: () => void;
+  onReportIssue?: () => void;
+  earlyExitDisabledReason?: string;
+  // Explicit `| undefined` lets tests opt a key out of the merged props entirely
+  // (see the filtering below), exercising the same "omit rather than pass
+  // undefined" pattern CommitmentDetailActions itself uses under
+  // exactOptionalPropertyTypes.
+  commitmentId?: string | undefined;
+  onSettle?: (() => void) | undefined;
+  settleDisabledReason?: string | undefined;
+  previewRefreshTrigger?: string | number | undefined;
+}
+
+function renderActions(overrides: ActionsOverrides = {}) {
+  const merged = {
     canEarlyExit: true,
     onEarlyExit: vi.fn(),
     onViewAttestations: vi.fn(),
@@ -34,6 +39,12 @@ function renderActions(
     settleDisabledReason: 'Settlement is unavailable until maturity',
     ...overrides,
   };
+
+  // Omit keys explicitly overridden to `undefined` instead of passing them
+  // through, matching how a real caller would build props.
+  const props = Object.fromEntries(
+    Object.entries(merged).filter(([, value]) => value !== undefined),
+  ) as unknown as React.ComponentProps<typeof CommitmentDetailActions>;
 
   const view = render(<CommitmentDetailActions {...props} />);
   return { props, ...view };
@@ -201,6 +212,58 @@ describe('CommitmentDetailActions', () => {
     buttons.forEach((button) => {
       expect(button.className).toContain('focus-visible:ring-2');
       expect(button.className).toContain('focus-visible:ring-[#0FF0FC]');
+    });
+  });
+
+  describe('optional settlement checklist props', () => {
+    it('renders the settlement checklist with only commitmentId, omitting onSettle/settleDisabledReason/previewRefreshTrigger entirely', async () => {
+      render(
+        <CommitmentDetailActions
+          canEarlyExit={true}
+          onEarlyExit={vi.fn()}
+          onViewAttestations={vi.fn()}
+          onExportData={vi.fn()}
+          onReportIssue={vi.fn()}
+          commitmentId="1"
+        />,
+      );
+
+      expect(await screen.findByText('Settlement preview')).toBeTruthy();
+      expect(screen.queryByRole('button', { name: 'Settle' })).toBeNull();
+    });
+
+    it('does not render a Settle button when onSettle is not provided', async () => {
+      renderActions({ onSettle: undefined });
+
+      expect(await screen.findByText('Settlement preview')).toBeTruthy();
+      expect(screen.queryByRole('button', { name: 'Settle' })).toBeNull();
+    });
+
+    it('renders a Settle button when onSettle is provided', async () => {
+      renderActions({ onSettle: vi.fn() });
+
+      expect(await screen.findByRole('button', { name: 'Settle' })).toBeTruthy();
+    });
+
+    it('does not render a disabled-reason note when settleDisabledReason is not provided', async () => {
+      renderActions({ settleDisabledReason: undefined });
+
+      expect(await screen.findByText('Settlement preview')).toBeTruthy();
+      expect(screen.queryByRole('note')).toBeNull();
+    });
+
+    it('renders the disabled-reason note when settleDisabledReason is provided', async () => {
+      renderActions({ settleDisabledReason: 'Settlement is unavailable until maturity' });
+
+      expect(await screen.findByRole('note')).toHaveTextContent(
+        'Settlement is unavailable until maturity',
+      );
+    });
+
+    it('does not render the settlement checklist section when commitmentId is not provided', () => {
+      renderActions({ commitmentId: undefined });
+
+      expect(screen.queryByText('Settlement preview')).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Closes #1246

## Summary

`CommitmentDetailActions` rendered `SettlementEligibilityChecklist` by passing `onSettle`, `disabledReason` (from `settleDisabledReason`), and `refreshTrigger` (from `previewRefreshTrigger`) straight through as JSX props, even when their values were `undefined`. Under the project's `exactOptionalPropertyTypes: true` setting, this fails `tsc --noEmit` with `TS2375`, because `SettlementEligibilityChecklistProps` declares those fields as plain optional (`onSettle?: () => void`, etc.) without an explicit `| undefined`, and TypeScript treats explicitly assigning `undefined` to such a field differently from omitting the key entirely.

- Built a `settlementChecklistProps` object in `CommitmentDetailActions.tsx` using the codebase's existing conditional-spread convention (already used in `src/lib/backend/dto.ts`, `src/lib/backend/apiResponse.ts`, `src/lib/backend/cors.ts`, and `src/components/shell/AppSidebar.tsx`): `...(value !== undefined ? { key: value } : {})`. Each of `onSettle`, `disabledReason`, and `refreshTrigger` is now included only when its source value is not `undefined`, so the key is fully omitted rather than present-with-`undefined`.
- Spread `{...settlementChecklistProps}` onto `<SettlementEligibilityChecklist>` alongside the always-required `commitmentId` prop.
- No behavioral change: at runtime, an omitted key and an explicit `undefined` value are indistinguishable to a destructuring assignment, so `SettlementEligibilityChecklist`'s rendering (Settle button visibility, disabled-reason note, refresh-trigger effect dependency) is identical before and after. This is purely a type-level fix.

## Files

**Modified files**
- `src/components/CommitmentDetailActions.tsx` — build `SettlementEligibilityChecklist` props via conditional spread instead of passing potentially-`undefined` values directly
- `src/components/__tests__/CommitmentDetailActions.test.tsx` — extended existing test file (see below); also hardened the `renderActions` test helper so overriding an optional prop with `undefined` omits the key from the props object passed to the component, matching the same pattern being fixed in the source (this was needed because the helper's old merge logic would otherwise itself violate `exactOptionalPropertyTypes` when a test tries to explicitly unset a prop)

No new files were needed — this is a self-contained fix within the existing action-rail component and its existing test file.

## Implementation details

- `settlementChecklistProps` is computed once per render, right after the props destructuring, from three independent conditional spreads — one per optional field — so each key's presence is decided independently.
- `commitmentId` remains a directly-assigned prop (`commitmentId={commitmentId}`) since it's required on `SettlementEligibilityChecklistProps` and is already guaranteed truthy inside the `{commitmentId ? (...) : null}` guard that wraps the checklist.
- The `CommitmentDetailActionsProps` interface itself was left unchanged — the fix is entirely about how this component *constructs* the child's props, not about its own prop types.

## Tests added

All in `src/components/__tests__/CommitmentDetailActions.test.tsx`, under a new `describe('optional settlement checklist props', ...)` block:
- Renders the settlement checklist with only `commitmentId` supplied (all three optional props omitted from the JSX entirely) and confirms it still renders ("Settlement preview" heading present, no "Settle" button).
- Does not render a "Settle" button when `onSettle` is omitted.
- Renders a "Settle" button when `onSettle` is provided (regression check for existing behavior).
- Does not render the disabled-reason `role="note"` element when `settleDisabledReason` is omitted.
- Renders the disabled-reason note with the correct text when `settleDisabledReason` is provided (regression check).
- Does not render the settlement checklist section at all when `commitmentId` is omitted.

Also updated the `renderActions` helper: its `overrides` parameter type now explicitly includes `| undefined` on the settlement-related optional fields (so tests can express "unset this"), and the helper filters out any `undefined`-valued keys before merging with the defaults and rendering — so `renderActions({ onSettle: undefined })` genuinely omits the key rather than passing `undefined` through, exercising the same shape of fix as the production code.

## How to test

```bash
pnpm install
pnpm vitest run src/components/__tests__/CommitmentDetailActions.test.tsx src/components/settlement/SettlementEligibilityChecklist.test.tsx
```

All 21 tests pass (18 in `CommitmentDetailActions.test.tsx`, 3 pre-existing in `SettlementEligibilityChecklist.test.tsx`, unaffected by this change).

Also verified with `tsc --noEmit` that `src/components/CommitmentDetailActions.tsx` and its test file no longer report `TS2375`/`TS2379`. (An unrelated pre-existing syntax error in `src/components/MarketplaceHeader/MarketplaceHeader.tsx` currently short-circuits the full project type-check before it reaches most files — that file was not touched by this PR. With that file's syntax temporarily patched locally just to let the checker run further, the previously-reported `TS2375` at `CommitmentDetailActions.tsx:75` is confirmed gone after this change, and no new errors were introduced in either changed file.)