### PR TITLE
fix: guard possibly-undefined entry in IntersectionObserver callback

### DIFF
--- a/src/components/landing-page/sections/CoreConceptsSection.tsx
+++ b/src/components/landing-page/sections/CoreConceptsSection.tsx
@@ -136,6 +136,7 @@ export const CoreConceptsSection: React.FC = () => {
     if (!node) return;
     const observer = new IntersectionObserver(
       ([entry]) => {
+        if (!entry) return;
         if (entry.isIntersecting) {
           setIsVisible(true);
           observer.disconnect();


### PR DESCRIPTION
Fixes #1238

Add a null check for `entry` before accessing `entry.isIntersecting` in `CoreConceptsSection.tsx`. The destructured array entry from `IntersectionObserver` entries can be `undefined` when the array is empty, which caused `TS18048`.

Confirmed `tsc --noEmit` is clean for this file.