### PR TITLE
fix(api): bound dispute evidence field to 500 characters

### DIFF
--- a/src/app/api/commitments/[id]/dispute/route.test.ts
+++ b/src/app/api/commitments/[id]/dispute/route.test.ts
@@ -176,6 +176,14 @@ describe('POST /api/commitments/[id]/dispute', () => {
       const [req, ctx] = makeRequest('cmt-123', { reason: 'x'.repeat(501) });
       await expectError(req, ctx, 400, 'VALIDATION_ERROR');
     });
+
+    it('rejects evidence exceeding 500 characters', async () => {
+      const [req, ctx] = makeRequest('cmt-123', {
+        reason: 'Test',
+        evidence: 'x'.repeat(501),
+      });
+      await expectError(req, ctx, 400, 'VALIDATION_ERROR');
+    });
   });
 
   describe('404 - not found', () => {

--- a/src/app/api/commitments/[id]/dispute/route.ts
+++ b/src/app/api/commitments/[id]/dispute/route.ts
@@ -11,7 +11,7 @@ import { recordAuditEvent } from '@/lib/backend/auditLog';
 
 const DisputeRequestSchema = z.object({
     reason: z.string().min(1, 'Dispute reason is required').max(500),
-    evidence: z.string().optional(),
+    evidence: z.string().max(500).optional(),
     callerAddress: z.string().optional(),
 });
 


### PR DESCRIPTION
## Summary
- `evidence` in the dispute request schema was unbounded while the adjacent `reason` field was capped at 500 chars, allowing arbitrarily large payloads into audit logs and on-chain dispute records.
- Added `.max(500)` to `evidence` to match the existing `reason` cap.
- Added a test asserting an oversized `evidence` value (501 chars) is rejected with `400 VALIDATION_ERROR`.

## Test plan
- [x] Added unit test mirroring the existing "rejects reason exceeding 500 characters" case, for `evidence`
- [ ] CI test suite run

closes #1375

🤖 Generated with [Claude Code](https://claude.com/claude-code)