### PR TITLE
fix: improve dispute modal focus trap handling

### DIFF
--- a/src/components/modals/DisputeModal.test.tsx
+++ b/src/components/modals/DisputeModal.test.tsx
@@ -148,4 +148,24 @@ describe('DisputeModal', () => {
     fireEvent.keyDown(dialog, { key: 'Escape' });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it('handles Tab key gracefully when no focusable elements exist', () => {
+    const { onClose } = renderModal();
+    const dialog = screen.getByRole('dialog', { name: /dispute commitment/i });
+
+    // Temporarily remove all focusable elements to simulate edge case
+    const focusableElements = dialog.querySelectorAll('button, input, select, textarea, [tabindex]');
+    focusableElements.forEach((el) => {
+      if (el instanceof HTMLElement) {
+        el.setAttribute('disabled', 'disabled');
+        el.setAttribute('tabindex', '-1');
+      }
+    });
+
+    // This should not throw even with no focusable elements
+    expect(() => {
+      fireEvent.keyDown(dialog, { key: 'Tab' });
+      fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true });
+    }).not.toThrow();
+  });
 });

--- a/src/components/modals/DisputeModal.tsx
+++ b/src/components/modals/DisputeModal.tsx
@@ -166,10 +166,10 @@ export default function DisputeModal({ isOpen, commitmentId, onClose, onSubmitte
 
     if (event.shiftKey && document.activeElement === first) {
       event.preventDefault();
-      last.focus();
+      last?.focus();
     } else if (!event.shiftKey && document.activeElement === last) {
       event.preventDefault();
-      first.focus();
+      first?.focus();
     }
   };
 


### PR DESCRIPTION
## Summary
- Added focus safety guards for DisputeModal keyboard navigation handlers.
- Improved Tab/Shift+Tab handling when no focusable elements exist.
- Added test coverage for modals without focusable children.

## Validation
- Confirmed `tsc --noEmit` passes for `DisputeModal.tsx`.
- Added test case covering missing focusable elements.

## Notes
Unable to execute the test suite locally due to environment-related issues with Node/pnpm compatibility and Vitest module resolution. The test implementation is included and should pass in a compatible development environment.