### PR TITLE
refactor(types): consolidate duplicate Commitment types into domain.ts

### DIFF
--- a/src/app/commitments/page.tsx
+++ b/src/app/commitments/page.tsx
@@ -142,7 +142,7 @@ function calculateStatsFromCommitments(commitments: Commitment[]): CommitmentSta
   // Calculate average compliance score
   const avgComplianceScore =
     commitments.length > 0
-      ? Math.round(commitments.reduce((sum, c) => sum + c.complianceScore, 0) / commitments.length)
+      ? Math.round(commitments.reduce((sum, c) => sum + c.complianceScore!, 0) / commitments.length)
       : 0
 
   // Calculate total fees generated (1% of total committed value as placeholder)
@@ -182,7 +182,7 @@ export default function MyCommitments() {
   const [listingCommitmentId, setListingCommitmentId] = useState<string | null>(null)
   const [isExportOpen, setIsExportOpen] = useState(false)
   const [selectedIdsForExport, setSelectedIdsForExport] = useState<string[]>([])
-  const [isExporting, setIsExporting] = useState(false)
+  const [isExporting, _setIsExporting] = useState(false)
   const [hasAcknowledged, setHasAcknowledged] = useState(false)
   const [commitmentsList, setCommitmentsList] = useState<Commitment[]>(mockCommitments)
   const [isLoading, setIsLoading] = useState(true)

--- a/src/components/MyCommitmentCard.tsx
+++ b/src/components/MyCommitmentCard.tsx
@@ -75,14 +75,14 @@ const MyCommitmentCard: React.FC<MyCommitmentCardProps> = ({
       : status === "Early Exit"
       ? "bg-[rgba(245,158,11,0.1)] text-[#ff8904] font-roboto"
       : "bg-[rgba(239,68,68,0.1)] text-[#ef4444] font-roboto";
-  const isPositive = changePercent >= 0;
+  const isPositive = changePercent! >= 0;
 
   // Dynamic colors
   const durationColorClass =
     "bg-[linear-gradient(180deg,#0FF0FC_0%,#0A7A82_100%)]";
 
   const complianceColorClass =
-    complianceScore > 80
+    complianceScore! > 80
       ? "bg-[#05DF72]"
       : "bg-[linear-gradient(180deg,#0FF0FC_0%,#0A7A82_100%)]";
 
@@ -142,7 +142,7 @@ const MyCommitmentCard: React.FC<MyCommitmentCardProps> = ({
         <div className="flex items-center gap-2 text-[14px]">
           <span className="text-[#94A3B8]">Current Value:</span>
           <span style={{ fontWeight: 600, fontFamily: "Roboto Mono" }}>
-            {currentValue} {asset}
+            {currentValue!} {asset}
           </span>
           <span
             className={isPositive ? "text-[#05DF72]" : "text-[#EF4444]"}
@@ -160,7 +160,7 @@ const MyCommitmentCard: React.FC<MyCommitmentCardProps> = ({
               />
             )}
             {isPositive ? "+" : ""}
-            {changePercent.toFixed(2)}%
+            {changePercent!.toFixed(2)}%
           </span>
         </div>
       </div>
@@ -179,20 +179,20 @@ const MyCommitmentCard: React.FC<MyCommitmentCardProps> = ({
               Duration Progress
             </span>
             <span className="text-white font-medium font-roboto">
-              <MaturityCountdown maturityTimestamp={new Date(expiryDate).getTime()} />
+              <MaturityCountdown maturityTimestamp={new Date(expiryDate!).getTime()} />
             </span>
           </div>
           <div className="h-[6px] rounded-full bg-white/10 overflow-hidden">
             <div
               className={`h-full rounded-full ${durationColorClass}`}
-              style={{ width: `${durationProgress}%` }}
+              style={{ width: `${durationProgress!}%` }}
             />
           </div>
           <span
             className="text-[#94A3B8] font-roboto"
             style={{ fontSize: "12px", marginTop: "-4px" }}
           >
-            {durationProgress}%
+            {durationProgress!}%
           </span>
         </div>
 
@@ -208,12 +208,12 @@ const MyCommitmentCard: React.FC<MyCommitmentCardProps> = ({
             >
               Compliance Score
             </span>
-            <span className="text-white font-semibold">{complianceScore}%</span>
+            <span className="text-white font-semibold">{complianceScore!}%</span>
           </div>
           <div className="h-[6px] rounded-full bg-white/10 overflow-hidden">
             <div
               className={`h-full rounded-full ${complianceColorClass}`}
-              style={{ width: `${complianceScore}%` }}
+              style={{ width: `${complianceScore!}%` }}
             />
           </div>
         </div>
@@ -228,7 +228,7 @@ const MyCommitmentCard: React.FC<MyCommitmentCardProps> = ({
             Max Loss
           </span>
           <span className="text-[16px] font-semibold font-roboto">
-            {maxLoss}
+            {maxLoss!}
           </span>
         </div>
         <div className="flex h-full w-full flex-col gap-[3.99px] rounded-[10px] bg-[#FFFFFF05] px-3 py-3">
@@ -239,7 +239,7 @@ const MyCommitmentCard: React.FC<MyCommitmentCardProps> = ({
             Current Drawdown
           </span>
           <span className="text-[16px] font-semibold font-roboto">
-            {currentDrawdown}
+            {currentDrawdown!}
           </span>
         </div>
       </div>
@@ -252,7 +252,7 @@ const MyCommitmentCard: React.FC<MyCommitmentCardProps> = ({
           >
             Created
           </span>
-          <span className="text-white font-roboto">{createdDate}</span>
+          <span className="text-white font-roboto">{createdDate!}</span>
         </div>
         <div className="flex flex-col gap-1 items-end">
           <span
@@ -261,7 +261,7 @@ const MyCommitmentCard: React.FC<MyCommitmentCardProps> = ({
           >
             Expires
           </span>
-          <span className="text-white font-roboto">{expiryDate}</span>
+          <span className="text-white font-roboto">{expiryDate!}</span>
         </div>
       </div>
 

--- a/src/lib/types/domain.ts
+++ b/src/lib/types/domain.ts
@@ -27,11 +27,26 @@ export interface Commitment {
   expiresAt?: string;
 }
 
+export type TrendDirection = 'up' | 'down' | 'neutral';
+
+export interface StatTrend {
+  value: number;
+  direction: TrendDirection;
+  period?: string;
+}
+
 export interface CommitmentStats {
   totalActive: number;
   totalCommittedValue: string;
   avgComplianceScore: number;
   totalFeesGenerated: string;
+  /** Optional per-metric trend indicators */
+  trends?: {
+    totalActive?: StatTrend;
+    totalCommittedValue?: StatTrend;
+    avgComplianceScore?: StatTrend;
+    totalFeesGenerated?: StatTrend;
+  };
 }
 
 export const ATTESTATION_TYPES = [

--- a/src/types/commitment.ts
+++ b/src/types/commitment.ts
@@ -1,41 +1,13 @@
-export type CommitmentType = 'Safe' | 'Balanced' | 'Aggressive';
-export type CommitmentStatus = 'Active' | 'Settled' | 'Violated' | 'Early Exit';
-
-export interface Commitment {
-  id: string;
-  type: CommitmentType;
-  status: CommitmentStatus;
-  asset: string;
-  amount: string;
-  currentValue: string;
-  changePercent: number;
-  durationProgress: number; // 0-100
-  daysRemaining: number;
-  complianceScore: number; // 0-100
-  maxLoss: string;
-  currentDrawdown: string;
-  createdDate: string;
-  expiryDate: string;
-}
-
-export type TrendDirection = 'up' | 'down' | 'neutral';
-
-export interface StatTrend {
-  value: number;
-  direction: TrendDirection;
-  period?: string;
-}
-
-export interface CommitmentStats {
-  totalActive: number;
-  totalCommittedValue: string;
-  avgComplianceScore: number;
-  totalFeesGenerated: string;
-  /** Optional per-metric trend indicators */
-  trends?: {
-    totalActive?: StatTrend;
-    totalCommittedValue?: StatTrend;
-    avgComplianceScore?: StatTrend;
-    totalFeesGenerated?: StatTrend;
-  };
-}
+/**
+ * Re-exports canonical Commitment types from the single source of truth in
+ * `@/lib/types/domain`.  Import from this module in UI-layer files that
+ * previously depended on the now-removed standalone definitions.
+ */
+export type {
+  CommitmentType,
+  CommitmentStatus,
+  Commitment,
+  CommitmentStats,
+  TrendDirection,
+  StatTrend,
+} from '@/lib/types/domain';

--- a/src/utils/sortCommitments.ts
+++ b/src/utils/sortCommitments.ts
@@ -17,10 +17,10 @@ export function sortCommitments(commitments: Commitment[], sortBy: SortOption): 
 
   switch (sortBy) {
     case 'Newest':
-      sorted.sort((a, b) => new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime());
+      sorted.sort((a, b) => new Date(b.createdDate!).getTime() - new Date(a.createdDate!).getTime());
       break;
     case 'Oldest':
-      sorted.sort((a, b) => new Date(a.createdDate).getTime() - new Date(b.createdDate).getTime());
+      sorted.sort((a, b) => new Date(a.createdDate!).getTime() - new Date(b.createdDate!).getTime());
       break;
     case 'ValueHighLow':
       sorted.sort((a, b) => Number(b.amount.replace(/,/g, '')) - Number(a.amount.replace(/,/g, '')));
@@ -29,22 +29,22 @@ export function sortCommitments(commitments: Commitment[], sortBy: SortOption): 
       sorted.sort((a, b) => Number(a.amount.replace(/,/g, '')) - Number(b.amount.replace(/,/g, '')));
       break;
     case 'MaturitySoonest':
-      sorted.sort((a, b) => a.daysRemaining - b.daysRemaining);
+      sorted.sort((a, b) => a.daysRemaining! - b.daysRemaining!);
       break;
     case 'MaturityLatest':
-      sorted.sort((a, b) => b.daysRemaining - a.daysRemaining);
+      sorted.sort((a, b) => b.daysRemaining! - a.daysRemaining!);
       break;
     case 'ComplianceHighLow':
-      sorted.sort((a, b) => b.complianceScore - a.complianceScore);
+      sorted.sort((a, b) => b.complianceScore! - a.complianceScore!);
       break;
     case 'ComplianceLowHigh':
-      sorted.sort((a, b) => a.complianceScore - b.complianceScore);
+      sorted.sort((a, b) => a.complianceScore! - b.complianceScore!);
       break;
     case 'YieldHighLow':
-      sorted.sort((a, b) => b.changePercent - a.changePercent);
+      sorted.sort((a, b) => b.changePercent! - a.changePercent!);
       break;
     case 'YieldLowHigh':
-      sorted.sort((a, b) => a.changePercent - b.changePercent);
+      sorted.sort((a, b) => a.changePercent! - b.changePercent!);
       break;
     default:
       break;


### PR DESCRIPTION
## Summary

Consolidates duplicate `Commitment`, `CommitmentType`, `CommitmentStatus`, and `CommitmentStats` type definitions that existed independently in both `src/types/commitment.ts` and `src/lib/types/domain.ts` with incompatible field optionality.

## Changes

### 1. `src/lib/types/domain.ts` — canonical source of truth
- Added `TrendDirection` and `StatTrend` types (previously only in commitment.ts)
- Added optional `trends` field to `CommitmentStats` (previously only in commitment.ts)

### 2. `src/types/commitment.ts` — now a re-export barrel
- Replaced standalone type definitions with re-exports from `@/lib/types/domain`
- All 14 files importing from `@/types/commitment` continue to work without import path changes

### 3. Updated consumers for optional-field compatibility
- `src/utils/sortCommitments.ts` — added non-null assertions on `createdDate`, `daysRemaining`, `complianceScore`, `changePercent`
- `src/components/MyCommitmentCard.tsx` — added non-null assertions on destructured display fields
- `src/app/commitments/page.tsx` — added non-null assertion on `complianceScore` in reduce

### 4. Fixed pre-existing lint
- Prefixed unused `setIsExporting` with `_` in `src/app/commitments/page.tsx`

Closes #1404