### PR TITLE
fix(validation): export addressSchema directly, remove dead Old schemas

### DIFF
--- a/src/lib/backend/validation.ts
+++ b/src/lib/backend/validation.ts
@@ -50,14 +50,6 @@ export interface PaginationParams {
 }
 
 
-const amountSchema = z.union([z.string(), z.number()]).transform((val) => {
-  const num = typeof val === "string" ? parseFloat(val) : val;
-  if (isNaN(num) || num <= 0) {
-    throw new Error("Amount must be a positive number");
-  }
-  return num;
-});
-
 const _paginationSchema = z
   .object({
     page: z
@@ -87,27 +79,12 @@ const _paginationSchema = z
     page: data.page,
     limit: data.limit,
   }));
-const addressSchema = z
+export const addressSchema = z
   .string()
   .trim()
   .refine((addr) => StrKey.isValidEd25519PublicKey(addr), {
     message: "Must be a valid Stellar address (G... format).",
   });
-
-export const createCommitmentSchemaOld = z.object({
-  title: z.string().min(1, "Title is required"),
-  description: z.string().min(1, "Description is required"),
-  amount: amountSchema,
-  creatorAddress: addressSchema,
-});
-
-export const createMarketplaceListingSchemaOld = z.object({
-  title: z.string().min(1, "Title is required"),
-  description: z.string().optional(),
-  price: amountSchema,
-  category: z.string().min(1, "Category is required"),
-  sellerAddress: addressSchema,
-});
 
 const DisputeReasonSchema = z.object({
     reason: z.string().min(1, "Dispute reason is required").max(500, "Reason must be 500 characters or less"),
@@ -124,8 +101,6 @@ export type DisputeReasonInput = z.infer<typeof DisputeReasonSchema>;
 export type ResolveDisputeInput = z.infer<typeof ResolveDisputeSchema>;
 export type FilterParams = Record<string, string | number | boolean>;
 
-const addressSchema2 = addressSchema;
-
 const amountSchema2 = z.coerce
   .number()
   .positive("Amount must be a positive number");
@@ -137,7 +112,7 @@ const _paginationSchema2 = z.object({
 
 
 export const createCommitmentSchema = z.object({
-  ownerAddress: addressSchema2,
+  ownerAddress: addressSchema,
   asset: z
     .string()
     .trim()
@@ -160,7 +135,7 @@ export const createMarketplaceListingSchema = z.object({
   description: z.string().trim().optional(),
   price: amountSchema2,
   category: z.string().trim().min(1, "Category is required"),
-  sellerAddress: addressSchema2,
+  sellerAddress: addressSchema,
 });
 
 export const createAttestationSchema = z.object({
@@ -337,7 +312,7 @@ export type CreateMarketplaceListingInput = z.infer<
 // Validate Stellar address
 export function validateAddress(address: string): string {
   try {
-    return addressSchema2.parse(address);
+    return addressSchema.parse(address);
   } catch (error) {
     if (error instanceof z.ZodError) {
       throw new ValidationError(error.issues[0]?.message ?? "Invalid address", "address");
@@ -421,7 +396,7 @@ export function validateSupportedAsset(
  * @example
  * z.object({ ownerAddress: stellarAddressSchema })
  */
-export { addressSchema, addressSchema as stellarAddressSchema };
+export { addressSchema as stellarAddressSchema };
 
 // Amount schema: accept number or numeric string and coerce to number
 const amountSchema3 = z.union([z.number(), z.string()]).transform((v) => {

--- a/tests/lib/backend/validation.test.ts
+++ b/tests/lib/backend/validation.test.ts
@@ -15,6 +15,7 @@ import {
   createAttestationSchema,
   DisputeReasonSchema,
   ResolveDisputeSchema,
+  addressSchema,
   stellarAddressSchema,
 } from "@/lib/backend/validation";
 
@@ -988,5 +989,45 @@ describe("ResolveDisputeSchema", () => {
         notes: "x".repeat(1001),
       })
     ).toThrow(z.ZodError);
+  });
+});
+
+// ─── Module import regression ────────────────────────────────────────────────
+
+describe("module imports", () => {
+  it("exports addressSchema and stellarAddressSchema as the same Zod schema", () => {
+    expect(addressSchema).toBeDefined();
+    expect(stellarAddressSchema).toBe(addressSchema);
+  });
+
+  it("addressSchema rejects non-Stellar addresses", () => {
+    expect(() => addressSchema.parse("not-a-key")).toThrow(z.ZodError);
+  });
+
+  it("addressSchema accepts valid Stellar addresses", () => {
+    expect(addressSchema.parse(VALID_ADDRESS)).toBe(VALID_ADDRESS);
+  });
+
+  it("addressSchema is referenced by createCommitmentSchema", () => {
+    expect(() =>
+      createCommitmentSchema.parse({
+        ownerAddress: VALID_ADDRESS,
+        asset: SUPPORTED_ASSET_XLM,
+        amount: 10,
+        durationDays: 1,
+        maxLossBps: 0,
+      })
+    ).not.toThrow();
+  });
+
+  it("addressSchema is referenced by createMarketplaceListingSchema", () => {
+    expect(() =>
+      createMarketplaceListingSchema.parse({
+        title: "t",
+        price: 1,
+        category: "c",
+        sellerAddress: VALID_ADDRESS,
+      })
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
Fix the broken addressSchema re-export in src/lib/backend/validation.ts. The file previously declared a non-exported const addressSchema, then re-exported it at the bottom while also maintaining a redundant addressSchema2 alias. The Old schemas (createCommitmentSchemaOld, createMarketplaceListingSchemaOld) were exported but never imported anywhere.

Changes:
- Export addressSchema as a named const (was non-exported const)
- Remove the addressSchema2 alias; replace all usages with addressSchema
- Remove dead createCommitmentSchemaOld and createMarketplaceListingSchemaOld
- Remove unused amountSchema (only referenced by removed Old schemas)
- Add regression tests asserting the module imports cleanly and that addressSchema and stellarAddressSchema refer to the same schema

Closes #1283