### PR TITLE
Fix GuidedTour TourStepProps exactOptionalPropertyTypes violation

### DIFF
--- a/src/components/onboarding/GuidedTour.tsx
+++ b/src/components/onboarding/GuidedTour.tsx
@@ -30,7 +30,9 @@ export function GuidedTour({
       targetSelector={currentStepConfig.targetSelector}
       title={currentStepConfig.title}
       content={currentStepConfig.content}
-      position={currentStepConfig.position}
+      {...(currentStepConfig.position
+        ? { position: currentStepConfig.position }
+        : {})}
       currentStepIndex={currentStepIndex}
       totalSteps={totalSteps}
       onNext={onNext}


### PR DESCRIPTION
## Summary
Resolves #1234.

`GuidedTour.tsx` passed `currentStepConfig.position` (`"top" | "bottom" | "left" | "right" | undefined`) directly into `TourStep`'s optional `position?` prop, which violates the project's `exactOptionalPropertyTypes: true` setting and produced `TS2375` under `tsc --noEmit`.

## Change
Omit the `position` key entirely when it has no resolved value instead of assigning `undefined`. `TourStep` already defaults `position` to `'bottom'`, so behavior is unchanged.

## Acceptance criteria
- [x] Omit the `position` key when it has no resolved value instead of assigning `undefined`
- [x] `tsc --noEmit` is clean for this file (verified clean for the whole project)

## Testing
```
npx tsc --noEmit
```
No errors.