### PR TITLE
fix: correct mojibake-corrupted search placeholder in MarketplaceHeader

### DIFF
--- a/src/components/MarketplaceHeader/MarketplaceHeader.placeholder.test.ts
+++ b/src/components/MarketplaceHeader/MarketplaceHeader.placeholder.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Byte-level verification, complementing the DOM-level assertions in
+// MarketplaceHeader.test.tsx: reads the source file directly to prove the
+// placeholder is encoded as the real UTF-8 ellipsis character rather than
+// the historical Windows-1252-mojibake sequence.
+const filePath = path.resolve(__dirname, 'MarketplaceHeader.tsx');
+const source = fs.readFileSync(filePath, 'utf8');
+
+describe('MarketplaceHeader default search placeholder', () => {
+  it('defines DEFAULT_PLACEHOLDER as the correctly encoded string', () => {
+    expect(source).toContain("const DEFAULT_PLACEHOLDER = 'Search commitments…'");
+  });
+
+  it('does not contain the historical mojibake-corrupted placeholder', () => {
+    expect(source).not.toContain('â€¦');
+  });
+
+  it('encodes the ellipsis as the proper 3-byte UTF-8 sequence for U+2026, not a 7-byte mojibake run', () => {
+    const match = source.match(/const DEFAULT_PLACEHOLDER = '([^']*)'/);
+    const placeholder = match?.[1] ?? '';
+
+    expect(match).not.toBeNull();
+    expect(placeholder).toBe('Search commitments…');
+    expect(placeholder.codePointAt(placeholder.length - 1)).toBe(0x2026);
+
+    const trailingBytes = Buffer.from(placeholder, 'utf8').subarray(-3);
+    expect(Array.from(trailingBytes)).toEqual([0xe2, 0x80, 0xa6]);
+  });
+});

--- a/src/components/MarketplaceHeader/MarketplaceHeader.test.tsx
+++ b/src/components/MarketplaceHeader/MarketplaceHeader.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MarketplaceHeader } from './MarketplaceHeader';
+import { apiRequest } from '@/lib/client/apiClient';
+
+vi.mock('@/lib/client/apiClient', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/client/apiClient')>();
+  return {
+    ...actual,
+    apiRequest: vi.fn(),
+  };
+});
+
+// MarketStatsBanner makes its own independent API call (via @/lib/apiClient);
+// it's unrelated to the search placeholder under test here, so it's stubbed out.
+vi.mock('./MarketStatsBanner', () => ({
+  MarketStatsBanner: () => null,
+}));
+
+describe('MarketplaceHeader search placeholder', () => {
+  beforeEach(() => {
+    vi.mocked(apiRequest).mockResolvedValue({ activeListings: 0, averageYield: 0, medianPrice: 0 });
+  });
+
+  it('renders the search input with the correctly encoded default placeholder', async () => {
+    render(<MarketplaceHeader />);
+
+    const input = await screen.findByRole('combobox', { name: 'Search commitments' });
+    expect(input).toHaveAttribute('placeholder', 'Search commitments…');
+  });
+
+  it('does not render the historical mojibake-corrupted placeholder', async () => {
+    render(<MarketplaceHeader />);
+
+    const input = await screen.findByRole('combobox', { name: 'Search commitments' });
+    expect(input.getAttribute('placeholder')).not.toContain('â€¦');
+  });
+
+  it('respects a caller-provided searchPlaceholder override instead of the default', async () => {
+    render(<MarketplaceHeader searchPlaceholder="Find a commitment" />);
+
+    const input = await screen.findByRole('combobox', { name: 'Search commitments' });
+    expect(input).toHaveAttribute('placeholder', 'Find a commitment');
+  });
+});

--- a/src/components/MarketplaceHeader/MarketplaceHeader.tsx
+++ b/src/components/MarketplaceHeader/MarketplaceHeader.tsx
@@ -63,7 +63,7 @@ export interface MarketplaceHeaderProps {
   onResultSelect?: (item: CommitmentSearchResult) => void
 }
 
-const DEFAULT_PLACEHOLDER = 'Search commitmentsâ€¦'
+const DEFAULT_PLACEHOLDER = 'Search commitments…'
 
 // ---------------------------------------------------------------------------
 // Component
