### PR TITLE
fix: use conditional spread for optional empty-state props

### DIFF
--- a/src/components/MarketplaceResultsLayout.tsx
+++ b/src/components/MarketplaceResultsLayout.tsx
@@ -103,8 +103,8 @@ export function MarketplaceResultsLayout({
         {totalCount === 0 || emptyStateType === "error" ? (
           <MarketplaceEmptyState
             type={emptyStateType}
-            onRetry={onRetry}
-            onClearFilters={onClearFilters}
+            {...(onRetry !== undefined && { onRetry })}
+            {...(onClearFilters !== undefined && { onClearFilters })}
           />
         ) : (
           children


### PR DESCRIPTION
Fixes #1247

Use conditional spreads to omit `onRetry`/`onClearFilters` keys entirely when undefined, satisfying `exactOptionalPropertyTypes: true` (TS2375).