### PR TITLE
Wire Date range and Format selectors in ExportCommitmentsModal to the…

### DIFF
--- a/src/app/api/commitments/export/route.test.ts
+++ b/src/app/api/commitments/export/route.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/backend/rateLimit', () => ({
+  checkRateLimit: vi.fn(),
+}));
+
+vi.mock('@/lib/backend/auth', () => ({
+  verifySessionToken: vi.fn(),
+}));
+
+vi.mock('@/lib/backend/services/contracts', () => ({
+  getUserCommitmentsFromChain: vi.fn(),
+}));
+
+import { checkRateLimit } from '@/lib/backend/rateLimit';
+import { verifySessionToken } from '@/lib/backend/auth';
+import { getUserCommitmentsFromChain } from '@/lib/backend/services/contracts';
+import { GET } from './route';
+
+const OWNER = 'gowneraddress';
+
+function makeRequest(query: string): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/commitments/export?${query}`, {
+    headers: { authorization: 'Bearer test-token' },
+  });
+}
+
+function commitment(overrides: Partial<{ id: string; createdAt: string }> = {}) {
+  return {
+    id: overrides.id ?? 'commitment-1',
+    ownerAddress: OWNER,
+    asset: 'XLM',
+    amount: '100',
+    status: 'ACTIVE' as const,
+    complianceScore: 100,
+    currentValue: '100',
+    feeEarned: '0',
+    violationCount: 0,
+    createdAt: overrides.createdAt,
+    expiresAt: undefined,
+  };
+}
+
+async function readCsvBody(res: Response): Promise<string> {
+  return await res.text();
+}
+
+describe('GET /api/commitments/export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(checkRateLimit).mockResolvedValue(true);
+    vi.mocked(verifySessionToken).mockReturnValue({ valid: true, address: OWNER });
+  });
+
+  it('rejects an unsupported export format with 400', async () => {
+    vi.mocked(getUserCommitmentsFromChain).mockResolvedValue([commitment()]);
+
+    const res = await GET(makeRequest(`ownerAddress=${OWNER}&format=json`), { params: {} });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe('BAD_REQUEST');
+    expect(body.error.message).toContain('json');
+  });
+
+  it('defaults to csv when no format is specified', async () => {
+    vi.mocked(getUserCommitmentsFromChain).mockResolvedValue([commitment()]);
+
+    const res = await GET(makeRequest(`ownerAddress=${OWNER}`), { params: {} });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/csv');
+  });
+
+  it('excludes commitments created before the requested date range cutoff', async () => {
+    const now = new Date('2026-06-15T00:00:00.000Z');
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    vi.mocked(getUserCommitmentsFromChain).mockResolvedValue([
+      commitment({ id: 'recent', createdAt: '2026-06-10T00:00:00.000Z' }),
+      commitment({ id: 'old', createdAt: '2026-01-01T00:00:00.000Z' }),
+    ]);
+
+    const res = await GET(
+      makeRequest(`ownerAddress=${OWNER}&dateRange=7d&columns=Commitment ID`),
+      { params: {} },
+    );
+    const csv = await readCsvBody(res);
+
+    expect(csv).toContain('recent');
+    expect(csv).not.toContain('old');
+
+    vi.useRealTimers();
+  });
+
+  it('includes all commitments when dateRange is "all" or omitted', async () => {
+    vi.mocked(getUserCommitmentsFromChain).mockResolvedValue([
+      commitment({ id: 'recent', createdAt: '2026-06-10T00:00:00.000Z' }),
+      commitment({ id: 'old', createdAt: '2020-01-01T00:00:00.000Z' }),
+    ]);
+
+    const res = await GET(
+      makeRequest(`ownerAddress=${OWNER}&dateRange=all&columns=Commitment ID`),
+      { params: {} },
+    );
+    const csv = await readCsvBody(res);
+
+    expect(csv).toContain('recent');
+    expect(csv).toContain('old');
+  });
+
+  it('excludes commitments with a missing createdAt when a narrower range is requested', async () => {
+    vi.mocked(getUserCommitmentsFromChain).mockResolvedValue([
+      commitment({ id: 'undated', createdAt: undefined }),
+    ]);
+
+    const res = await GET(
+      makeRequest(`ownerAddress=${OWNER}&dateRange=30d&columns=Commitment ID`),
+      { params: {} },
+    );
+    const csv = await readCsvBody(res);
+
+    expect(csv).not.toContain('undated');
+  });
+
+  it('falls back to "all" for an unrecognized dateRange value instead of rejecting the request', async () => {
+    vi.mocked(getUserCommitmentsFromChain).mockResolvedValue([
+      commitment({ id: 'commitment-x', createdAt: '2020-01-01T00:00:00.000Z' }),
+    ]);
+
+    const res = await GET(
+      makeRequest(`ownerAddress=${OWNER}&dateRange=not-a-real-range&columns=Commitment ID`),
+      { params: {} },
+    );
+    const csv = await readCsvBody(res);
+
+    expect(res.status).toBe(200);
+    expect(csv).toContain('commitment-x');
+  });
+});

--- a/src/app/api/commitments/export/route.ts
+++ b/src/app/api/commitments/export/route.ts
@@ -10,7 +10,7 @@ import {
 import { checkRateLimit } from '@/lib/backend/rateLimit';
 import {
   getUserCommitmentsFromChain,
-  type Commitment,
+  type ChainCommitment,
 } from '@/lib/backend/services/contracts';
 import { withApiHandler } from '@/lib/backend/withApiHandler';
 
@@ -31,7 +31,7 @@ const ALL_CSV_HEADERS = [
 type CsvHeader = (typeof ALL_CSV_HEADERS)[number];
 
 /** Map each header label to the commitment field that supplies its value. */
-const HEADER_TO_FIELD: Record<CsvHeader, (c: Commitment) => unknown> = {
+const HEADER_TO_FIELD: Record<CsvHeader, (c: ChainCommitment) => unknown> = {
   'Commitment ID': (c) => c.id,
   'Owner': (c) => c.ownerAddress,
   'Asset': (c) => c.asset,
@@ -75,7 +75,7 @@ function normalizeAddress(address: string): string {
  * between iterations.
  */
 function* commitmentsToRows(
-  commitments: Iterable<Commitment>,
+  commitments: Iterable<ChainCommitment>,
   headers: readonly CsvHeader[],
 ): Generator<CsvRow> {
   for (const commitment of commitments) {
@@ -96,6 +96,64 @@ function resolveRequestedHeaders(columnsParam: string | null): CsvHeader[] {
     (ALL_CSV_HEADERS as readonly string[]).includes(c),
   );
   return valid.length > 0 ? valid : [...ALL_CSV_HEADERS];
+}
+
+const SUPPORTED_EXPORT_FORMATS = ['csv'] as const;
+type ExportFormat = (typeof SUPPORTED_EXPORT_FORMATS)[number];
+
+/**
+ * Only CSV is implemented server-side today. Any other value (e.g. the
+ * "JSON soon" option surfaced but disabled in the UI) is rejected rather
+ * than silently downgraded to CSV.
+ */
+function resolveExportFormat(formatParam: string | null): ExportFormat {
+  if (!formatParam || formatParam === 'csv') return 'csv';
+
+  throw new BadRequestError(`Unsupported export format: ${formatParam}. Only "csv" is available.`);
+}
+
+const DATE_RANGES = ['all', '7d', '30d', 'year'] as const;
+type DateRange = (typeof DATE_RANGES)[number];
+
+function resolveDateRange(dateRangeParam: string | null): DateRange {
+  if (!dateRangeParam) return 'all';
+  return (DATE_RANGES as readonly string[]).includes(dateRangeParam)
+    ? (dateRangeParam as DateRange)
+    : 'all';
+}
+
+/** Cutoff instant a commitment's `createdAt` must be on-or-after to match `range`. */
+function dateRangeCutoff(range: DateRange, now: Date): Date | null {
+  switch (range) {
+    case '7d':
+      return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    case '30d':
+      return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    case 'year':
+      return new Date(now.getFullYear(), 0, 1);
+    case 'all':
+      return null;
+  }
+}
+
+/**
+ * Filters commitments to those created on-or-after the range's cutoff.
+ * Commitments with a missing/unparseable `createdAt` are excluded from any
+ * range narrower than "all", since their membership can't be confirmed.
+ */
+function filterByDateRange(
+  commitments: ChainCommitment[],
+  range: DateRange,
+  now: Date = new Date(),
+): ChainCommitment[] {
+  const cutoff = dateRangeCutoff(range, now);
+  if (!cutoff) return commitments;
+
+  return commitments.filter((c) => {
+    if (!c.createdAt) return false;
+    const createdAt = new Date(c.createdAt);
+    return !Number.isNaN(createdAt.getTime()) && createdAt >= cutoff;
+  });
 }
 
 export const GET = withApiHandler(async (req: NextRequest) => {
@@ -124,12 +182,14 @@ export const GET = withApiHandler(async (req: NextRequest) => {
   }
 
   const headers = resolveRequestedHeaders(searchParams.get('columns'));
+  resolveExportFormat(searchParams.get('format'));
+  const dateRange = resolveDateRange(searchParams.get('dateRange'));
 
   // Fetch happens before streaming starts so any failure here is caught by
   // `withApiHandler` and surfaced as a JSON error response, not a truncated
   // CSV. When `getUserCommitmentsFromChain` becomes streamable, swap the
   // generator argument for the async iterable directly.
-  const commitments = await getUserCommitmentsFromChain(ownerAddress);
+  const commitments = filterByDateRange(await getUserCommitmentsFromChain(ownerAddress), dateRange);
   const stream = createCsvStream(headers, commitmentsToRows(commitments, headers));
 
   return new NextResponse(stream, {

--- a/src/components/export/ExportCommitmentsModal.tsx
+++ b/src/components/export/ExportCommitmentsModal.tsx
@@ -24,6 +24,17 @@ export type ExportColumn = (typeof ALL_EXPORT_COLUMNS)[number];
 
 export type ScheduleInterval = 'never' | 'daily' | 'weekly' | 'monthly';
 
+export type ExportDateRange = 'all' | '7d' | '30d' | 'year';
+
+const DATE_RANGE_OPTIONS: { value: ExportDateRange; label: string }[] = [
+  { value: 'all', label: 'All time' },
+  { value: '7d', label: 'Last 7 days' },
+  { value: '30d', label: 'Last 30 days' },
+  { value: 'year', label: 'This year' },
+];
+
+export type ExportFormat = 'csv' | 'json';
+
 const SCHEDULE_OPTIONS: { value: ScheduleInterval; label: string }[] = [
   { value: 'never', label: 'No reminder' },
   { value: 'daily', label: 'Daily' },
@@ -179,6 +190,8 @@ export default function ExportCommitmentsModal({
   const [message, setMessage] = useState('');
   const [selectedColumns, setSelectedColumns] = useState<ExportColumn[]>([...ALL_EXPORT_COLUMNS]);
   const [scheduleInterval, setScheduleInterval] = useState<ScheduleInterval>('never');
+  const [dateRange, setDateRange] = useState<ExportDateRange>('all');
+  const [format, setFormat] = useState<ExportFormat>('csv');
 
   // Restore preferences when modal opens
   useEffect(() => {
@@ -188,6 +201,8 @@ export default function ExportCommitmentsModal({
     const prefs = loadExportPreferences();
     setSelectedColumns(prefs.selectedColumns);
     setScheduleInterval(prefs.scheduleInterval);
+    setDateRange('all');
+    setFormat('csv');
   }, [isOpen]);
 
   const toggleColumn = useCallback((column: ExportColumn) => {
@@ -236,6 +251,8 @@ export default function ExportCommitmentsModal({
       const url = new URL(endpoint, window.location.origin);
       url.searchParams.set('ownerAddress', normalizedAddress);
       url.searchParams.set('columns', selectedColumns.join(','));
+      url.searchParams.set('dateRange', dateRange);
+      url.searchParams.set('format', format);
 
       // Add selected IDs if provided
       if (selectedIds && selectedIds.length > 0) {
@@ -273,7 +290,7 @@ export default function ExportCommitmentsModal({
       setStatus('error');
       setMessage('Export failed. Try again in a moment.');
     }
-  }, [endpoint, ownerAddress, sessionToken, selectedColumns, scheduleInterval, noneChecked]);
+  }, [endpoint, ownerAddress, sessionToken, selectedColumns, scheduleInterval, dateRange, format, noneChecked]);
 
   const isLoading = status === 'loading';
 
@@ -333,12 +350,15 @@ export default function ExportCommitmentsModal({
             Date range
             <select
               className="rounded-[12px] border border-white/10 bg-black px-3 py-2 text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC]"
-              defaultValue="all"
+              value={dateRange}
+              onChange={(e) => setDateRange(e.target.value as ExportDateRange)}
+              aria-label="Date range"
             >
-              <option value="all">All time</option>
-              <option value="7d">Last 7 days</option>
-              <option value="30d">Last 30 days</option>
-              <option value="year">This year</option>
+              {DATE_RANGE_OPTIONS.map(({ value, label }) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
             </select>
           </label>
 
@@ -346,7 +366,9 @@ export default function ExportCommitmentsModal({
             Format
             <select
               className="rounded-[12px] border border-white/10 bg-black px-3 py-2 text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0FF0FC]"
-              defaultValue="csv"
+              value={format}
+              onChange={(e) => setFormat(e.target.value as ExportFormat)}
+              aria-label="Export format"
             >
               <option value="csv">CSV</option>
               <option value="json" disabled>

--- a/tests/components/ExportCommitmentsModal.test.tsx
+++ b/tests/components/ExportCommitmentsModal.test.tsx
@@ -61,7 +61,7 @@ describe('ExportCommitmentsModal', () => {
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
-        'http://localhost:3000/api/commitments/export?ownerAddress=GOWNERADDRESS',
+        'http://localhost:3000/api/commitments/export?ownerAddress=GOWNERADDRESS&columns=Commitment+ID%2COwner%2CAsset%2CAmount%2CStatus%2CCompliance+Score%2CCurrent+Value%2CFee+Earned%2CViolation+Count%2CCreated+At%2CExpires+At&dateRange=all&format=csv',
         {
           method: 'GET',
           headers: {
@@ -399,12 +399,82 @@ describe('ExportCommitmentsModal', () => {
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
-        'http://localhost:3000/api/commitments/export?ownerAddress=GOWNERADDRESS',
+        'http://localhost:3000/api/commitments/export?ownerAddress=GOWNERADDRESS&columns=Commitment+ID%2COwner%2CAsset%2CAmount%2CStatus%2CCompliance+Score%2CCurrent+Value%2CFee+Earned%2CViolation+Count%2CCreated+At%2CExpires+At&dateRange=all&format=csv',
         expect.objectContaining({
           headers: { Authorization: 'Bearer token-with-space' },
         })
       );
     });
+  });
+
+  it('includes a non-default date range in the outgoing export request URL', async () => {
+    mockSuccessfulFetch();
+
+    renderModal();
+
+    fireEvent.change(screen.getByLabelText('Date range'), { target: { value: '30d' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('dateRange=30d'),
+        expect.any(Object)
+      );
+    });
+
+    const [calledUrl] = vi.mocked(fetch).mock.calls[0];
+    expect(calledUrl).not.toContain('dateRange=all');
+  });
+
+  it('defaults the date range and format to all-time CSV when left untouched', async () => {
+    mockSuccessfulFetch();
+
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('dateRange=all'),
+        expect.any(Object)
+      );
+    });
+
+    const [calledUrl] = vi.mocked(fetch).mock.calls[0];
+    expect(calledUrl).toContain('format=csv');
+  });
+
+  it('resets date range and format selections when the dialog reopens', () => {
+    const { rerender } = render(
+      <ExportCommitmentsModal
+        isOpen={true}
+        onClose={vi.fn()}
+        ownerAddress="GOWNERADDRESS"
+        sessionToken="session-token"
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Date range'), { target: { value: 'year' } });
+    expect((screen.getByLabelText('Date range') as HTMLSelectElement).value).toBe('year');
+
+    rerender(
+      <ExportCommitmentsModal
+        isOpen={false}
+        onClose={vi.fn()}
+        ownerAddress="GOWNERADDRESS"
+        sessionToken="session-token"
+      />
+    );
+    rerender(
+      <ExportCommitmentsModal
+        isOpen={true}
+        onClose={vi.fn()}
+        ownerAddress="GOWNERADDRESS"
+        sessionToken="session-token"
+      />
+    );
+
+    expect((screen.getByLabelText('Date range') as HTMLSelectElement).value).toBe('all');
   });
 
   it('skips whitespace-only tokens and falls through to the next storage key', async () => {


### PR DESCRIPTION
The "Date range" and "Format" dropdown selectors in ExportCommitmentsModal.tsx lack onChange handlers and backing state, making them purely visual. The handleExport function only passes ownerAddress, columns, and ids to the API — user selections remain ignored.

## Description

Both dropdowns rendered with `defaultValue` and no `onChange`, so they were uncontrolled and never influenced the export. This wires them to real state, includes both in the request, and adds server-side support so the selections actually change what gets exported.

Closes #1255

## Changes

- **`src/components/export/ExportCommitmentsModal.tsx`**: added `dateRange`/`format` state (types `ExportDateRange`/`ExportFormat`), wired `onChange` on both selects, reset both to their defaults when the modal reopens (matching the existing preference-reset effect), and included `dateRange`/`format` as export query params.
- **`src/app/api/commitments/export/route.ts`**:
  - `format` is validated — only `csv` is implemented (the UI's "JSON soon" option is already disabled), so any other value now gets a 400 instead of being silently ignored.
  - `dateRange` (`7d`/`30d`/`year`/`all`) filters commitments by `createdAt` before streaming the CSV; an unparseable or missing `createdAt` excludes a commitment from any range narrower than "all" rather than guessing.
  - Fixed the file's `type Commitment` import, which didn't correspond to any actual export in `contracts.ts` — the real type is `ChainCommitment`. This had gone unnoticed because (for reasons I couldn't fully pin down) this particular route file isn't part of the checked `tsc` program in this environment, so the broken import compiled silently.
- **`src/app/api/commitments/export/route.test.ts`** (new): covers format rejection, date-range filtering (including the missing-`createdAt` and unrecognized-value edge cases), and the CSV default path.
- **`tests/components/ExportCommitmentsModal.test.tsx`**: added the regression test the issue asks for (non-default date range alters the outgoing request URL), a default-params test, and a reset-on-reopen test. Also fixed a pre-existing, unrelated hardcoded-URL assertion that was missing the `columns` param `handleExport` has always sent — confirmed that test was already failing on `master` before this change.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [x] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [x] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

The two selects are now controlled/interactive instead of static; no layout or styling change. Didn't capture screenshots since the visual diff is effectively nil.