### PR TITLE
fix: add rate limiting to POST /api/auth/sessions/revoke-others

### DIFF
--- a/src/app/api/auth/sessions/revoke-others/route.test.ts
+++ b/src/app/api/auth/sessions/revoke-others/route.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from './route';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/backend/rateLimit', () => ({
+    checkRateLimit: vi.fn(),
+}));
+
+vi.mock('@/lib/backend/auth', () => ({
+    AUTH_COOKIE_NAME: 'session',
+    verifySessionToken: vi.fn(),
+    revokeOtherSessions: vi.fn(),
+}));
+
+import { checkRateLimit } from '@/lib/backend/rateLimit';
+import { verifySessionToken, revokeOtherSessions } from '@/lib/backend/auth';
+
+const VALID_TOKEN = 'valid-session-token';
+
+const makeRequest = (opts: { token?: string; ip?: string } = {}) => {
+    const { token = VALID_TOKEN, ip = '127.0.0.1' } = opts;
+    const req = new NextRequest('http://localhost:3000/api/auth/sessions/revoke-others', {
+        method: 'POST',
+        headers: {
+            ...(ip ? { 'x-forwarded-for': ip } : {}),
+            Cookie: token ? `session=${token}` : '',
+        },
+    });
+    return req;
+};
+
+describe('POST /api/auth/sessions/revoke-others', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(checkRateLimit).mockResolvedValue(true);
+        vi.mocked(verifySessionToken).mockReturnValue({ valid: true, address: 'GABC' });
+        vi.mocked(revokeOtherSessions).mockReturnValue(2);
+    });
+
+    it('revokes other sessions and returns count on success', async () => {
+        const res = await POST(makeRequest(), { params: {} });
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.success).toBe(true);
+        expect(body.data.revokedCount).toBe(2);
+        expect(body.data.message).toBe('Revoked 2 other sessions.');
+        expect(revokeOtherSessions).toHaveBeenCalledWith(VALID_TOKEN);
+    });
+
+    it('returns 429 when rate limited', async () => {
+        vi.mocked(checkRateLimit).mockResolvedValue(false);
+
+        const res = await POST(makeRequest(), { params: {} });
+        const body = await res.json();
+
+        expect(res.status).toBe(429);
+        expect(body.success).toBe(false);
+        expect(body.error.code).toBe('TOO_MANY_REQUESTS');
+        expect(checkRateLimit).toHaveBeenCalledWith('anonymous', 'api/auth/sessions/revoke-others');
+        expect(revokeOtherSessions).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when no session cookie is present', async () => {
+        const req = new NextRequest('http://localhost:3000/api/auth/sessions/revoke-others', {
+            method: 'POST',
+            headers: { 'x-forwarded-for': '127.0.0.1' },
+        });
+
+        const res = await POST(req, { params: {} });
+        const body = await res.json();
+
+        expect(res.status).toBe(401);
+        expect(body.error.code).toBe('UNAUTHORIZED');
+    });
+
+    it('returns 401 when session token is invalid', async () => {
+        vi.mocked(verifySessionToken).mockReturnValue({ valid: false, error: 'Token expired' });
+
+        const res = await POST(makeRequest(), { params: {} });
+        const body = await res.json();
+
+        expect(res.status).toBe(401);
+        expect(body.error.code).toBe('UNAUTHORIZED');
+        expect(body.error.message).toBe('Token expired');
+    });
+
+    it('uses singular "session" when exactly one session is revoked', async () => {
+        vi.mocked(revokeOtherSessions).mockReturnValue(1);
+
+        const res = await POST(makeRequest(), { params: {} });
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.data.revokedCount).toBe(1);
+        expect(body.data.message).toBe('Revoked 1 other session.');
+    });
+
+    it('falls back to anonymous IP when no forwarding headers present', async () => {
+        const req = new NextRequest('http://localhost:3000/api/auth/sessions/revoke-others', {
+            method: 'POST',
+            headers: { Cookie: `session=${VALID_TOKEN}` },
+        });
+
+        const res = await POST(req, { params: {} });
+        expect(res.status).toBe(200);
+        expect(checkRateLimit).toHaveBeenCalledWith('anonymous', 'api/auth/sessions/revoke-others');
+    });
+
+    it('returns 500 on unexpected handler error', async () => {
+        vi.mocked(revokeOtherSessions).mockImplementation(() => { throw new Error('db error'); });
+
+        const res = await POST(makeRequest(), { params: {} });
+        const body = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(body.error.code).toBe('INTERNAL_ERROR');
+    });
+});

--- a/src/app/api/auth/sessions/revoke-others/route.ts
+++ b/src/app/api/auth/sessions/revoke-others/route.ts
@@ -2,6 +2,9 @@ import { NextRequest } from 'next/server';
 import { withApiHandler } from '@/lib/backend/withApiHandler';
 import { ok, fail } from '@/lib/backend/apiResponse';
 import { AUTH_COOKIE_NAME, verifySessionToken, revokeOtherSessions } from '@/lib/backend/auth';
+import { TooManyRequestsError } from '@/lib/backend/errors';
+import { getClientIp } from '@/lib/backend/getClientIp';
+import { checkRateLimit } from '@/lib/backend/rateLimit';
 
 /**
  * POST /api/auth/sessions/revoke-others
@@ -10,6 +13,12 @@ import { AUTH_COOKIE_NAME, verifySessionToken, revokeOtherSessions } from '@/lib
  * preserving only the current session.
  */
 export const POST = withApiHandler(async (req: NextRequest) => {
+    const ip = getClientIp(req);
+
+    if (!(await checkRateLimit(ip, 'api/auth/sessions/revoke-others'))) {
+        throw new TooManyRequestsError('Rate limit exceeded. Please try again later.');
+    }
+
     const sessionCookie = req.cookies.get(AUTH_COOKIE_NAME);
     const token = sessionCookie?.value;
 


### PR DESCRIPTION
closes #1385 
Adds checkRateLimit call keyed by IP before performing the revoke, matching the pattern used by the nonce and verify auth routes. Also adds route.test.ts covering the 429 path and other edge cases.

Closes #1385

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Closes # (issue number)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Please review the [Developer Guide](https://github.com/Commitlabs-Org/Commitlabs-Frontend/blob/master/DEVELOPER_GUIDE.md) before checking the items below:

- [ ] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [ ] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [ ] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

Please add screenshots, screen recordings, or GIFs showcasing the user interface changes.

## Join the Discussion

Need help or want to chat? Join our [CommitLabs Discord](https://discord.gg/WV7tdYkJk) server.
