### PR TITLE
fix: replace placeholder href=# with real URLs on landing page action cards

### DIFF
--- a/src/components/landing-page/sections/ExperienceSection.tsx
+++ b/src/components/landing-page/sections/ExperienceSection.tsx
@@ -137,17 +137,17 @@ export const ExperienceSection: React.FC = () => {
           <ActionCard
             icon={<FaGithub size={40} />}
             label="View on Github"
-            href="#"
+            href="https://github.com/Commitlabs-Org/Commitlabs-Frontend"
           />
           <ActionCard
             icon={<IoDocumentText size={40} />}
             label="Read Docs"
-            href="#"
+            href="https://github.com/Commitlabs-Org/Commitlabs-Frontend/tree/master/docs"
           />
           <ActionCard
             icon={<FaEnvelope size={40} />}
             label="Get in Touch"
-            href="#"
+            href="https://discord.gg/WV7tdYkJk"
           />
         </motion.div>
       </motion.div>


### PR DESCRIPTION
## Summary

Replaced three placeholder href="#" values in the landing page ExperienceSection with real destination URLs.

## Changes

| Card | Before | After |
|------|--------|-------|
| View on Github | href="#" | href="https://github.com/Commitlabs-Org/Commitlabs-Frontend" |
| Read Docs | href="#" | href="https://github.com/Commitlabs-Org/Commitlabs-Frontend/tree/master/docs" |
| Get in Touch | href="#" | href="https://discord.gg/WV7tdYkJk" |

## Context

The three ActionCard components in src/components/landing-page/sections/ExperienceSection.tsx (lines 149-165) were rendered as 	arget="_blank" rel="noopener noreferrer" links but all pointed to href="#". Activating any of them opened a new blank tab at the top of the current page instead of navigating to the intended destination. This is on the public landing page -- the first thing prospective contributors and users encounter.

## Verification

- Confirmed all three cards now point to valid, publicly accessible URLs
- No other href="#" placeholders remain in the component
- ActionCard component's default href prop (line 44) was intentionally preserved as-is since it only serves as a fallback

Fixes #1422