@@ -78,7 +78,6 @@ export function MarketplaceHeader({
   searchQuery: controlledQuery,
   ownerAddress,
   onResultSelect,
-}: MarketplaceHeaderProps) {
 }: MarketplaceHeaderProps) {
   // ── Sort ───────────────────────────────────────────────────────────────────
   const [sortValue, setSortValue] = useState<SortValue>('popular')
@@ -260,7 +259,7 @@ export function MarketplaceHeader({
               </span>
             )}
 
-            {/* Results listbox â€“ always rendered so aria-controls is valid */}
+            {/* Results listbox – always rendered so aria-controls is valid */}
             <ul
               id={listboxId}
               role="listbox"
@@ -278,6 +277,11 @@ export function MarketplaceHeader({
                 </li>
               ) : (
                 results.map((item, i) => (
+                  // Keyboard selection is already handled by the search input's
+                  // onKeyDown (Enter selects the active option; see handleKeyDown
+                  // above), matching the ARIA combobox/listbox pattern where focus
+                  // stays on the input rather than moving to each option.
+                  // eslint-disable-next-line jsx-a11y/click-events-have-key-events
                   <li
                     key={item.commitmentId}
                     id={`${listboxId}-option-${i}`}

--- a/tests/no-mojibake-source-strings.test.ts
+++ b/tests/no-mojibake-source-strings.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Guards against mojibake: UTF-8-encoded General Punctuation characters
+ * (curly quotes, dashes, ellipses, bullets, trademark sign, etc. — the
+ * U+2000-U+206F block) that were decoded as Windows-1252 / Latin-1 and
+ * re-encoded as UTF-8, producing garbled sequences like
+ * "Search commitmentsâ€¦" instead of "Search commitments…".
+ *
+ * Every character in that block starts with UTF-8 bytes E2 80 xx, which
+ * misread as Windows-1252 always decodes to the literal two-character
+ * prefix "â€" (U+00E2, U+20AC) before the corrupted final byte. Legitimate
+ * prose containing "â" (e.g. French "âge") is never directly followed by
+ * "€", so this pattern has effectively no false positives.
+ */
+const MOJIBAKE_PATTERN = /â€./gu;
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+const IGNORED_DIR_NAMES = new Set(['node_modules', '.next', '.git', 'dist', 'build', 'coverage']);
+// Test/spec files are excluded: they may legitimately embed a mojibake string
+// as a comparison fixture (to assert real source no longer contains it), which
+// isn't itself a corruption of user-facing content.
+const TEST_FILE_PATTERN = /\.(test|spec)\.[jt]sx?$/;
+const SOURCE_ROOT = path.resolve(process.cwd(), 'src');
+
+function collectSourceFiles(dir: string, files: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (IGNORED_DIR_NAMES.has(entry.name)) continue;
+
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectSourceFiles(fullPath, files);
+    } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name)) && !TEST_FILE_PATTERN.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+describe('source encoding — no mojibake', () => {
+  it('contains no Windows-1252-mis-decoded UTF-8 punctuation in any src/ file', () => {
+    const offenders: Array<{ file: string; matches: string[] }> = [];
+
+    for (const file of collectSourceFiles(SOURCE_ROOT)) {
+      const content = fs.readFileSync(file, 'utf8');
+      const matches = content.match(MOJIBAKE_PATTERN);
+      if (matches) {
+        offenders.push({
+          file: path.relative(process.cwd(), file),
+          matches: Array.from(new Set(matches)),
+        });
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('flags a known mojibake sample so this check can never silently no-op', () => {
+    expect('Search commitmentsâ€¦').toMatch(MOJIBAKE_PATTERN);
+    expect('Search commitments…').not.toMatch(MOJIBAKE_PATTERN);
+  });
+});


### PR DESCRIPTION
Closes #1224

## Summary

`DEFAULT_PLACEHOLDER` in `src/components/MarketplaceHeader/MarketplaceHeader.tsx` was encoded as `'Search commitmentsâ€¦'`. A byte-level inspection confirmed the trailing bytes were `c3 a2 e2 82 ac c2 a6` — the classic mojibake signature produced when a UTF-8 ellipsis (`…`, bytes `e2 80 a6`) is misread as Windows-1252/Latin-1 and re-encoded as UTF-8 (each original UTF-8 byte gets reinterpreted as one cp1252 character and re-encoded: `E2`→`â`, `80`→`€`, `A6`→`¦`). This corrupted string was shown as the literal Marketplace search input placeholder any time a caller didn't override `searchPlaceholder`.

- Replaced the constant with the correctly encoded `'Search commitments…'` (verified the file is UTF-8 and the trailing bytes are the proper 3-byte sequence `E2 80 A6` for U+2026), matching how the rest of the codebase already writes real ellipsis characters (`MarketplaceCard.tsx`, `SettlementEligibilityChecklist.tsx`, `WalletConnectButton.tsx`, etc. all use `…` directly).
- Added a repo-wide Vitest check, `tests/no-mojibake-source-strings.test.ts`, that recursively scans every `.ts/.tsx/.js/.jsx` file under `src/` (excluding test/spec files, which may legitimately reference the bad pattern as a comparison fixture) for the `â€`-prefixed mojibake family — the UTF-8 General Punctuation block (curly quotes, dashes, ellipsis, bullet, trademark sign, etc.) misread as Windows-1252 always decodes to that exact two-character prefix, so this has effectively zero false-positive risk against legitimate prose. This implements the issue's "lint/CI check... that fails on non-ASCII mojibake sequences like â€¦" acceptance criterion and will catch any regression of this class of bug anywhere in the source tree, not just this one file.
- Added `src/components/MarketplaceHeader/MarketplaceHeader.test.tsx`, a real component-render test (using React Testing Library) that mounts `<MarketplaceHeader />` and asserts the rendered search input's `placeholder` attribute is exactly `'Search commitments…'`, is not the corrupted string, and that a caller-supplied `searchPlaceholder` override still works.
- Added `src/components/MarketplaceHeader/MarketplaceHeader.placeholder.test.ts`, a byte-level test that reads the source file directly and asserts the exact 3-byte UTF-8 encoding of the trailing ellipsis character, complementing the DOM-level test above.

## Incidental fixes required to unblock this change

`MarketplaceHeader.tsx` had two additional pre-existing, unrelated defects that made it impossible to touch this file at all (they parse-broke the file and blocked this repo's own pre-commit `eslint --fix` gate on any staged change to it):

1. **A duplicated parameter-list line** (`}: MarketplaceHeaderProps) {` appeared twice in a row in the `MarketplaceHeader` function signature), which made the file a syntax error — unparseable, unimportable, unrenderable in any test. Removed the duplicate line. This is what makes the new component-render test possible at all; previously `MarketplaceHeader` could not be imported by any test.
2. Fixing that syntax error surfaced a dormant `jsx-a11y/click-events-have-key-events` lint error on the results `<li role="option" onClick=...>` (previously hidden because the file never got far enough through the parser for ESLint to check it). Keyboard interaction with these options is already fully handled by the search input's `onKeyDown` (`handleKeyDown` — Enter selects the active option, matching the standard ARIA combobox/listbox pattern where focus stays on the input). Suppressed with a scoped, commented `eslint-disable-next-line`, following the same convention already used elsewhere in this codebase (see `CreateCommitmentStepConfigure.tsx`).
3. The new repo-wide mojibake scan also caught a second, independent instance of the same `â€`-family corruption in a nearby JSX comment (`{/* Results listbox â€“ ... */}` → `–`), which was fixed so the new check passes cleanly.

None of these three changes alter any existing behavior — the a11y fix is a lint suppression backed by already-existing keyboard support, not new behavior.

## Known pre-existing issues left untouched (out of scope for this fix)

While verifying with `tsc --noEmit`, two further pre-existing, unrelated problems were found and intentionally **not** touched, since they're outside this issue's scope:
- `MarketplaceHeader.tsx` references an undefined type `MarketplaceStats` (`TS2304`) — a separate missing-type-definition bug.
- `tests/components/MarketplaceHeader/MarketplaceHeader.test.tsx` (a different, pre-existing test file at the repo root `tests/` directory, distinct from the new file added here) contains its own content wholesale-duplicated within a single file (duplicate imports/mocks), most likely a bad merge artifact — it doesn't compile under `tsc --noEmit`. It predates this PR (confirmed present on `master`).

## Files

**New files**
- `src/components/MarketplaceHeader/MarketplaceHeader.test.tsx` — component-render tests for the placeholder
- `src/components/MarketplaceHeader/MarketplaceHeader.placeholder.test.ts` — byte-level source encoding tests
- `tests/no-mojibake-source-strings.test.ts` — repo-wide mojibake lint/CI check

**Modified files**
- `src/components/MarketplaceHeader/MarketplaceHeader.tsx` — corrected the placeholder string; removed the blocking duplicate parameter-list line; fixed a second `â€`-family mojibake instance in a comment; suppressed the newly-surfaced, already-handled a11y lint finding

## Tests added

- `tests/no-mojibake-source-strings.test.ts`:
  - Recursively scans `src/` for the `â€`-prefixed mojibake pattern and asserts zero offending files.
  - A canary test asserting the regex actually matches a known mojibake sample and does not match the corrected string, so this check can never silently no-op (e.g. if the regex were accidentally broken).
- `src/components/MarketplaceHeader/MarketplaceHeader.test.tsx`:
  - Renders `<MarketplaceHeader />` and asserts the search input's `placeholder` attribute equals `'Search commitments…'`.
  - Asserts the rendered placeholder does not contain the historical `â€¦` mojibake sequence.
  - Asserts a caller-supplied `searchPlaceholder` prop still overrides the default correctly.
- `src/components/MarketplaceHeader/MarketplaceHeader.placeholder.test.ts`:
  - Asserts the source file contains the exact corrected constant declaration.
  - Asserts the source file does not contain the historical mojibake substring.
  - Asserts the placeholder's trailing character has code point `U+2026` and is encoded as the exact 3-byte UTF-8 sequence `E2 80 A6`.

## How to test

```bash
pnpm install
pnpm vitest run tests/no-mojibake-source-strings.test.ts \
  src/components/MarketplaceHeader/MarketplaceHeader.test.tsx \
  src/components/MarketplaceHeader/MarketplaceHeader.placeholder.test.ts
```

All 3 files / 8 tests pass. Also verified:
- `xxd`/`file -bi` confirm the file is saved as UTF-8 and the placeholder's trailing bytes are the correct 3-byte ellipsis sequence (`E2 80 A6`), not the old 7-byte mojibake run.
- `eslint` is clean on `MarketplaceHeader.tsx` and all three new/changed test files (previously `eslint` couldn't even parse `MarketplaceHeader.tsx` due to the unrelated duplicate-line syntax error).
- `tsc --noEmit` shows no errors introduced by this change (the only remaining `MarketplaceHeader.tsx` diagnostic, `TS2304: Cannot find name 'MarketplaceStats'`, is the pre-existing, unrelated issue noted above).