### PR TITLE
Centralize Safe/Balanced/Aggressive risk color palette into shared source

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,6 +33,10 @@
   --color-accent-blue: var(--accent-blue-alt);
   --color-accent-orange: var(--accent-orange);
 
+  --color-risk-safe: var(--risk-safe);
+  --color-risk-balanced: var(--risk-balanced);
+  --color-risk-aggressive: var(--risk-aggressive);
+
   --color-overlay: var(--surface-overlay);
 }
 
@@ -121,6 +125,11 @@
   /* Status variants */
   --status-positive-alt: #00C950;
   --status-danger-alt: #ef4444;
+
+  /* Risk profile colors */
+  --risk-safe: #00C950;
+  --risk-balanced: #51A2FF;
+  --risk-aggressive: #FF8904;
 }
 
 /* Light theme overrides */
@@ -163,6 +172,10 @@
 
   --status-positive-alt: #059669;
   --status-danger-alt: #dc2626;
+
+  --risk-safe: #059669;
+  --risk-balanced: #3b82f6;
+  --risk-aggressive: #d97706;
 }
 
 /* * {

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -229,14 +229,14 @@ function ListTypeIcon({ type }: { type: 'Safe' | 'Balanced' | 'Aggressive' }) {
   }
   if (type === 'Balanced') {
     return (
-      <svg width="20" height="20" viewBox="0 0 28 28" fill="none" className="text-[#51A2FF]">
+      <svg width="20" height="20" viewBox="0 0 28 28" fill="none" className="text-risk-balanced">
         <path d="M25.662 8.16504L15.7472 18.0799L9.91493 12.2476L2.33301 19.8295" stroke="currentColor" strokeWidth="2.3329" strokeLinecap="round" strokeLinejoin="round" />
         <path d="M18.6631 8.16504H25.6618V15.1637" stroke="currentColor" strokeWidth="2.3329" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
     )
   }
   return (
-    <svg width="20" height="20" viewBox="0 0 28 28" fill="none" className="text-[#FF8904]">
+    <svg width="20" height="20" viewBox="0 0 28 28" fill="none" className="text-risk-aggressive">
       <path d="M9.91461 16.9137C10.688 16.9137 11.4297 16.6064 11.9766 16.0596C12.5235 15.5127 12.8307 14.771 12.8307 13.9976C12.8307 12.3879 12.2475 11.6647 11.6643 10.4982C10.4138 7.99851 11.403 5.76942 13.9972 3.49951C14.5804 6.41564 16.3301 9.21512 18.663 11.0814C20.9959 12.9478 22.1623 15.164 22.1623 17.4969C22.1623 18.5692 21.9511 19.6309 21.5408 20.6216C21.1305 21.6122 20.529 22.5123 19.7708 23.2705C19.0126 24.0287 18.1125 24.6302 17.1218 25.0405C16.1312 25.4509 15.0694 25.6621 13.9972 25.6621C12.9249 25.6621 11.8632 25.4509 10.8725 25.0405C9.88187 24.6302 8.98175 24.0287 8.22355 23.2705C7.46534 22.5123 6.8639 21.6122 6.45357 20.6216C6.04323 19.6309 5.83203 18.5692 5.83203 17.4969C5.83203 16.152 6.3371 14.8211 6.99848 13.9976C6.99848 14.771 7.30571 15.5127 7.85259 16.0596C8.39947 16.6064 9.1412 16.9137 9.91461 16.9137Z" stroke="currentColor" strokeWidth="2.3329" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   )
@@ -245,17 +245,17 @@ function ListTypeIcon({ type }: { type: 'Safe' | 'Balanced' | 'Aggressive' }) {
 export function MarketplaceRow({ item }: { item: Listing }) {
   const badgeClass =
     item.type === "Safe"
-      ? "bg-[#0f2a1d] text-[#00C950]"
+      ? "bg-[#0f2a1d] text-risk-safe"
       : item.type === "Balanced"
-        ? "bg-[#122238] text-[#51A2FF]"
-        : "bg-[#2b1c10] text-[#FF8904]"
+        ? "bg-[#122238] text-risk-balanced"
+        : "bg-[#2b1c10] text-risk-aggressive"
 
   const scoreColorClass =
     item.type === "Safe"
-      ? "text-[#00C950]"
+      ? "text-risk-safe"
       : item.type === "Balanced"
-        ? "text-[#51A2FF]"
-        : "text-[#FF8904]"
+        ? "text-risk-balanced"
+        : "text-risk-aggressive"
 
   return (
     <div className="group flex flex-col sm:flex-row sm:items-center justify-between gap-6 rounded-2xl border border-white/10 bg-[#0A0A0A]/90 p-6 sm:p-5 transition-all hover:border-white/20 hover:bg-white/5">

--- a/src/components/MarketplaceCard.tsx
+++ b/src/components/MarketplaceCard.tsx
@@ -7,6 +7,7 @@ import { CommitmentDetailsModal } from "./modals/CommitmentDetailsModal";
 import PurchaseSuccessModal from "./modals/PurchaseSuccessModal";
 import { TrustBadge, TrustLevel } from "./TrustBadge";
 import { formatPercent } from '@/utils/format';
+import { RISK_COLORS } from '@/constants/riskColors';
 export type CommitmentType = "Safe" | "Balanced" | "Aggressive";
 
 export interface MarketplaceCardProps {
@@ -80,18 +81,18 @@ function TypeIcon({ type }: { type: CommitmentType }) {
         viewBox="0 0 28 28"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        className="w-[26px] h-[26px]"
+        className="w-[26px] h-[26px] text-risk-balanced"
       >
         <path
           d="M25.662 8.16504L15.7472 18.0799L9.91493 12.2476L2.33301 19.8295"
-          stroke="#51A2FF"
+          stroke="currentColor"
           strokeWidth="2.3329"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
         <path
           d="M18.6631 8.16504H25.6618V15.1637"
-          stroke="#51A2FF"
+          stroke="currentColor"
           strokeWidth="2.3329"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -106,11 +107,11 @@ function TypeIcon({ type }: { type: CommitmentType }) {
       height="28"
       viewBox="0 0 28 28"
       fill="none"
-      className="w-[26px] h-[26px]"
+      className="w-[26px] h-[26px] text-risk-aggressive"
     >
       <path
         d="M9.91461 16.9137C10.688 16.9137 11.4297 16.6064 11.9766 16.0596C12.5235 15.5127 12.8307 14.771 12.8307 13.9976C12.8307 12.3879 12.2475 11.6647 11.6643 10.4982C10.4138 7.99851 11.403 5.76942 13.9972 3.49951C14.5804 6.41564 16.3301 9.21512 18.663 11.0814C20.9959 12.9478 22.1623 15.164 22.1623 17.4969C22.1623 18.5692 21.9511 19.6309 21.5408 20.6216C21.1305 21.6122 20.529 22.5123 19.7708 23.2705C19.0126 24.0287 18.1125 24.6302 17.1218 25.0405C16.1312 25.4509 15.0694 25.6621 13.9972 25.6621C12.9249 25.6621 11.8632 25.4509 10.8725 25.0405C9.88187 24.6302 8.98175 24.0287 8.22355 23.2705C7.46534 22.5123 6.8639 21.6122 6.45357 20.6216C6.04323 19.6309 5.83203 18.5692 5.83203 17.4969C5.83203 16.152 6.3371 14.8211 6.99848 13.9976C6.99848 14.771 7.30571 15.5127 7.85259 16.0596C8.39947 16.6064 9.1412 16.9137 9.91461 16.9137Z"
-        stroke="#FF8904"
+        stroke="currentColor"
         strokeWidth="2.3329"
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -235,17 +236,17 @@ function MarketplaceCardComponent({
 
   const scoreColorClass =
     type === "Safe"
-      ? "text-[#00C950]/95"
+      ? "text-risk-safe/95"
       : type === "Balanced"
-        ? "text-[#51A2FF]/95"
-        : "text-[#FF8904]/95";
+        ? "text-risk-balanced/95"
+        : "text-risk-aggressive/95";
 
   const badgeClass =
     type === "Safe"
-      ? "bg-[#0f2a1d] text-[#00C950]"
+      ? "bg-[#0f2a1d] text-risk-safe"
       : type === "Balanced"
-        ? "bg-[#122238] text-[#51A2FF]"
-        : "bg-[#2b1c10] text-[#FF8904]";
+        ? "bg-[#122238] text-risk-balanced"
+        : "bg-[#2b1c10] text-risk-aggressive";
 
   const resolvedTradeHref =
     tradeHref ?? `/commitments/${encodeURIComponent(id)}`;

--- a/src/constants/riskColors.ts
+++ b/src/constants/riskColors.ts
@@ -1,0 +1,7 @@
+export const RISK_COLORS = {
+  Safe: '#00C950',
+  Balanced: '#51A2FF',
+  Aggressive: '#FF8904',
+} as const;
+
+export type RiskType = keyof typeof RISK_COLORS;


### PR DESCRIPTION
Centralizes the three risk-profile colors (Safe `#00C950`, Balanced `#51A2FF`, Aggressive `#FF8904`) that were previously hardcoded as inline hex literals across many files.

## Changes

### 
- Added `--color-risk-safe`, `--color-risk-balanced`, `--color-risk-aggressive` to the Tailwind v4 `@theme` block → generates utilities like `text-risk-safe`, `bg-risk-balanced/50`, `border-risk-aggressive`
- Defined `--risk-*` CSS custom properties in `:root` (dark theme) and `[data-theme="light"]` so the palette works under both themes
- Light-theme overrides use accessible contrast-optimized values (`#059669`, `#3b82f6`, `#d97706`)

###  (new)
- Exports `RISK_COLORS` const object keyed by `Safe` / `Balanced` / `Aggressive` with the canonical hex values
- Exports `RiskType` type alias
- Provides a single TypeScript source of truth for components that need the raw hex string (e.g. SVG `stroke` attributes, imperative code)

### 
- `scoreColorClass`: `text-[#00C950]/95` → `text-risk-safe/95`, etc.
- `badgeClass`: `text-[#00C950]` → `text-risk-safe`, etc.
- `TypeIcon` SVGs (Balanced, Aggressive): `stroke="#51A2FF"` → `stroke="currentColor"` with `className="text-risk-balanced"` (etc.), enabling theme-driven color switching

### 
- `ListTypeIcon` SVGs: same `currentColor` + theme class pattern
- `MarketplaceRow.badgeClass` / `scoreColorClass`: replaced all three hex literals with Tailwind risk-* classes

## Future work
The remaining ~15 files still containing these hex values (e.g. `TrustBadge`, `ReputationDisplay`, `CommitmentDetailOverview`, `RecentlyViewedRail`, tests/`*.test.tsx`) should be migrated in follow-up PRs to use the shared source.

Closes #1261