### PR TITLE
fix(wallet): correct network detection in WalletAccountMenu (#1419)

### DIFF
--- a/src/components/wallet/WalletAccountMenu.test.tsx
+++ b/src/components/wallet/WalletAccountMenu.test.tsx
@@ -17,16 +17,27 @@ const mockedGetAddress = vi.mocked(getAddress);
 const mockedFetch = vi.mocked(global.fetch);
 
 describe('WalletAccountMenu', () => {
+  // Helper: build the standard { success, data, meta } envelope that
+  // GET /api/protocol/constants actually returns.
+  function makeConstantsResponse(networkPassphrase: string) {
+    return Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          success: true,
+          data: { network: networkPassphrase },
+          meta: {},
+        }),
+    } as Response);
+  }
+
   beforeEach(() => {
     mockedGetAddress.mockReset();
     mockedFetch.mockReset();
-    // Default mock for protocol constants
+    // Default mock: testnet passphrase wrapped in the correct envelope shape.
     mockedFetch.mockImplementation((url) => {
       if (url === '/api/protocol/constants') {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ network: 'testnet' }),
-        } as Response);
+        return makeConstantsResponse('Test SDF Network ; September 2015');
       }
       if (url === '/api/auth/logout') {
         return Promise.resolve({
@@ -238,5 +249,56 @@ describe('WalletAccountMenu', () => {
         /Connection canceled in Freighter/i,
       ),
     );
+  });
+
+  describe('network detection from protocol constants', () => {
+    const CONNECTED_ADDRESS = 'GABCD1234EFGH5678IJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOP';
+
+    it('shows "Testnet" badge and links to testnet explorer when backend returns the testnet passphrase', async () => {
+      // Default fetch mock already returns the testnet passphrase.
+      mockedGetAddress.mockResolvedValueOnce({ address: CONNECTED_ADDRESS });
+
+      render(<WalletAccountMenu />);
+
+      await waitFor(() =>
+        expect(screen.getByText(/GABC…MNOP/)).toBeInTheDocument(),
+      );
+
+      // Open the menu to reveal the network badge.
+      fireEvent.click(screen.getByRole('button', { name: /connected wallet/i }));
+
+      expect(await screen.findByText(/Testnet/i)).toBeInTheDocument();
+      expect(screen.queryByText(/^Public$/i)).not.toBeInTheDocument();
+    });
+
+    it('shows "Public" badge and links to mainnet explorer when backend returns the mainnet passphrase', async () => {
+      mockedFetch.mockImplementation((url) => {
+        if (url === '/api/protocol/constants') {
+          return makeConstantsResponse(
+            'Public Global Stellar Network ; September 2015',
+          );
+        }
+        if (url === '/api/auth/logout') {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ message: 'Logged out successfully' }),
+          } as Response);
+        }
+        return Promise.reject(new Error('Not found'));
+      });
+
+      mockedGetAddress.mockResolvedValueOnce({ address: CONNECTED_ADDRESS });
+
+      render(<WalletAccountMenu />);
+
+      await waitFor(() =>
+        expect(screen.getByText(/GABC…MNOP/)).toBeInTheDocument(),
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /connected wallet/i }));
+
+      expect(await screen.findByText(/Public/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Testnet/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/wallet/WalletAccountMenu.tsx
+++ b/src/components/wallet/WalletAccountMenu.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useWallet } from '@/hooks/useWallet';
-import { openExplorerUrl } from '@/utils/explorerLinks';
+import { openExplorerUrl, getExplorerNetworkFromPassphrase } from '@/utils/explorerLinks';
 import { Copy, ExternalLink, LogOut, ChevronDown } from 'lucide-react';
 import { clsx } from 'clsx';
 
@@ -51,11 +51,11 @@ export const WalletAccountMenu: React.FC = () => {
         const response = await fetch('/api/protocol/constants');
         if (response.ok) {
           const data = await response.json();
-          if (data.network === 'testnet') {
-            setNetwork('testnet');
-          } else {
-            setNetwork('public');
-          }
+          // The route wraps its payload in { success, data, meta }, so the
+          // constants live at data.data. The network field is the full Stellar
+          // network passphrase, not the literal word "testnet".
+          const passphrase: string | undefined = data?.data?.network;
+          setNetwork(getExplorerNetworkFromPassphrase(passphrase));
         }
       } catch {
         // Default to public if fetch fails
@@ -182,6 +182,7 @@ export const WalletAccountMenu: React.FC = () => {
               className='origin-top-right absolute right-0 mt-2 w-64 rounded-[14px] border border-[rgba(255,255,255,0.08)] bg-[#0a0a0a] shadow-[0_0_22px_rgba(0,0,0,0.45)] ring-1 ring-white ring-opacity-10'
               role='menu'
               aria-label='Wallet account menu'
+              tabIndex={-1}
               onKeyDown={handleMenuKeyDown}
             >
               <div className='px-4 py-3 border-b border-[rgba(255,255,255,0.08)]'>


### PR DESCRIPTION
closes  #1419 
- Unwrap the { success, data, meta } API envelope: read data.data.network instead of data.network (which was always undefined)
- Replace exact string comparison against 'testnet' with getExplorerNetworkFromPassphrase(), which maps the full Stellar network passphrase to 'public' | 'testnet' — fixing the always-Public badge and broken mainnet explorer link when running on testnet
- Add tabIndex={-1} to role=menu div to satisfy jsx-a11y/interactive-supports-focus
- Update test mock to return the correct envelope shape
- Add two focused tests: testnet passphrase -> Testnet badge, mainnet passphrase -> Public badge

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Closes # (issue number)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Please review the [Developer Guide](https://github.com/Commitlabs-Org/Commitlabs-Frontend/blob/master/DEVELOPER_GUIDE.md) before checking the items below:

- [ ] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [ ] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [ ] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

Please add screenshots, screen recordings, or GIFs showcasing the user interface changes.

## Join the Discussion

Need help or want to chat? Join our [CommitLabs Discord](https://discord.gg/WV7tdYkJk) server.
