### PR TITLE
Migrate useWallet to rely exclusively on the HttpOnly session cookie

### DIFF
--- a/docs/WALLET_AUTH.md
+++ b/docs/WALLET_AUTH.md
@@ -23,8 +23,8 @@ sequenceDiagram
     User->>Freighter Wallet: Approves signature
     Freighter Wallet-->>Frontend (useWallet): Return signature
     Frontend (useWallet)->>Backend (Auth API): POST /api/auth/verify { address, signature, message }
-    Backend (Auth API)-->>Frontend (useWallet): Return { verified: true, sessionToken }
-    Frontend (useWallet)->>Frontend (useWallet): Save sessionToken & cookie
+    Backend (Auth API)-->>Frontend (useWallet): Set-Cookie: cl_auth_session (HttpOnly); body { verified: true, address }
+    Frontend (useWallet)->>Frontend (useWallet): Mark authenticated (no token held client-side)
 ```
 
 ### 1. Request Nonce
@@ -71,7 +71,14 @@ The backend:
 - Validates that the challenge has not expired.
 - Verifies the signature against the public key (`address`) using Ed25519 verification.
 - Checks that the nonce matches the registered session challenge for the specified address, then deletes (consumes) the nonce.
-- Returns a secure `sessionToken`.
+- Creates a session token and sets it as an HttpOnly cookie (`cl_auth_session`) on the response. The token is never included in the JSON body.
+
+### 4. Check Session
+To learn whether an existing HttpOnly cookie is still valid (e.g. on page load), the frontend calls:
+```
+GET /api/auth/session
+```
+which returns `{ authenticated: boolean, address?: string }`, derived entirely server-side from the cookie. This is the only way the client can observe authentication state, since it cannot read the cookie's value directly.
 
 ---
 
@@ -79,8 +86,8 @@ The backend:
 
 ### 1. Account-Switching Protection
 If a user switches accounts within Freighter, or disconnects their wallet:
-- The hook compares the current connected wallet address against the authenticated address stored during the handshake (`commitlabs.authAddress`).
-- Upon mismatch or disconnection, the active session token, local storage keys, and cookie are instantly cleared to prevent unauthorized state-changing requests.
+- The hook re-checks `/api/auth/session` and compares the server-reported authenticated address against the current connected wallet address.
+- Upon mismatch or disconnection, the hook calls `/api/auth/logout`, which revokes the session and clears the cookie server-side.
 
 ### 2. Plaintext Secrets Handling
 To prevent leaks:
@@ -88,14 +95,12 @@ To prevent leaks:
 - Disconnected wallets clean up all references.
 
 ### 3. Session Token Storage
-Upon successful authentication, the `sessionToken` is written to:
-- State for in-memory hook consumption.
-- LocalStorage and SessionStorage under `commitlabs.sessionToken`, `commitlabs:sessionToken`, and `sessionToken` for backward compatibility with older page exports.
-- A secure `session` cookie:
-  ```typescript
-  document.cookie = `session=${token}; path=/; SameSite=Lax; Secure`;
-  ```
-  This is required for backend route handlers that enforce cookie-based session verification.
+The session token exists **only** as an HttpOnly cookie (`cl_auth_session`), set directly by `/api/auth/verify` via `response.cookies.set(...)` with `httpOnly: true`. It is:
+- Never included in any JSON response body.
+- Never written to `localStorage`, `sessionStorage`, or a JS-readable cookie.
+- Sent automatically by the browser on same-origin requests; the frontend does not need to (and cannot) read or attach it manually.
+
+This closes the XSS-to-token-theft vector that existed when the token was readable from client-side JavaScript.
 
 ### 4. Idempotency & Race Conditions
 - Multiple simultaneous calls to `signIn()` are ignored if a sign-in process is already in progress (`authenticating === true`).

--- a/src/app/api/auth/session/route.test.ts
+++ b/src/app/api/auth/session/route.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/backend/auth', () => ({
+  AUTH_COOKIE_NAME: 'cl_auth_session',
+  verifySessionToken: vi.fn(),
+}));
+
+const AUTH_COOKIE_NAME = 'cl_auth_session';
+
+import { GET } from './route';
+import { verifySessionToken } from '@/lib/backend/auth';
+
+const makeRequest = (cookie?: string) =>
+  new NextRequest('http://localhost:3000/api/auth/session', {
+    headers: cookie ? { cookie } : {},
+  });
+
+describe('GET /api/auth/session', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports unauthenticated when no session cookie is present', async () => {
+    const res = await GET(makeRequest(), { params: {} });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.authenticated).toBe(false);
+    expect(body.data.address).toBeUndefined();
+    expect(verifySessionToken).not.toHaveBeenCalled();
+  });
+
+  it('reports unauthenticated when the session token is invalid or expired', async () => {
+    vi.mocked(verifySessionToken).mockReturnValue({ valid: false, error: 'Session expired' });
+
+    const res = await GET(makeRequest(`${AUTH_COOKIE_NAME}=stale-token`), { params: {} });
+    const body = await res.json();
+
+    expect(body.data.authenticated).toBe(false);
+    expect(body.data.address).toBeUndefined();
+  });
+
+  it('reports the authenticated address without ever echoing the token back', async () => {
+    vi.mocked(verifySessionToken).mockReturnValue({ valid: true, address: 'GABC' });
+
+    const res = await GET(makeRequest(`${AUTH_COOKIE_NAME}=valid-token`), { params: {} });
+    const body = await res.json();
+
+    expect(body.data.authenticated).toBe(true);
+    expect(body.data.address).toBe('GABC');
+    expect(JSON.stringify(body)).not.toContain('valid-token');
+  });
+});

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from 'next/server';
+import { ok, methodNotAllowed } from '@/lib/backend/apiResponse';
+import { withApiHandler } from '@/lib/backend/withApiHandler';
+import { AUTH_COOKIE_NAME, verifySessionToken } from '@/lib/backend/auth';
+
+/**
+ * GET /api/auth/session
+ *
+ * Reports whether the caller holds a valid wallet-auth session, based solely
+ * on the HttpOnly session cookie. Never echoes the session token back to the
+ * client — only the address it belongs to.
+ */
+export const GET = withApiHandler(async (req: NextRequest) => {
+  const token = req.cookies.get(AUTH_COOKIE_NAME)?.value;
+  if (!token) {
+    return ok({ authenticated: false });
+  }
+
+  const verification = verifySessionToken(token);
+  if (!verification.valid) {
+    return ok({ authenticated: false });
+  }
+
+  return ok({ authenticated: true, address: verification.address });
+});
+
+const _405 = methodNotAllowed(['GET']);
+export { _405 as POST, _405 as PUT, _405 as PATCH, _405 as DELETE };

--- a/src/app/api/auth/verify/route.test.ts
+++ b/src/app/api/auth/verify/route.test.ts
@@ -9,10 +9,16 @@ vi.mock('@/lib/backend/rateLimit', () => ({
 vi.mock('@/lib/backend/auth', () => ({
   verifySignatureWithNonce: vi.fn(),
   createSessionToken: vi.fn(),
+  AUTH_COOKIE_NAME: 'cl_auth_session',
+  COOKIE_OPTIONS: {
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    path: '/',
+  },
 }));
 
 import { checkRateLimit } from '@/lib/backend/rateLimit';
-import { verifySignatureWithNonce, createSessionToken } from '@/lib/backend/auth';
+import { verifySignatureWithNonce, createSessionToken, AUTH_COOKIE_NAME } from '@/lib/backend/auth';
 
 const VALID_BODY = {
   address: 'GABC',
@@ -35,7 +41,7 @@ describe('POST /api/auth/verify', () => {
     vi.mocked(createSessionToken).mockReturnValue('session_GABC_1234567890');
   });
 
-  it('returns verified true and sessionToken on success', async () => {
+  it('returns verified true and sets the session as an HttpOnly cookie, never in the body', async () => {
     const res = await POST(makeRequest(VALID_BODY), { params: {} });
     const body = await res.json();
 
@@ -43,8 +49,12 @@ describe('POST /api/auth/verify', () => {
     expect(body.success).toBe(true);
     expect(body.data.verified).toBe(true);
     expect(body.data.address).toBe('GABC');
-    expect(body.data.sessionToken).toBe('session_GABC_1234567890');
+    expect(body.data.sessionToken).toBeUndefined();
     expect(verifySignatureWithNonce).toHaveBeenCalledWith(VALID_BODY);
+
+    const cookie = res.cookies.get(AUTH_COOKIE_NAME);
+    expect(cookie?.value).toBe('session_GABC_1234567890');
+    expect(cookie?.httpOnly).toBe(true);
   });
 
   it('returns 429 when rate limited', async () => {

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { z } from 'zod';
 import { ok, methodNotAllowed } from '@/lib/backend/apiResponse';
-import { verifySignatureWithNonce, createSessionToken } from '@/lib/backend/auth';
+import { verifySignatureWithNonce, createSessionToken, AUTH_COOKIE_NAME, COOKIE_OPTIONS } from '@/lib/backend/auth';
 import { createCorsOptionsHandler, type CorsRoutePolicy } from '@/lib/backend/cors';
 import { TooManyRequestsError, ValidationError, UnauthorizedError } from '@/lib/backend/errors';
 import { getClientIp } from '@/lib/backend/getClientIp';
@@ -46,17 +46,22 @@ export const POST = withApiHandler(async (req: NextRequest, _context, correlatio
 
   const sessionToken = createSessionToken(validation.data.address);
 
-  return ok(
+  const response = ok(
     {
       verified: true,
       address: verificationResult.address,
       message: 'Signature verified successfully',
-      sessionToken,
     },
     undefined,
     200,
     correlationId,
   );
+
+  // Session lives exclusively in an HttpOnly cookie; the token itself is
+  // never exposed to client-side JavaScript.
+  response.cookies.set(AUTH_COOKIE_NAME, sessionToken, COOKIE_OPTIONS);
+
+  return response;
 }, { cors: AUTH_VERIFY_CORS_POLICY });
 
 const _405 = methodNotAllowed(['POST']);

--- a/src/hooks/__tests__/useWalletAuth.test.ts
+++ b/src/hooks/__tests__/useWalletAuth.test.ts
@@ -12,19 +12,46 @@ vi.mock('@stellar/freighter-api', () => ({
 const mockGetAddress = vi.mocked(getAddress);
 const mockSignMessage = vi.mocked(signMessage);
 
+function jsonResponse(ok: boolean, body: any): Response {
+  return { ok, json: async () => body } as Response;
+}
+
+/**
+ * Dispatches mocked fetch calls by URL instead of relying on call order,
+ * since the hook now issues an automatic GET /api/auth/session check
+ * whenever the connected address changes (not just during signIn/signOut).
+ */
+function createFetchMock(overrides: {
+  session?: () => Response;
+  nonce?: () => Response;
+  verify?: () => Response;
+  logout?: () => Response;
+}) {
+  return vi.fn(async (url: string) => {
+    if (url === '/api/auth/session') {
+      return (overrides.session ?? (() => jsonResponse(true, { authenticated: false })))();
+    }
+    if (url === '/api/auth/nonce') {
+      return (overrides.nonce ?? (() => jsonResponse(false, {})))();
+    }
+    if (url === '/api/auth/verify') {
+      return (overrides.verify ?? (() => jsonResponse(false, {})))();
+    }
+    if (url === '/api/auth/logout') {
+      return (overrides.logout ?? (() => jsonResponse(true, {})))();
+    }
+    throw new Error(`Unhandled fetch to ${url}`);
+  });
+}
+
 describe('useWallet authentication', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAddress.mockReset();
     mockSignMessage.mockReset();
-    vi.stubGlobal('fetch', vi.fn());
     window.localStorage.clear();
     window.sessionStorage.clear();
-    // Clear cookies cleanly
-    document.cookie = 'session=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
-    document.cookie = 'session=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
-    
-    // Default mock response to avoid unhandled TypeErrors in the background
+    document.cookie = '';
     mockSignMessage.mockResolvedValue({ signedMessage: 'mock_signature' });
   });
 
@@ -35,32 +62,19 @@ describe('useWallet authentication', () => {
   it('successful authentication flow (happy path)', async () => {
     mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
 
-    const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        success: true,
-        data: {
-          nonce: 'test_nonce',
-          message: 'Sign in to CommitLabs: test_nonce',
-        },
-      }),
-    } as Response);
-
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        success: true,
-        data: {
-          verified: true,
-          sessionToken: 'session_mockToken_123',
-        },
-      }),
-    } as Response);
-
-    mockSignMessage.mockResolvedValueOnce({
-      signedMessage: 'mock_signature',
+    const mockFetch = createFetchMock({
+      nonce: () =>
+        jsonResponse(true, {
+          success: true,
+          data: { nonce: 'test_nonce', message: 'Sign in to CommitLabs: test_nonce' },
+        }),
+      verify: () =>
+        jsonResponse(true, {
+          success: true,
+          data: { verified: true, address: 'GCONNECTED' },
+        }),
     });
+    vi.stubGlobal('fetch', mockFetch);
 
     const { result } = renderHook(() => useWallet());
 
@@ -80,28 +94,24 @@ describe('useWallet authentication', () => {
 
     expect(result.current.authenticating).toBe(false);
     expect(result.current.authenticated).toBe(true);
-    expect(result.current.sessionToken).toBe('session_mockToken_123');
     expect(result.current.authError).toBeNull();
 
-    expect(window.localStorage.getItem('sessionToken')).toBe('session_mockToken_123');
-    expect(window.localStorage.getItem('commitlabs.authAddress')).toBe('GCONNECTED');
-    expect(document.cookie).toContain('session=session_mockToken_123');
+    // The session lives exclusively in the server-set HttpOnly cookie.
+    // The client must never write the token anywhere itself.
+    expect(window.localStorage.length).toBe(0);
+    expect(window.sessionStorage.length).toBe(0);
+    expect(document.cookie).toBe('');
   });
 
   it('handles user-rejected signature', async () => {
     mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
 
-    const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: { nonce: 'n', message: 'msg' },
-      }),
-    } as Response);
-
-    mockSignMessage.mockResolvedValueOnce({
-      error: 'User rejected signature',
+    const mockFetch = createFetchMock({
+      nonce: () => jsonResponse(true, { data: { nonce: 'n', message: 'msg' } }),
     });
+    vi.stubGlobal('fetch', mockFetch);
+
+    mockSignMessage.mockResolvedValueOnce({ error: 'User rejected signature' });
 
     const { result } = renderHook(() => useWallet());
     await waitFor(() => expect(result.current.connected).toBe(true));
@@ -119,17 +129,16 @@ describe('useWallet authentication', () => {
     expect(signInError.message).toBe('User rejected signature');
 
     expect(result.current.authenticated).toBe(false);
-    expect(result.current.sessionToken).toBeNull();
     expect(result.current.authError).toBe('User rejected signature');
   });
 
   it('handles nonce fetch failure', async () => {
     mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
 
-    const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-    } as Response);
+    const mockFetch = createFetchMock({
+      nonce: () => jsonResponse(false, {}),
+    });
+    vi.stubGlobal('fetch', mockFetch);
 
     const { result } = renderHook(() => useWallet());
     await waitFor(() => expect(result.current.connected).toBe(true));
@@ -147,31 +156,20 @@ describe('useWallet authentication', () => {
     expect(signInError.message).toBe('Failed to fetch authentication nonce.');
 
     expect(result.current.authenticated).toBe(false);
-    expect(result.current.sessionToken).toBeNull();
     expect(result.current.authError).toBe('Failed to fetch authentication nonce.');
   });
 
   it('handles signature verification failure', async () => {
     mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
 
-    const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: { nonce: 'n', message: 'msg' },
-      }),
-    } as Response);
-
-    mockSignMessage.mockResolvedValueOnce({
-      signedMessage: 'sig',
+    const mockFetch = createFetchMock({
+      nonce: () => jsonResponse(true, { data: { nonce: 'n', message: 'msg' } }),
+      verify: () =>
+        jsonResponse(false, { error: { message: 'Invalid signature supplied' } }),
     });
+    vi.stubGlobal('fetch', mockFetch);
 
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({
-        error: { message: 'Invalid signature supplied' },
-      }),
-    } as Response);
+    mockSignMessage.mockResolvedValueOnce({ signedMessage: 'sig' });
 
     const { result } = renderHook(() => useWallet());
     await waitFor(() => expect(result.current.connected).toBe(true));
@@ -189,26 +187,19 @@ describe('useWallet authentication', () => {
     expect(signInError.message).toBe('Invalid signature supplied');
 
     expect(result.current.authenticated).toBe(false);
-    expect(result.current.sessionToken).toBeNull();
     expect(result.current.authError).toBe('Invalid signature supplied');
   });
 
   it('re-fetches the address when signIn starts without a connected wallet', async () => {
-    mockGetAddress.mockResolvedValueOnce({ error: 'User rejected request' }).mockResolvedValueOnce({ address: 'GCONNECTED' });
+    mockGetAddress
+      .mockResolvedValueOnce({ error: 'User rejected request' })
+      .mockResolvedValueOnce({ address: 'GCONNECTED' });
 
-    const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: { nonce: 'n', message: 'msg' },
-      }),
-    } as Response);
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: { verified: true, sessionToken: 'token' },
-      }),
-    } as Response);
+    const mockFetch = createFetchMock({
+      nonce: () => jsonResponse(true, { data: { nonce: 'n', message: 'msg' } }),
+      verify: () => jsonResponse(true, { data: { verified: true, address: 'GCONNECTED' } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
 
     const { result } = renderHook(() => useWallet());
     await waitFor(() => expect(result.current.error).toContain('rejected'));
@@ -221,16 +212,13 @@ describe('useWallet authentication', () => {
     expect(result.current.address).toBe('GCONNECTED');
   });
 
-  it('handles missing nonce message and no signature response', async () => {
+  it('reports missing nonce challenge messages', async () => {
     mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
 
-    const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: { nonce: 'n' },
-      }),
-    } as Response);
+    const mockFetch = createFetchMock({
+      nonce: () => jsonResponse(true, { data: { nonce: 'n' } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
 
     mockSignMessage.mockResolvedValueOnce(undefined as unknown as { signedMessage: string });
 
@@ -252,6 +240,7 @@ describe('useWallet authentication', () => {
 
   it('surfaces a generic fallback error for unknown Freighter failures', async () => {
     mockGetAddress.mockRejectedValue(new Error('mystery wallet failure'));
+    vi.stubGlobal('fetch', createFetchMock({}));
 
     const { result } = renderHook(() => useWallet());
 
@@ -261,6 +250,7 @@ describe('useWallet authentication', () => {
 
   it('reports getAddress errors during signIn as authentication errors', async () => {
     mockGetAddress.mockResolvedValue({ error: 'Freighter is locked' });
+    vi.stubGlobal('fetch', createFetchMock({}));
 
     const { result } = renderHook(() => useWallet());
     await waitFor(() => expect(result.current.error).toContain('Freighter'));
@@ -281,6 +271,7 @@ describe('useWallet authentication', () => {
 
   it('reports missing wallet addresses during signIn', async () => {
     mockGetAddress.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+    vi.stubGlobal('fetch', createFetchMock({}));
 
     const { result } = renderHook(() => useWallet());
     await waitFor(() => expect(getAddress).toHaveBeenCalled());
@@ -301,13 +292,10 @@ describe('useWallet authentication', () => {
   it('reports missing signature responses from Freighter', async () => {
     mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
 
-    const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: { nonce: 'n', message: 'msg' },
-      }),
-    } as Response);
+    const mockFetch = createFetchMock({
+      nonce: () => jsonResponse(true, { data: { nonce: 'n', message: 'msg' } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
 
     mockSignMessage.mockResolvedValueOnce(undefined as unknown as { signedMessage: string });
 
@@ -330,13 +318,10 @@ describe('useWallet authentication', () => {
   it('reports missing signedMessage payloads during signIn', async () => {
     mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
 
-    const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: { nonce: 'n', message: 'msg' },
-      }),
-    } as Response);
+    const mockFetch = createFetchMock({
+      nonce: () => jsonResponse(true, { data: { nonce: 'n', message: 'msg' } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
 
     mockSignMessage.mockResolvedValueOnce({} as { signedMessage: string });
 
@@ -356,25 +341,14 @@ describe('useWallet authentication', () => {
     expect(signInError.message).toContain('rejected');
   });
 
-  it('handles verification responses without a session token', async () => {
+  it('treats a verify response with verified: false as a failed handshake', async () => {
     mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
 
-    const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: { nonce: 'n', message: 'msg' },
-      }),
-    } as Response);
-
-    mockSignMessage.mockResolvedValue({ signedMessage: 'sig' });
-
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: { verified: true, sessionToken: '' },
-      }),
-    } as Response);
+    const mockFetch = createFetchMock({
+      nonce: () => jsonResponse(true, { data: { nonce: 'n', message: 'msg' } }),
+      verify: () => jsonResponse(true, { data: { verified: false } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
 
     const { result } = renderHook(() => useWallet());
     await waitFor(() => expect(result.current.connected).toBe(true));
@@ -389,40 +363,41 @@ describe('useWallet authentication', () => {
     });
 
     expect(signInError).not.toBeNull();
-    expect(signInError.message).toContain('Session token');
+    expect(signInError.message).toContain('Verification failed');
+    expect(result.current.authenticated).toBe(false);
   });
 
-  it('successful sign-out clears storage, cookies, and state', async () => {
+  it('successful sign-out clears authenticated state', async () => {
     mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
 
-    window.localStorage.setItem('sessionToken', 'session_active_123');
-    window.localStorage.setItem('commitlabs.authAddress', 'GCONNECTED');
-    document.cookie = 'session=session_active_123';
-
-    const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-    } as Response);
+    const mockFetch = createFetchMock({
+      session: () => jsonResponse(true, { authenticated: true, address: 'GCONNECTED' }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
 
     const { result } = renderHook(() => useWallet());
-    await waitFor(() => expect(result.current.sessionToken).toBe('session_active_123'));
-    expect(result.current.authenticated).toBe(true);
+    await waitFor(() => expect(result.current.authenticated).toBe(true));
 
     await act(async () => {
       await result.current.signOut();
     });
 
     expect(result.current.authenticated).toBe(false);
-    expect(result.current.sessionToken).toBeNull();
-    expect(window.localStorage.getItem('sessionToken')).toBeNull();
-    expect(document.cookie).not.toContain('session=session_active_123');
+    expect(mockFetch).toHaveBeenCalledWith('/api/auth/logout', { method: 'POST' });
+
+    // No client-visible token anywhere to clean up.
+    expect(window.localStorage.length).toBe(0);
+    expect(window.sessionStorage.length).toBe(0);
+    expect(document.cookie).toBe('');
   });
 
   it('automatic sign-out on address mismatch or disconnect (account-switching safety)', async () => {
     mockGetAddress.mockResolvedValueOnce({ address: 'GCONNECTED_1' });
-    window.localStorage.setItem('sessionToken', 'session_active_123');
-    window.localStorage.setItem('commitlabs.authAddress', 'GCONNECTED_1');
-    document.cookie = 'session=session_active_123';
+
+    const mockFetch = createFetchMock({
+      session: () => jsonResponse(true, { authenticated: true, address: 'GCONNECTED_1' }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
 
     const { result } = renderHook(() => useWallet());
     await waitFor(() => expect(result.current.connected).toBe(true));
@@ -437,30 +412,30 @@ describe('useWallet authentication', () => {
 
     await waitFor(() => expect(result.current.address).toBe('GCONNECTED_2'));
     await waitFor(() => expect(result.current.authenticated).toBe(false));
-    expect(result.current.sessionToken).toBeNull();
-    expect(window.localStorage.getItem('sessionToken')).toBeNull();
+
+    // The session for GCONNECTED_1 no longer matches the wallet's reported
+    // address, so the hook must have called logout to drop it.
+    expect(mockFetch).toHaveBeenCalledWith('/api/auth/logout', { method: 'POST' });
   });
 
   it('prevent parallel signIn calls if already authenticating', async () => {
     mockGetAddress.mockResolvedValue({ address: 'GCONNECTED' });
 
-    const mockFetch = vi.mocked(fetch);
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => new Promise(resolve => setTimeout(() => resolve({
-        data: { nonce: 'n', message: 'msg' },
-      }), 50)),
-    } as Response);
+    let resolveNonce: (value: Response) => void;
+    const noncePromise = new Promise<Response>((resolve) => {
+      resolveNonce = resolve;
+    });
 
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: { verified: true, sessionToken: 'token' },
-      }),
-    } as Response);
+    const mockFetch = createFetchMock({
+      nonce: () => noncePromise,
+      verify: () => jsonResponse(true, { data: { verified: true, address: 'GCONNECTED' } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
 
     const { result } = renderHook(() => useWallet());
     await waitFor(() => expect(result.current.connected).toBe(true));
+
+    const nonceCallsBefore = mockFetch.mock.calls.filter((c) => c[0] === '/api/auth/nonce').length;
 
     let signInPromise1: Promise<void>;
     act(() => {
@@ -474,10 +449,13 @@ describe('useWallet authentication', () => {
       signInPromise2 = result.current.signIn();
     });
 
+    resolveNonce!(jsonResponse(true, { data: { nonce: 'n', message: 'msg' } }));
+
     await act(async () => {
       await Promise.all([signInPromise1, signInPromise2]);
     });
 
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const nonceCallsAfter = mockFetch.mock.calls.filter((c) => c[0] === '/api/auth/nonce').length;
+    expect(nonceCallsAfter - nonceCallsBefore).toBe(1);
   });
 });

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,5 +1,5 @@
 import { getAddress, getNetworkDetails, signMessage } from "@stellar/freighter-api";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 
 const WALLET_TIMEOUT_MS = 10000;
 
@@ -74,59 +74,29 @@ const withWalletTimeout = async <T,>(promise: Promise<T>, fallbackMessage: strin
   });
 };
 
-const STORED_TOKEN_KEYS = [
-  "commitlabs.sessionToken",
-  "commitlabs:sessionToken",
-  "sessionToken",
-];
+interface SessionCheckResult {
+  authenticated: boolean;
+  address?: string;
+}
 
-const getStoredToken = (): string | null => {
-  if (typeof window === "undefined") return null;
-  for (const key of STORED_TOKEN_KEYS) {
-    const val = window.sessionStorage.getItem(key) ?? window.localStorage.getItem(key);
-    if (val?.trim()) return val.trim();
+/**
+ * Asks the server whether the HttpOnly session cookie (set by
+ * /api/auth/verify) is still valid. The session token itself is never
+ * readable from client-side JavaScript.
+ */
+const checkSession = async (): Promise<SessionCheckResult> => {
+  try {
+    const res = await fetch("/api/auth/session");
+    if (!res.ok) return { authenticated: false };
+    const json = await res.json();
+    const data = json.data || json;
+    if (data.authenticated && data.address) {
+      return { authenticated: true, address: data.address };
+    }
+    return { authenticated: false };
+  } catch {
+    return { authenticated: false };
   }
-  // Try reading from cookies
-  const cookies = document.cookie.split(";");
-  for (const c of cookies) {
-    const [name, val] = c.trim().split("=");
-    if (name === "session" && val) return decodeURIComponent(val);
-  }
-  return null;
-};
-
-const getStoredAddress = (): string | null => {
-  if (typeof window === "undefined") return null;
-  return window.sessionStorage.getItem("commitlabs.authAddress") ?? window.localStorage.getItem("commitlabs.authAddress");
-};
-
-const saveSession = (token: string, addr: string) => {
-  if (typeof window === "undefined") return;
-  for (const key of STORED_TOKEN_KEYS) {
-    window.localStorage.setItem(key, token);
-    window.sessionStorage.setItem(key, token);
-  }
-  window.localStorage.setItem("commitlabs.authAddress", addr);
-  window.sessionStorage.setItem("commitlabs.authAddress", addr);
-
-  const secureFlag = window.location.protocol === "https:" ? "; Secure" : "";
-  document.cookie = `session=${encodeURIComponent(token)}; path=/; SameSite=Lax${secureFlag}`;
-};
-
-const clearSession = () => {
-  if (typeof window === "undefined") return;
-  for (const key of STORED_TOKEN_KEYS) {
-    window.localStorage.removeItem(key);
-    window.sessionStorage.removeItem(key);
-  }
-  window.localStorage.removeItem("commitlabs.authAddress");
-  window.sessionStorage.removeItem("commitlabs.authAddress");
-
-  const secureFlag = window.location.protocol === "https:" ? "; Secure" : "";
-  document.cookie = `session=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax${secureFlag}`;
-  // Fallbacks for testing environments or strict cookie parsers
-  document.cookie = "session=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
-  document.cookie = "session=; max-age=0";
 };
 
 /**
@@ -141,9 +111,18 @@ export const useWallet = () => {
   const [walletNetwork, setWalletNetwork] = useState<string | null>(null);
 
   // Authentication State
-  const [sessionToken, setSessionToken] = useState<string | null>(() => getStoredToken());
+  const [authenticated, setAuthenticated] = useState(false);
   const [authenticating, setAuthenticating] = useState(false);
   const [authError, setAuthError] = useState<string | null>(null);
+
+  // signIn() sometimes has to set `address`/`connected` itself (when it
+  // starts without an already-connected wallet), which would otherwise
+  // re-trigger the "sync auth state with server" effect below concurrently
+  // with signIn's own in-progress nonce/verify flow - racing its
+  // checkSession() call against signIn's own setAuthenticated(true) once it
+  // completes. signIn is authoritative for its own outcome, so it flips this
+  // flag to tell that effect to skip the redundant round-trip once.
+  const skipNextAuthSyncRef = useRef(false);
 
   const fetchAddress = useCallback(async () => {
     setConnecting(true);
@@ -194,18 +173,11 @@ export const useWallet = () => {
 
   const signOut = useCallback(async () => {
     try {
-      const storedToken = getStoredToken();
-      if (storedToken) {
-        await fetch("/api/auth/logout", {
-          method: "POST",
-          headers: {
-            "Authorization": `Bearer ${storedToken}`,
-          },
-        }).catch(() => {});
-      }
+      // The HttpOnly session cookie is sent automatically; the server reads
+      // it to know which session to revoke.
+      await fetch("/api/auth/logout", { method: "POST" }).catch(() => {});
     } finally {
-      clearSession();
-      setSessionToken(null);
+      setAuthenticated(false);
       setAuthError(null);
     }
   }, []);
@@ -236,6 +208,7 @@ export const useWallet = () => {
           throw new Error("Unable to retrieve address from Freighter.");
         }
         currentAddress = result.address;
+        skipNextAuthSyncRef.current = true;
         setAddress(currentAddress);
         setConnected(true);
         setError(null);
@@ -299,22 +272,22 @@ export const useWallet = () => {
 
       const verifyData = await verifyRes.json();
       const vData = verifyData.data || verifyData;
-      const { verified, sessionToken: token } = vData;
+      const { verified } = vData;
 
-      if (!verified || !token) {
-        throw new Error("Verification failed: Session token not received.");
+      if (!verified) {
+        throw new Error("Verification failed.");
       }
 
-      saveSession(token, currentAddress);
-      setSessionToken(token);
+      // The server has set the HttpOnly session cookie on this response;
+      // there is no token for the client to hold onto.
+      setAuthenticated(true);
       setAuthError(null);
       setError(null);
     } catch (e) {
       const msg = (e as Error).message || "Authentication handshake failed.";
       setAuthError(msg);
       setError(msg);
-      clearSession();
-      setSessionToken(null);
+      setAuthenticated(false);
       setConnected(false);
       setAddress("");
       setWalletNetwork(null);
@@ -329,28 +302,49 @@ export const useWallet = () => {
     fetchAddress();
   }, [fetchAddress]);
 
-  // Sync session state once connection check completes or when address/connected changes
+  // Sync auth state with the server once the Freighter connection check
+  // completes, or whenever the connected address changes. The session lives
+  // exclusively in the HttpOnly cookie, so the only way to know if it's
+  // still valid is to ask the server.
+  //
+  // Skipped once when signIn() itself just set `connected`/`address` (see
+  // skipNextAuthSyncRef above) - signIn already determines the authoritative
+  // outcome via its own nonce/verify flow, so a redundant checkSession() call
+  // here would race against signIn's own setAuthenticated(true) and could
+  // clobber it depending on which one resolves last.
   useEffect(() => {
-    if (typeof window === "undefined") return;
     if (!initialCheckDone) return;
-
-    const storedToken = getStoredToken();
-    const storedAddress = getStoredAddress();
-
-    if (connected && address) {
-      if (storedToken && storedAddress === address) {
-        setSessionToken(storedToken);
-      } else {
-        clearSession();
-        setSessionToken(null);
-      }
-    } else {
-      clearSession();
-      setSessionToken(null);
+    if (skipNextAuthSyncRef.current) {
+      skipNextAuthSyncRef.current = false;
+      return;
     }
-  }, [address, connected, initialCheckDone]);
+    let cancelled = false;
 
-  const authenticated = !!sessionToken;
+    (async () => {
+      if (!connected || !address) {
+        if (!cancelled) setAuthenticated(false);
+        return;
+      }
+
+      const session = await checkSession();
+      if (cancelled) return;
+
+      if (session.authenticated && session.address === address) {
+        setAuthenticated(true);
+      } else if (session.authenticated) {
+        // The authenticated session belongs to a different address than the
+        // one Freighter now reports (e.g. the user switched accounts) -
+        // drop the stale session rather than trust it.
+        await signOut();
+      } else {
+        setAuthenticated(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [address, connected, initialCheckDone, signOut]);
 
   return {
     connected,
@@ -359,7 +353,6 @@ export const useWallet = () => {
     disconnect,
     error,
     connecting,
-    sessionToken,
     authenticated,
     authenticating,
     authError,

--- a/src/lib/backend/auth.ts
+++ b/src/lib/backend/auth.ts
@@ -32,6 +32,17 @@ export interface SignatureVerificationResult {
 const NONCE_TTL_SECONDS = 5 * 60;
 const SESSION_TTL = 24 * 60 * 60 * 1000;
 
+/** HttpOnly cookie holding the opaque wallet-auth session token. */
+export const AUTH_COOKIE_NAME = "cl_auth_session";
+
+export const COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: "lax" as const,
+  secure: process.env.NODE_ENV === "production",
+  path: "/",
+  maxAge: SESSION_TTL / 1000,
+};
+
 /**
  * Env vars checked (in priority order) when deriving the default domain.
  *


### PR DESCRIPTION
The saveSession function in src/hooks/useWallet.ts creates a security vulnerability by storing authentication tokens in localStorage (three duplicate key aliases), sessionStorage (three duplicate key aliases), and a non-HttpOnly document.cookie — all readable by any script executing on the page, creating an XSS-to-token-theft vector.

## Description

`useWallet`'s `saveSession()` wrote the session token to `localStorage`/`sessionStorage` under three key aliases plus a JS-readable `document.cookie`. This conflicted with the existing secure HttpOnly cookie implementation in `lib/backend/session.ts`, which turned out to exist but was never actually wired into the wallet-connect flow — `/api/auth/verify` only ever returned the token in its JSON body and never set a cookie, which is exactly why the client fell back to storing it itself.

This PR wires the existing HttpOnly cookie infrastructure into the real auth flow and removes all client-side token storage from `useWallet`.

Closes #1330

## Changes

- **`src/lib/backend/auth.ts`**: exports `AUTH_COOKIE_NAME`/`COOKIE_OPTIONS`. These were already imported by `logout/route.ts` and the `sessions` routes but never defined there — those routes were silently broken before this fix.
- **`src/app/api/auth/verify/route.ts`**: sets the session as an HttpOnly cookie via `response.cookies.set(...)`; no longer returns the raw token in the JSON body.
- **`src/app/api/auth/session/route.ts`** (new): `GET` endpoint reporting `{ authenticated, address }` derived from the cookie server-side — the only way the client can now learn its auth state, since it can't read the cookie's value.
- **`src/hooks/useWallet.ts`**: removed `getStoredToken`/`getStoredAddress`/`saveSession`/`clearSession` entirely. `signIn`/`signOut` no longer touch storage; the hook syncs `authenticated` via `/api/auth/session` and drops stale sessions (e.g. wallet account switch) via `/api/auth/logout`.
- **`docs/WALLET_AUTH.md`**: updated to describe the cookie-only flow instead of documenting the old multi-location storage as intentional.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [x] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [x] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

N/A — backend/hook logic change, no UI impact.