### PR TITLE
fix: exactOptionalPropertyTypes violation in HealthMetricsFeeGenerationChart

### DIFF
--- a/src/components/VolatilityExposureMeter/VolatilityExposureMeter.tsx
+++ b/src/components/VolatilityExposureMeter/VolatilityExposureMeter.tsx
@@ -15,16 +15,23 @@ export interface VolatilityExposureMeterProps {
    * Should be ordered oldest → newest; at least 2 values required to render.
    */
   historyData?: number[]
+  /** Custom low/medium zone boundaries (0–100). Defaults to 33/66. */
+  zoneThresholds?: { lowMax: number; mediumMax: number }
 }
+
+const DEFAULT_ZONE_THRESHOLDS = { lowMax: 33, mediumMax: 66 }
 
 function clamp(value: number): number {
   if (typeof value !== 'number' || Number.isNaN(value)) return 0
   return Math.max(0, Math.min(100, value))
 }
 
-function exposureLevel(percent: number): 'low' | 'medium' | 'high' {
-  if (percent <= 33) return 'low'
-  if (percent <= 66) return 'medium'
+function exposureLevel(
+  percent: number,
+  thresholds: { lowMax: number; mediumMax: number },
+): 'low' | 'medium' | 'high' {
+  if (percent <= thresholds.lowMax) return 'low'
+  if (percent <= thresholds.mediumMax) return 'medium'
   return 'high'
 }
 
@@ -72,9 +79,10 @@ export default function VolatilityExposureMeter({
   insufficientData = false,
   description,
   historyData,
+  zoneThresholds = DEFAULT_ZONE_THRESHOLDS,
 }: VolatilityExposureMeterProps) {
   const percent = clamp(valuePercent)
-  const level = exposureLevel(percent)
+  const level = exposureLevel(percent, zoneThresholds)
   const levelLabel = level === 'low' ? 'Low' : level === 'medium' ? 'Moderate' : 'Elevated'
   const ariaLabel = `Volatility exposure: ${percent}%, ${level} range.`
   const valueText = insufficientData

--- a/src/components/dashboard/HealthMetricsFeeGenerationChart.tsx
+++ b/src/components/dashboard/HealthMetricsFeeGenerationChart.tsx
@@ -131,7 +131,9 @@ export const HealthMetricsFeeGenerationChart: React.FC<HealthMetricsFeeGeneratio
                 <div className="mt-4">
                     <VolatilityExposureMeter
                         insufficientData={exposure.status === 'insufficient_data'}
-                        valuePercent={exposure.exposurePercent}
+                        {...(exposure.exposurePercent !== undefined
+                            ? { valuePercent: exposure.exposurePercent }
+                            : {})}
                         zoneThresholds={exposure.zoneThresholds}
                         description="Current exposure to volatile assets based on allocation and market conditions."
                     />


### PR DESCRIPTION
Closes #1249

## Problem
`HealthMetricsFeeGenerationChart.tsx` passes `zoneThresholds` and `valuePercent` into the embedded `VolatilityExposureMeter` in a way `tsc` rejects under `exactOptionalPropertyTypes: true` (TS2375):
- `VolatilityExposureMeterProps` never declared a `zoneThresholds` prop at all, even though this chart and its two siblings (`HealthMetricsDrawdownChart`, `HealthMetricsValueHistoryChart`) already pass it — it was silently dropped and the meter's level classification was hardcoded to 33/66 instead of using it.
- `valuePercent={exposure.exposurePercent}` passes a `number | undefined` into a prop typed `valuePercent?: number`, which `exactOptionalPropertyTypes` treats as distinct from "key omitted."

## Fix
- Added an optional `zoneThresholds?: { lowMax: number; mediumMax: number }` prop to `VolatilityExposureMeterProps` (default `{ lowMax: 33, mediumMax: 66 }`, preserving current behavior), and wired it into `exposureLevel()` instead of the hardcoded literals.
- In `HealthMetricsFeeGenerationChart.tsx`, build the meter props via a conditional spread so `valuePercent` is omitted rather than explicitly `undefined` when `exposure.exposurePercent` is unavailable.

## Scope note
This file is the only one covered by #1249. `HealthMetricsDrawdownChart.tsx` and `HealthMetricsValueHistoryChart.tsx` have the same `valuePercent` pattern and would benefit from the identical conditional-spread treatment, but I left them untouched since they're outside this issue's scope (each appears to be tracked separately).

## Verification
- `npx tsc --noEmit` — no errors remain for `HealthMetricsFeeGenerationChart.tsx` or `VolatilityExposureMeter.tsx`.
- `npx vitest run src/components/VolatilityExposureMeter src/components/dashboard/HealthMetricsFeeGenerationChart src/components/dashboard/CommitmentHealthMetrics` — same pass/fail counts before and after this change (32 pre-existing unrelated failures, 22 passing, confirmed identical on `master` without this diff); no regressions introduced.