### PR TITLE
fix(i18n): wire up dead LocaleSwitcher component in navigation #1258

### DIFF
--- a/src/components/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher.tsx
@@ -48,15 +48,16 @@ export function LocaleSwitcher({ onChange }: LocaleSwitcherProps) {
   const locales = Object.keys(LOCALE_LABELS) as Locale[];
 
   return (
-    <label style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem' }}>
+    <label className="inline-flex items-center gap-1">
       <span className="sr-only">Language</span>
       <select
         aria-label="Select language"
         onChange={handleChange}
         value={locale}
+        className="appearance-none bg-transparent border border-[rgba(0,212,255,0.2)] rounded-[10px] px-3 py-[0.45rem] text-[12px] text-white/70 cursor-pointer transition-colors duration-200 hover:border-[rgba(0,212,255,0.45)] hover:text-white/70 focus-visible:border-[rgba(0,212,255,0.6)] focus-visible:outline-none"
       >
         {locales.map((l) => (
-          <option key={l} value={l}>
+          <option key={l} value={l} className="bg-[#0a0a0a] text-white">
             {LOCALE_LABELS[l]}
           </option>
         ))}

--- a/src/components/landing-page/Navigation.tsx
+++ b/src/components/landing-page/Navigation.tsx
@@ -10,6 +10,7 @@ import { WalletConnectButton } from "@/components/WalletConnectButton";
 import { HelpDrawer } from "@/components/help/HelpDrawer";
 import { useCommandPalette } from "@/hooks/useCommandPalette";
 import { WalletAccountMenu } from "@/components/wallet/WalletAccountMenu";
+import { LocaleSwitcher } from "@/components/LocaleSwitcher";
 
 export const Navigation: React.FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -146,6 +147,7 @@ export const Navigation: React.FC = () => {
           </button>
           <HelpDrawer />
           <ThemeToggle />
+          <LocaleSwitcher />
           <WalletConnectButton />
           <WalletAccountMenu />
           {/* Mobile menu button */}


### PR DESCRIPTION
## Overview

This PR wires up the existing but unused `LocaleSwitcher` component into the landing page navigation header, making the partially scaffolded i18n system actually accessible to users.

## Related Issue

Closes [#1258](https://github.com/Commitlabs-Org/Commitlabs-Frontend/issues/1258)

## Changes

- **[MODIFY]** `src/components/landing-page/Navigation.tsx` - imported and rendered `<LocaleSwitcher />` in the header controls row next to ThemeToggle
- **[MODIFY]** `src/components/LocaleSwitcher.tsx` - replaced inline styles with Tailwind classes matching the dark theme (transparent bg, border styling, hover/focus states)

No new files were created. The component already supported both `en` and `es` locales and the i18n module (`@/lib/i18n/messages`) already had translations for both.

## Verification Results

```
npm test -- src/components/landing-page/__tests__/Navigation.test.tsx src/lib/i18n/__tests__/i18n.test.ts
✅ 32/32 passed (27 i18n tests + 5 Navigation tests)

Lint: No new errors introduced (all errors are pre-existing)
Typecheck: Pre-existing error in GlossaryTerm.tsx only
```

## Acceptance Criteria

| Criteria | Status |
|---|---|
| Mount `LocaleSwitcher` in the app shell | ✅ Added to Navigation header controls |
| At least one additional locale | ✅ `es` (Español) already defined in messages |
| Component styled to match theme | ✅ Dark theme Tailwind classes applied |
| Existing tests pass | ✅ 32/32 passed |
| No new lint errors | ✅ All lint errors pre-existing |