### PR TITLE
docs(testing): replace leaked absolute local file path with repo-relative link

### DIFF
--- a/docs/testing/A11Y_TESTS.md
+++ b/docs/testing/A11Y_TESTS.md
@@ -8,7 +8,7 @@ Accessibility is a core priority of the Commitlabs project. To prevent regressio
 
 Automated accessibility tests are executed in the Vitest runner.
 
-1. **Test Matchers**: The project registers the axe matcher in [vitest.setup.ts](file:///Users/winnergbolagade/Desktop/drips/Commitlabs-Frontend/tests/setup/vitest.setup.ts):
+1. **Test Matchers**: The project registers the axe matcher in [vitest.setup.ts](../../tests/setup/vitest.setup.ts):
    ```typescript
    import * as axeMatchers from 'vitest-axe/matchers';
    import 'vitest-axe/extend-expect';


### PR DESCRIPTION
## Summary

Fixes an issue in `docs/testing/A11Y_TESTS.md` where a contributor's local absolute file path was committed instead of a repo-relative link.

### Changes
- Replaced `file:///Users/winnergbolagade/Desktop/drips/Commitlabs-Frontend/tests/setup/vitest.setup.ts` with `../../tests/setup/vitest.setup.ts` (matching the convention used in `docs/testing/FIXTURES.md`)

### Verification
- Grepped the entire `docs/` directory for any other `file:///Users/` leaked paths — none found.

Closes #1428