### PR TITLE
fix(hooks): replace dead beforePopState with App Router navigation guard

### DIFF
--- a/src/hooks/__tests__/useUnsavedChangesGuard.test.ts
+++ b/src/hooks/__tests__/useUnsavedChangesGuard.test.ts
@@ -1,24 +1,358 @@
-import { renderHook, act } from '@testing-library/react-hooks'
-import { useUnsavedChangesGuard } from '@/hooks/useUnsavedChangesGuard'
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUnsavedChangesGuard } from '@/hooks/useUnsavedChangesGuard';
 
-test('detects dirty state and resets baseline', () => {
-  const initial = { a: 1, b: 2 }
-  const { result, rerender } = renderHook(({ state }) => useUnsavedChangesGuard(state), {
-    initialProps: { state: initial },
-  })
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-  // initially not dirty
-  expect(result.current.isDirty).toBe(false)
+/** Fire a popstate event as the browser would after history.go() / back(). */
+function firePopState() {
+  window.dispatchEvent(new PopStateEvent('popstate', { state: null }));
+}
 
-  // change state
-  const changed = { a: 1, b: 3 }
-  rerender({ state: changed })
-  expect(result.current.isDirty).toBe(true)
+/** Create and dispatch a click on a plain <a> element with the given href. */
+function clickAnchor(href: string, target?: string): HTMLAnchorElement {
+  const a = document.createElement('a');
+  a.href = href;
+  if (target) a.target = target;
+  document.body.appendChild(a);
+  a.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  document.body.removeChild(a);
+  return a;
+}
 
-  // reset baseline via resetBaseline (simulate after save)
-  act(() => {
-    result.current.resetBaseline()
-  })
-  // after reset, not dirty
-  expect(result.current.isDirty).toBe(false)
-})
+// ---------------------------------------------------------------------------
+// Shared setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.spyOn(window, 'confirm').mockReturnValue(false);
+  vi.spyOn(history, 'pushState');
+  vi.spyOn(history, 'go');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Dirty-state tracking (existing behaviour)
+// ---------------------------------------------------------------------------
+
+describe('dirty-state tracking', () => {
+  it('is not dirty on mount', () => {
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({ a: 1, b: 2 }),
+    );
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it('becomes dirty when state changes', () => {
+    const { result, rerender } = renderHook(
+      ({ state }: { state: Record<string, number> }) =>
+        useUnsavedChangesGuard(state),
+      { initialProps: { state: { a: 1, b: 2 } } },
+    );
+
+    rerender({ state: { a: 1, b: 3 } });
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it('goes back to clean after resetBaseline', () => {
+    const { result, rerender } = renderHook(
+      ({ state }: { state: Record<string, number> }) =>
+        useUnsavedChangesGuard(state),
+      { initialProps: { state: { a: 1, b: 2 } } },
+    );
+
+    rerender({ state: { a: 1, b: 3 } });
+    expect(result.current.isDirty).toBe(true);
+
+    act(() => result.current.resetBaseline());
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it('stays dirty after resetBaseline if state is changed again', () => {
+    const { result, rerender } = renderHook(
+      ({ state }: { state: Record<string, number> }) =>
+        useUnsavedChangesGuard(state),
+      { initialProps: { state: { a: 1 } } },
+    );
+
+    rerender({ state: { a: 2 } });
+    act(() => result.current.resetBaseline());
+    expect(result.current.isDirty).toBe(false);
+
+    rerender({ state: { a: 3 } });
+    expect(result.current.isDirty).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// beforeunload guard
+// ---------------------------------------------------------------------------
+
+describe('beforeunload guard', () => {
+  it('calls preventDefault and sets returnValue when dirty', () => {
+    const { rerender } = renderHook(
+      ({ state }: { state: Record<string, number> }) =>
+        useUnsavedChangesGuard(state),
+      { initialProps: { state: { a: 1 } } },
+    );
+
+    rerender({ state: { a: 2 } }); // make dirty
+
+    const event = new Event('beforeunload') as BeforeUnloadEvent;
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+    act(() => window.dispatchEvent(event));
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    // jsdom sets returnValue to true when preventDefault() is called on
+    // BeforeUnloadEvent; real browsers set it to ''. Either way the guard
+    // fired — we just verify it is truthy.
+    expect(event.returnValue).toBeTruthy();
+  });
+
+  it('does NOT call preventDefault when not dirty', () => {
+    renderHook(() => useUnsavedChangesGuard({ a: 1 }));
+
+    const event = new Event('beforeunload') as BeforeUnloadEvent;
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+    act(() => window.dispatchEvent(event));
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+  });
+
+  it('removes the beforeunload listener on unmount', () => {
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useUnsavedChangesGuard({ a: 1 }));
+    unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// popstate (back/forward) guard
+// ---------------------------------------------------------------------------
+
+describe('popstate guard', () => {
+  it('pushes a sentinel history entry on mount', () => {
+    renderHook(() => useUnsavedChangesGuard({ a: 1 }));
+    expect(history.pushState).toHaveBeenCalledWith(null, '');
+  });
+
+  it('does nothing on popstate when not dirty', () => {
+    renderHook(() => useUnsavedChangesGuard({ a: 1 }));
+    act(() => firePopState());
+    // confirm should never be shown when clean
+    expect(window.confirm).not.toHaveBeenCalled();
+  });
+
+  it('shows confirm dialog on popstate when dirty', () => {
+    const { rerender } = renderHook(
+      ({ state }: { state: Record<string, number> }) =>
+        useUnsavedChangesGuard(state),
+      { initialProps: { state: { a: 1 } } },
+    );
+
+    rerender({ state: { a: 2 } }); // make dirty
+    act(() => firePopState());
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      'You have unsaved changes. Are you sure you want to leave?',
+    );
+  });
+
+  it('stays on page (re-pushes sentinel) when user cancels', () => {
+    vi.mocked(window.confirm).mockReturnValue(false);
+
+    const { rerender } = renderHook(
+      ({ state }: { state: Record<string, number> }) =>
+        useUnsavedChangesGuard(state),
+      { initialProps: { state: { a: 1 } } },
+    );
+
+    rerender({ state: { a: 2 } });
+    // Clear calls from mount
+    vi.mocked(history.pushState).mockClear();
+
+    act(() => firePopState());
+
+    // Should push sentinel again to keep guard active
+    expect(history.pushState).toHaveBeenCalledWith(null, '');
+    // Should NOT navigate back
+    expect(history.go).not.toHaveBeenCalled();
+  });
+
+  it('navigates away when user confirms', () => {
+    vi.mocked(window.confirm).mockReturnValue(true);
+
+    const { rerender } = renderHook(
+      ({ state }: { state: Record<string, number> }) =>
+        useUnsavedChangesGuard(state),
+      { initialProps: { state: { a: 1 } } },
+    );
+
+    rerender({ state: { a: 2 } });
+    act(() => firePopState());
+
+    // history.go(-2) = undo sentinel push + perform original navigation
+    expect(history.go).toHaveBeenCalledWith(-2);
+  });
+
+  it('removes popstate listener on unmount', () => {
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useUnsavedChangesGuard({ a: 1 }));
+    unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'popstate',
+      expect.any(Function),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Link-click guard
+// ---------------------------------------------------------------------------
+
+describe('link-click guard', () => {
+  it('does nothing on link click when not dirty', () => {
+    renderHook(() => useUnsavedChangesGuard({ a: 1 }));
+    // Clicking a link when clean should not trigger confirm
+    act(() => clickAnchor('/other-page'));
+    expect(window.confirm).not.toHaveBeenCalled();
+  });
+
+  it('shows confirm dialog when a link is clicked and state is dirty', () => {
+    const { rerender } = renderHook(
+      ({ state }: { state: Record<string, number> }) =>
+        useUnsavedChangesGuard(state),
+      { initialProps: { state: { a: 1 } } },
+    );
+
+    rerender({ state: { a: 2 } });
+    act(() => clickAnchor('/other-page'));
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      'You have unsaved changes. Are you sure you want to leave?',
+    );
+  });
+
+  it('prevents navigation when user cancels on link click', () => {
+    vi.mocked(window.confirm).mockReturnValue(false);
+
+    const { rerender } = renderHook(
+      ({ state }: { state: Record<string, number> }) =>
+        useUnsavedChangesGuard(state),
+      { initialProps: { state: { a: 1 } } },
+    );
+
+    rerender({ state: { a: 2 } });
+
+    const a = document.createElement('a');
+    a.href = '/other-page';
+    document.body.appendChild(a);
+
+    const clickEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = vi.spyOn(clickEvent, 'preventDefault');
+
+    act(() => a.dispatchEvent(clickEvent));
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    document.body.removeChild(a);
+  });
+
+  it('allows navigation when user confirms on link click', () => {
+    vi.mocked(window.confirm).mockReturnValue(true);
+
+    const { rerender } = renderHook(
+      ({ state }: { state: Record<string, number> }) =>
+        useUnsavedChangesGuard(state),
+      { initialProps: { state: { a: 1 } } },
+    );
+
+    rerender({ state: { a: 2 } });
+
+    const a = document.createElement('a');
+    a.href = '/other-page';
+    document.body.appendChild(a);
+
+    const clickEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = vi.spyOn(clickEvent, 'preventDefault');
+
+    act(() => a.dispatchEvent(clickEvent));
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+    document.body.removeChild(a);
+  });
+
+  it('ignores hash-only links when dirty', () => {
+    const { rerender } = renderHook(
+      ({ state }: { state: Record<string, number> }) =>
+        useUnsavedChangesGuard(state),
+      { initialProps: { state: { a: 1 } } },
+    );
+
+    rerender({ state: { a: 2 } });
+    act(() => clickAnchor('#section'));
+
+    expect(window.confirm).not.toHaveBeenCalled();
+  });
+
+  it('ignores _blank target links when dirty', () => {
+    const { rerender } = renderHook(
+      ({ state }: { state: Record<string, number> }) =>
+        useUnsavedChangesGuard(state),
+      { initialProps: { state: { a: 1 } } },
+    );
+
+    rerender({ state: { a: 2 } });
+    act(() => clickAnchor('/other-page', '_blank'));
+
+    expect(window.confirm).not.toHaveBeenCalled();
+  });
+
+  it('ignores clicks on non-anchor elements', () => {
+    const { rerender } = renderHook(
+      ({ state }: { state: Record<string, number> }) =>
+        useUnsavedChangesGuard(state),
+      { initialProps: { state: { a: 1 } } },
+    );
+
+    rerender({ state: { a: 2 } });
+
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    act(() =>
+      button.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true }),
+      ),
+    );
+    document.body.removeChild(button);
+
+    expect(window.confirm).not.toHaveBeenCalled();
+  });
+
+  it('removes click listener on unmount', () => {
+    const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener');
+    const { unmount } = renderHook(() => useUnsavedChangesGuard({ a: 1 }));
+    unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'click',
+      expect.any(Function),
+      true,
+    );
+  });
+});

--- a/src/hooks/useUnsavedChangesGuard.ts
+++ b/src/hooks/useUnsavedChangesGuard.ts
@@ -1,66 +1,132 @@
-import { useEffect, useRef, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useRef, useState, useCallback } from 'react';
 
 /**
  * Hook to track dirty state of a form/object and guard against accidental navigation.
  *
- * @param currentState The current state object (e.g., preferences).
+ * Works with the Next.js App Router. Guards against:
+ *   - Browser unload (refresh/tab close) via `beforeunload`
+ *   - Browser back/forward navigation via `popstate`
+ *   - Link-click navigation via a document-level `click` interceptor
+ *
+ * @param currentState The current state object to track (e.g., form values).
  * @returns {
- *   isDirty: boolean indicating if changes differ from baseline,
- *   resetBaseline: () => void to set current state as new baseline (e.g., after save)
+ *   isDirty: boolean indicating if the current state differs from the baseline,
+ *   resetBaseline: () => void to accept the current state as the new baseline (e.g., after save)
  * }
  */
-export function useUnsavedChangesGuard<T extends Record<string, any>>(currentState: T) {
+export function useUnsavedChangesGuard<T extends Record<string, unknown>>(
+  currentState: T,
+): { isDirty: boolean; resetBaseline: () => void } {
   const baselineRef = useRef<T>(JSON.parse(JSON.stringify(currentState)));
   const [isDirty, setIsDirty] = useState(false);
-  const router = useRouter();
+
+  // Keep a ref so event handlers always see the current isDirty without
+  // needing to be re-registered on every render.
+  const isDirtyRef = useRef(isDirty);
+  isDirtyRef.current = isDirty;
 
   // Compare current state with baseline whenever it changes.
   useEffect(() => {
-    const dirty = JSON.stringify(currentState) !== JSON.stringify(baselineRef.current);
+    const dirty =
+      JSON.stringify(currentState) !== JSON.stringify(baselineRef.current);
     setIsDirty(dirty);
   }, [currentState]);
 
-  const resetBaseline = () => {
+  const resetBaseline = useCallback(() => {
     baselineRef.current = JSON.parse(JSON.stringify(currentState));
     setIsDirty(false);
-  };
+  }, [currentState]);
 
-  // Prompt on browser unload (refresh/close)
+  // Guard against browser unload (refresh / tab close).
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
-      if (isDirty) {
+      if (isDirtyRef.current) {
         e.preventDefault();
+        // Setting returnValue is required by some browsers to trigger the
+        // native "Leave site?" dialog.
         e.returnValue = '';
-        return '';
       }
     };
     window.addEventListener('beforeunload', handler);
     return () => window.removeEventListener('beforeunload', handler);
-  }, [isDirty]);
+  }, []);
 
-  // Guard against client-side navigation using Next.js router.
+  // Guard against browser back/forward navigation (popstate).
+  // When the user navigates back/forward and there are unsaved changes, we
+  // push the current entry back onto the history stack and show a confirm
+  // dialog. If the user confirms, we let the navigation proceed.
   useEffect(() => {
-    const handle = (state: any) => {
-      if (isDirty) {
-        const confirmLeave = window.confirm('You have unsaved changes. Are you sure you want to leave?');
-        if (!confirmLeave) return false;
+    // Push a sentinel entry so we have something to restore to when the user
+    // presses back. This is harmless if the entry already exists.
+    history.pushState(null, '');
+
+    const handlePopState = () => {
+      if (!isDirtyRef.current) return;
+
+      // Re-push the sentinel to keep the guard active for subsequent attempts.
+      history.pushState(null, '');
+
+      const confirmLeave = window.confirm(
+        'You have unsaved changes. Are you sure you want to leave?',
+      );
+      if (confirmLeave) {
+        // User confirmed — go back twice: once to undo our sentinel push and
+        // once to perform the navigation the user originally requested.
+        history.go(-2);
       }
-      return true;
     };
-    // @ts-ignore – beforePopState may be undefined in some versions.
-    if (router && typeof router.beforePopState === 'function') {
-      // @ts-ignore
-      router.beforePopState(handle);
-    }
-    return () => {
-      // @ts-ignore
-      if (router && typeof router.beforePopState === 'function') {
-        // @ts-ignore
-        router.beforePopState(() => true);
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  // Guard against client-side link-click navigation.
+  // Intercepts clicks on <a> elements that would navigate away from the page.
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (!isDirtyRef.current) return;
+
+      const target = (e.target as HTMLElement).closest('a');
+      if (!target) return;
+
+      const href = target.getAttribute('href');
+      // Ignore hash-only links, javascript: links, and links that open in a
+      // new tab (those won't unload the current page).
+      if (
+        !href ||
+        href.startsWith('#') ||
+        href.startsWith('javascript:') ||
+        target.target === '_blank'
+      ) {
+        return;
+      }
+
+      // Ignore links to the current page (same pathname + search).
+      try {
+        const url = new URL(href, window.location.href);
+        if (
+          url.pathname === window.location.pathname &&
+          url.search === window.location.search
+        ) {
+          return;
+        }
+      } catch {
+        // Malformed href — let it through.
+        return;
+      }
+
+      const confirmLeave = window.confirm(
+        'You have unsaved changes. Are you sure you want to leave?',
+      );
+      if (!confirmLeave) {
+        e.preventDefault();
+        e.stopPropagation();
       }
     };
-  }, [router, isDirty]);
+
+    document.addEventListener('click', handleClick, true);
+    return () => document.removeEventListener('click', handleClick, true);
+  }, []);
 
   return { isDirty, resetBaseline };
 }


### PR DESCRIPTION
## Summary

Fixes the broken navigation guard in `useUnsavedChangesGuard` (issue #1328).

The third `useEffect` was calling `router.beforePopState()` — an API that only exists on the Pages Router. In the App Router, `typeof router.beforePopState` is always `false`, so the entire client-side navigation guard silently never ran. The `@ts-ignore` comments and defensive check were the original author's acknowledgement that it wouldn't type-check.

Closes #1328

## Changes

### `src/hooks/useUnsavedChangesGuard.ts`
- Remove `useRouter` / `beforePopState` entirely
- Replace with three App-Router-compatible guards:
  1. **`beforeunload`** — browser refresh/tab close (unchanged)
  2. **`popstate`** — browser back/forward; pushes a `history.pushState(null, '')` sentinel on mount so there is always an entry to restore; on `popstate` re-pushes sentinel (cancel) or calls `history.go(-2)` (confirm)
  3. **Document `click` capture listener** — intercepts `<a>` clicks before Next.js router; ignores hash-only links, `_blank` targets, same-page links, and non-anchors
- Fix generic: `T extends Record<string, any>` → `T extends Record<string, unknown>`
- Remove all four `@ts-ignore` comments and all `any` types
- Use `isDirtyRef` so event handlers always see current dirty state without re-registration

### `src/hooks/__tests__/useUnsavedChangesGuard.test.ts`
- Replace `@testing-library/react-hooks` (not in project) with `@testing-library/react`
- 21 tests across 4 describe blocks:
  - `dirty-state tracking` (4) — preserves original behaviour
  - `beforeunload guard` (3) — fires when dirty, skips when clean, cleans up
  - `popstate guard` (6) — sentinel on mount, cancel stays, confirm navigates, cleans up
  - `link-click guard` (8) — cancel, confirm, hash links, `_blank`, non-anchors, cleanup

## Test Results

```
Tests  21 passed (21)
```

## Checklist
- [x] Navigation guard works in App Router (no Pages Router APIs)
- [x] No `any` types or `@ts-ignore` comments
- [x] All existing dirty-state tracking tests preserved
- [x] New tests cover all three guard mechanisms
- [x] Lint passes (eslint ran via husky pre-commit hook)