### PR TITLE
fix(kv): unify KVStore interface, remove any, rename del→delete

### DIFF
--- a/src/lib/backend/__tests__/kv.test.ts
+++ b/src/lib/backend/__tests__/kv.test.ts
@@ -56,10 +56,10 @@ describe('backend kv adapter', () => {
     const kv = await createMemoryKV();
 
     await kv.set('cache:item', 'cached');
-    await kv.del('cache:item');
+    await kv.delete('cache:item');
 
     await expect(kv.get('cache:item')).resolves.toBeNull();
-    await expect(kv.del('cache:item')).resolves.toBeUndefined();
+    await expect(kv.delete('cache:item')).resolves.toBeUndefined();
   });
 
   it('expires keys after their ttl elapses', async () => {

--- a/src/lib/backend/idempotency.ts
+++ b/src/lib/backend/idempotency.ts
@@ -1,5 +1,5 @@
 
-export interface IdempotencyRecord<T = any> {
+export interface IdempotencyRecord<T = unknown> {
   key: string;
   status: 'STARTED' | 'COMPLETED' | 'FAILED';
   response?: T;
@@ -8,18 +8,14 @@ export interface IdempotencyRecord<T = any> {
   expiresAt: number;
 }
 
-export interface KVStore {
-  get<T>(key: string): Promise<T | null>;
-  set<T>(key: string, value: T, ttlSeconds?: number): Promise<void>;
-  delete(key: string): Promise<void>;
-}
+import type { KVStore } from "./kv";
 
 /**
  * A simple in-memory KV store with TTL support.
  * Designed to be swapped with Redis or Vercel KV.
  */
 export class InMemoryKVStore implements KVStore {
-  private store = new Map<string, { value: any; expiresAt: number }>();
+  private store = new Map<string, { value: unknown; expiresAt: number }>();
 
   async get<T>(key: string): Promise<T | null> {
     const entry = this.store.get(key);
@@ -42,6 +38,28 @@ export class InMemoryKVStore implements KVStore {
 
   async delete(key: string): Promise<void> {
     this.store.delete(key);
+  }
+
+  async getdel<T>(key: string): Promise<T | null> {
+    const value = await this.get<T>(key);
+    if (value !== null) {
+      this.store.delete(key);
+    }
+    return value;
+  }
+
+  async incr(key: string): Promise<number> {
+    const value = (await this.get<number>(key)) || 0;
+    const newValue = value + 1;
+    await this.set(key, newValue);
+    return newValue;
+  }
+
+  async expire(key: string, seconds: number): Promise<void> {
+    const entry = this.store.get(key);
+    if (entry) {
+      entry.expiresAt = Date.now() + seconds * 1000;
+    }
   }
 
   // Helper for cleanup (can be called periodically)

--- a/src/lib/backend/kv.ts
+++ b/src/lib/backend/kv.ts
@@ -4,8 +4,8 @@
  */
 export interface KVStore {
     get<T>(key: string): Promise<T | null>;
-    set(key: string, value: any, ttlSeconds?: number): Promise<void>;
-    del(key: string): Promise<void>;
+    set<T>(key: string, value: T, ttlSeconds?: number): Promise<void>;
+    delete(key: string): Promise<void>;
     /**
      * Atomically gets the value and deletes the key.
      * Essential for single-use nonces to prevent replay attacks.
@@ -25,7 +25,7 @@ export interface KVStore {
  * In-memory implementation for local development and testing.
  */
 class MemoryKVStore implements KVStore {
-    private store = new Map<string, { value: any; expiresAt: number | null }>();
+    private store = new Map<string, { value: unknown; expiresAt: number | null }>();
 
     async get<T>(key: string): Promise<T | null> {
         const item = this.store.get(key);
@@ -37,14 +37,14 @@ class MemoryKVStore implements KVStore {
         return item.value as T;
     }
 
-    async set(key: string, value: any, ttlSeconds?: number): Promise<void> {
+    async set<T>(key: string, value: T, ttlSeconds?: number): Promise<void> {
         this.store.set(key, {
             value,
             expiresAt: ttlSeconds ? Date.now() + ttlSeconds * 1000 : null,
         });
     }
 
-    async del(key: string): Promise<void> {
+    async delete(key: string): Promise<void> {
         this.store.delete(key);
     }
 
@@ -84,7 +84,7 @@ class UpstashKVStore implements KVStore {
         this.token = token;
     }
 
-    private async command(args: any[]) {
+    private async command(args: (string | number)[]) {
         const response = await fetch(`${this.url}`, {
             method: 'POST',
             headers: {
@@ -112,7 +112,7 @@ class UpstashKVStore implements KVStore {
         }
     }
 
-    async set(key: string, value: any, ttlSeconds?: number): Promise<void> {
+    async set<T>(key: string, value: T, ttlSeconds?: number): Promise<void> {
         const valueStr = typeof value === 'string' ? value : JSON.stringify(value);
         if (ttlSeconds) {
             await this.command(['SET', key, valueStr, 'EX', ttlSeconds]);
@@ -121,7 +121,7 @@ class UpstashKVStore implements KVStore {
         }
     }
 
-    async del(key: string): Promise<void> {
+    async delete(key: string): Promise<void> {
         await this.command(['DEL', key]);
     }
 


### PR DESCRIPTION
Fix the conflicting KVStore interfaces in kv.ts and idempotency.ts. Both files exported their own KVStore type with different method signatures (del vs delete, any vs generic T), causing confusion for anyone importing 'the' KVStore type.

Changes:
- kv.ts: rename del→delete, set(key,value:any)→set<T>(key,value:T), type UpstashKVStore.command args as (string|number)[], change internal Map value type from any to unknown
- idempotency.ts: remove duplicate KVStore interface, import from kv.ts, extend InMemoryKVStore to implement the full KVStore contract (add getdel, incr, expire stubs), change internal Map value type from any to unknown, change IdempotencyRecord default generic from any to unknown
- kv.test.ts: update del→delete calls

Closes #1290