### PR TITLE
fix(a11y): improve accessibility of Continue button in Configure step

### DIFF
--- a/src/components/CreateCommitmentStepConfigure.tsx
+++ b/src/components/CreateCommitmentStepConfigure.tsx
@@ -481,9 +481,19 @@ export default function CreateCommitmentStepConfigure({
           <button
             type="button"
             className={styles.continueButton}
-            onClick={onNext}
-            disabled={!canAdvance}
+            onClick={(e) => {
+              if (!canAdvance) {
+                e.preventDefault()
+                return
+              }
+              onNext()
+            }}
             aria-disabled={!canAdvance}
+            aria-describedby={!canAdvance ? [
+              (amountError || serverErrors.amount) ? 'amount-error' : null,
+              (durationError || serverErrors.durationDays) ? 'duration-error' : null,
+              (maxLossError || serverErrors.maxLossBps) ? 'maxloss-error' : null,
+            ].filter(Boolean).join(' ') || undefined : undefined}
             data-testid="configure-continue"
           >
             {serverValidating ? 'Validating…' : 'Continue'}


### PR DESCRIPTION
Closes #1417 


This PR addresses accessibility issue F-02-01 in the Create Commitment wizard's Configure step. 

Previously, the "Continue" button used the native `disabled` attribute when the form was invalid. This removed the element from the tab order and accessibility tree in most browsers, preventing keyboard and screen-reader users from reaching the button to understand why they couldn't proceed.

## Changes Made
- **Removed native `disabled` attribute**: The button is now always reachable via keyboard navigation.
- **Maintained `aria-disabled`**: Screen readers will properly announce the button as disabled when the form is invalid.
- **Intercepted Click Event**: Added a `no-op` check in the `onClick` handler (`e.preventDefault()`) to prevent form submission when `canAdvance` is false.
- **Added `aria-describedby`**: Dynamically linked the button to the active error messages (e.g., `amount-error`, `duration-error`, `maxloss-error`) so screen-reader users hear the unmet requirements when they focus the disabled button.

## Acceptance Criteria Met
- [x] Drop the native `disabled` attribute
- [x] Keep `aria-disabled`
- [x] Intercept the click to no-op when invalid
- [x] Add an `aria-describedby` naming the unmet requirement(s)