### PR TITLE
test: add unit tests for CommitmentEarlyExitModal

### DIFF
--- a/src/components/CommitmentEarlyExitModal/CommitmentEarlyExitModal.test.tsx
+++ b/src/components/CommitmentEarlyExitModal/CommitmentEarlyExitModal.test.tsx
@@ -1,0 +1,244 @@
+import React from 'react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchProtocolConstants } from '@/utils/protocol';
+import CommitmentEarlyExitModal from './CommitmentEarlyExitModal';
+
+vi.mock('@/utils/protocol', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/protocol')>(
+    '@/utils/protocol',
+  );
+
+  return {
+    ...actual,
+    fetchProtocolConstants: vi.fn(),
+  };
+});
+
+vi.mock('./ExitTimingPreview', () => ({
+  ExitTimingPreview: () => null,
+}));
+
+vi.mock('./GraceCountdownBanner', () => ({
+  GraceCountdownBanner: () => null,
+}));
+
+function setReducedMotion(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+const defaultProps = {
+  isOpen: true,
+  commitmentId: 'cm_123456',
+  originalAmount: '50,000 XLM',
+  penaltyPercent: '3%',
+  penaltyAmount: '1,500 XLM',
+  netReceiveAmount: '48,500 XLM',
+};
+
+describe('CommitmentEarlyExitModal', () => {
+  beforeEach(() => {
+    setReducedMotion(false);
+    vi.mocked(fetchProtocolConstants).mockResolvedValue({
+      protocolVersion: '1.0.0',
+      network: 'testnet',
+      fees: {
+        networkBaseFeeStroops: 100,
+        platformFeePercent: 0,
+      },
+      penalties: [],
+      commitmentLimits: {
+        minAmountXlm: 10,
+        maxAmountXlm: 1_000_000,
+        minDurationDays: 1,
+        maxDurationDays: 365,
+        maxLossPercentCeiling: 100,
+        earlyExitGracePeriodDays: 5,
+      },
+      cachedAt: new Date().toISOString(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function renderModal(overrides: Partial<React.ComponentProps<typeof CommitmentEarlyExitModal>> = {}) {
+    const onChangeAcknowledged = vi.fn();
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+
+    const utils = render(
+      <CommitmentEarlyExitModal
+        {...defaultProps}
+        hasAcknowledged={false}
+        onChangeAcknowledged={onChangeAcknowledged}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        {...overrides}
+      />,
+    );
+
+    return { ...utils, onChangeAcknowledged, onCancel, onConfirm };
+  }
+
+  it('renders the penalty breakdown and title when open', async () => {
+    renderModal();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Early Exit Warning')).toBeInTheDocument();
+    expect(screen.getByText('50,000 XLM')).toBeInTheDocument();
+    expect(screen.getByText('48,500 XLM')).toBeInTheDocument();
+  });
+
+  it('does not render when isOpen is false', async () => {
+    renderModal({ isOpen: false });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('keeps the confirm button disabled until the checkbox is checked and the commitment id is typed', async () => {
+    renderModal({ hasAcknowledged: false });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const confirmButton = screen.getByRole('button', { name: 'Confirm Early Exit' });
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent.change(
+      screen.getByLabelText('Type the commitment ID to confirm'),
+      { target: { value: defaultProps.commitmentId } },
+    );
+
+    expect(confirmButton).toBeDisabled();
+  });
+
+  it('keeps the confirm button disabled when acknowledged but the typed commitment id does not match', async () => {
+    renderModal({ hasAcknowledged: true });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const confirmButton = screen.getByRole('button', { name: 'Confirm Early Exit' });
+
+    fireEvent.change(
+      screen.getByLabelText('Type the commitment ID to confirm'),
+      { target: { value: 'not-the-right-id' } },
+    );
+
+    expect(confirmButton).toBeDisabled();
+  });
+
+  it('enables the confirm button once acknowledged and the exact commitment id is typed', async () => {
+    renderModal({ hasAcknowledged: true });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const confirmButton = screen.getByRole('button', { name: 'Confirm Early Exit' });
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent.change(
+      screen.getByLabelText('Type the commitment ID to confirm'),
+      { target: { value: defaultProps.commitmentId } },
+    );
+
+    expect(confirmButton).toBeEnabled();
+  });
+
+  it('calls onChangeAcknowledged when the acknowledgement checkbox is toggled', async () => {
+    const { onChangeAcknowledged } = renderModal({ hasAcknowledged: false });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(onChangeAcknowledged).toHaveBeenCalledWith(true);
+  });
+
+  it('fires onConfirm only when the confirm button is enabled and clicked', async () => {
+    const { onConfirm } = renderModal({ hasAcknowledged: true });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const confirmButton = screen.getByRole('button', { name: 'Confirm Early Exit' });
+
+    fireEvent.click(confirmButton);
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    fireEvent.change(
+      screen.getByLabelText('Type the commitment ID to confirm'),
+      { target: { value: defaultProps.commitmentId } },
+    );
+
+    fireEvent.click(confirmButton);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onCancel when the cancel button is clicked', async () => {
+    const { onCancel } = renderModal();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to onCancel for the close button when onClose is not provided', async () => {
+    const { onCancel } = renderModal();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose instead of onCancel when onClose is provided', async () => {
+    const onClose = vi.fn();
+    const { onCancel } = renderModal({ onClose });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add src/components/CommitmentEarlyExitModal/CommitmentEarlyExitModal.test.tsx covering the main modal component, which composes ExitTimingPreview and GraceCountdownBanner but previously had no dedicated tests of its own
- Assert the confirm button stays disabled until both the acknowledgement checkbox is checked and the exact commitment id is typed into the confirmation input, and that it becomes enabled once both conditions are met
- Assert onConfirm only fires on a click while enabled, onCancel fires from the Cancel button, onChangeAcknowledged fires when the checkbox is toggled, and the header close button falls back to onCancel when no onClose prop is supplied (and calls onClose instead when one is)
- Assert the modal renders the penalty breakdown table content when open and renders nothing when isOpen is false

The sibling pieces (ExitTimingPreview, GraceCountdown) already had test coverage, but the CommitmentEarlyExitModal component itself, which is wired to the Early Exit action on both src/app/commitments/page.tsx and src/app/commitments/[id]/page.tsx, did not. A regression in the hasAcknowledged/typed-id gating logic would have let a user confirm an early exit without acknowledging the penalty, and nothing in the existing suite would have caught it.

Test setup follows the same mocking pattern already used in GraceCountdown.test.tsx (mocking fetchProtocolConstants and the ExitTimingPreview child), plus mocks GraceCountdownBanner directly since its behavior is already covered by its own test file.

## Test plan

- [x] npx vitest run src/components/CommitmentEarlyExitModal/CommitmentEarlyExitModal.test.tsx (10 tests passing)
- [x] npx vitest run src/components/CommitmentEarlyExitModal (all 20 tests across the directory passing)
- [x] npx tsc --noEmit (no new type errors)
- [x] eslint --fix via pre-commit hook (lint-staged) passed on the new file

closes #1270