### PR TITLE
Reconcile MyCommitmentsOverview prop types with its children

### DIFF
--- a/src/components/MyCommitmentsOverview/MyCommitmentsOverview.tsx
+++ b/src/components/MyCommitmentsOverview/MyCommitmentsOverview.tsx
@@ -4,14 +4,10 @@ import React from 'react';
 import MyCommitmentsStats from '../MyCommitmentsStats/MyCommitmentsStats';
 import MyCommitmentsFilters from '../MyCommitmentsFilters/MyCommitmentsFilters';
 import { SortOption } from '@/utils/sortCommitments';
+import type { CommitmentStats } from '@/types/commitment';
 
 interface MyCommitmentsOverviewProps {
-  stats: {
-    totalActive: number;
-    totalCommittedValue: string;
-    averageComplianceScore: string;
-    totalFeesGenerated: string;
-  };
+  stats: CommitmentStats;
   search: {
     searchQuery: string;
     onSearchChange: (value: string) => void;
@@ -33,21 +29,16 @@ const MyCommitmentsOverview: React.FC<MyCommitmentsOverviewProps> = ({
 }) => {
   return (
     <div style={{ width: '100%' }}>
-      <MyCommitmentsStats
-        totalActive={stats.totalActive}
-        totalCommittedValue={stats.totalCommittedValue}
-        averageComplianceScore={stats.averageComplianceScore}
-        totalFeesGenerated={stats.totalFeesGenerated}
-      />
+      <MyCommitmentsStats {...stats} />
       <MyCommitmentsFilters
         searchQuery={search.searchQuery}
         onSearchChange={search.onSearchChange}
         status={filters.status}
         type={filters.type}
-        sortBy={filters.sortBy}
         onStatusChange={filters.onStatusChange}
         onTypeChange={filters.onTypeChange}
-        onSortByChange={filters.onSortByChange}
+        {...(filters.sortBy !== undefined ? { sortBy: filters.sortBy } : {})}
+        {...(filters.onSortByChange !== undefined ? { onSortByChange: filters.onSortByChange } : {})}
       />
     </div>
   );

--- a/src/components/__tests__/MyCommitmentsOverview.test.tsx
+++ b/src/components/__tests__/MyCommitmentsOverview.test.tsx
@@ -6,16 +6,16 @@ import { describe, it, expect, vi } from 'vitest';
 import MyCommitmentsOverview from '../MyCommitmentsOverview/MyCommitmentsOverview';
 
 vi.mock('../MyCommitmentsStats/MyCommitmentsStats', () => ({
-  default: ({ totalActive, totalCommittedValue, averageComplianceScore, totalFeesGenerated }: {
+  default: ({ totalActive, totalCommittedValue, avgComplianceScore, totalFeesGenerated }: {
     totalActive: number;
     totalCommittedValue: string;
-    averageComplianceScore: string;
+    avgComplianceScore: number;
     totalFeesGenerated: string;
   }) => (
     <div data-testid="stats">
       <span data-testid="stat-active">{totalActive}</span>
       <span data-testid="stat-value">{totalCommittedValue}</span>
-      <span data-testid="stat-compliance">{averageComplianceScore}</span>
+      <span data-testid="stat-compliance">{avgComplianceScore}</span>
       <span data-testid="stat-fees">{totalFeesGenerated}</span>
     </div>
   ),
@@ -27,15 +27,19 @@ vi.mock('../MyCommitmentsFilters/MyCommitmentsFilters', () => ({
     onSearchChange,
     status,
     type,
+    sortBy,
     onStatusChange,
     onTypeChange,
+    onSortByChange,
   }: {
     searchQuery: string;
     onSearchChange: (v: string) => void;
     status: string;
     type: string;
+    sortBy?: string;
     onStatusChange: (v: string) => void;
     onTypeChange: (v: string) => void;
+    onSortByChange?: (v: string) => void;
   }) => (
     <div data-testid="filters">
       <input
@@ -62,6 +66,13 @@ vi.mock('../MyCommitmentsFilters/MyCommitmentsFilters', () => ({
         <option value="">All</option>
         <option value="Balanced">Balanced</option>
       </select>
+      <span data-testid="sort-by">{sortBy ?? ''}</span>
+      <button
+        data-testid="sort-by-button"
+        onClick={() => onSortByChange?.('Oldest')}
+      >
+        change sort
+      </button>
     </div>
   ),
 }));
@@ -70,7 +81,7 @@ const DEFAULT_PROPS = {
   stats: {
     totalActive: 7,
     totalCommittedValue: '$125,000',
-    averageComplianceScore: '94.2%',
+    avgComplianceScore: 94.2,
     totalFeesGenerated: '$1,280',
   },
   search: {
@@ -96,9 +107,9 @@ describe('MyCommitmentsOverview — aggregation', () => {
     expect(screen.getByTestId('stat-value')).toHaveTextContent('$125,000');
   });
 
-  it('passes averageComplianceScore to the stats component', () => {
+  it('passes avgComplianceScore to the stats component', () => {
     render(<MyCommitmentsOverview {...DEFAULT_PROPS} />);
-    expect(screen.getByTestId('stat-compliance')).toHaveTextContent('94.2%');
+    expect(screen.getByTestId('stat-compliance')).toHaveTextContent('94.2');
   });
 
   it('passes totalFeesGenerated to the stats component', () => {
@@ -157,5 +168,24 @@ describe('MyCommitmentsOverview — grid wiring', () => {
     );
     fireEvent.change(screen.getByTestId('type-filter'), { target: { value: 'Balanced' } });
     expect(onTypeChange).toHaveBeenCalledWith('Balanced');
+  });
+
+  it('renders without a sortBy/onSortByChange pair without leaking an undefined prop', () => {
+    render(<MyCommitmentsOverview {...DEFAULT_PROPS} />);
+    expect(screen.getByTestId('sort-by')).toHaveTextContent('');
+  });
+
+  it('forwards sortBy and onSortByChange when provided', () => {
+    const onSortByChange = vi.fn();
+    render(
+      <MyCommitmentsOverview
+        {...DEFAULT_PROPS}
+        filters={{ ...DEFAULT_PROPS.filters, sortBy: 'Newest', onSortByChange }}
+      />,
+    );
+    expect(screen.getByTestId('sort-by')).toHaveTextContent('Newest');
+
+    fireEvent.click(screen.getByTestId('sort-by-button'));
+    expect(onSortByChange).toHaveBeenCalledWith('Oldest');
   });
 });


### PR DESCRIPTION
MyCommitmentsOverview.tsx passes a stats object containing an averageComplianceScore field to MyCommitmentsStats, but the component's props interface doesn't declare this field (TS2322). It also constructs MyCommitmentsFiltersProps with optional fields explicitly set to undefined, violating exactOptionalPropertyTypes (TS2375).

## Description

`MyCommitmentsOverview` declared its own inline `stats` shape with `averageComplianceScore: string`, but `MyCommitmentsStats`' actual props (via `CommitmentStats`) expect `avgComplianceScore: number` — a real field-name *and* type mismatch, not just a naming difference. It also always forwarded `filters.sortBy`/`filters.onSortByChange` even when undefined, which `exactOptionalPropertyTypes` rejects for optional props.

Closes #1242

## Changes

- **`src/components/MyCommitmentsOverview/MyCommitmentsOverview.tsx`**: `stats` is now typed as `CommitmentStats` (imported from `@/types/commitment`) and spread directly onto `<MyCommitmentsStats {...stats} />`, so the two can't drift apart again structurally. `sortBy`/`onSortByChange` are now only included in the filters props object when actually provided, via conditional spread, instead of always being assigned (possibly as `undefined`).
- **`src/components/__tests__/MyCommitmentsOverview.test.tsx`**: updated the mock and fixtures to the corrected `avgComplianceScore: number` field, and added tests specifically covering the conditional-spread fix (renders correctly with no `sortBy`/`onSortByChange` pair; forwards both correctly when provided).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [x] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [x] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

N/A — type-level fix only, no rendering or styling change.