### PR TITLE
validate pending transaction session state with Zod

### DIFF
--- a/src/components/transaction/ResumePendingTransactionBanner.tsx
+++ b/src/components/transaction/ResumePendingTransactionBanner.tsx
@@ -1,9 +1,19 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { z } from 'zod';
 import type { TransactionTimelinePhase } from './TransactionStepTimeline';
 
 const STORAGE_KEY = 'pending_transaction';
+
+export const PendingTransactionSchema = z.object({
+  commitmentId: z.string().min(1),
+  phase: z.enum(['build', 'sign', 'submit', 'confirm']),
+  startedAt: z.string().refine((val) => !isNaN(Date.parse(val)), {
+    message: 'Invalid ISO date string',
+  }),
+  txHash: z.string().optional(),
+});
 
 export interface PendingTransactionState {
   commitmentId: string;
@@ -33,9 +43,23 @@ export function ResumePendingTransactionBanner({
   useEffect(() => {
     try {
       const raw = sessionStorage.getItem(STORAGE_KEY);
-      if (raw) setPending(JSON.parse(raw));
+      if (!raw) {
+        setPending(null);
+        return;
+      }
+
+      const parsed = JSON.parse(raw);
+      const result = PendingTransactionSchema.safeParse(parsed);
+      if (!result.success) {
+        sessionStorage.removeItem(STORAGE_KEY);
+        setPending(null);
+        return;
+      }
+
+      setPending(result.data);
     } catch {
-      // ignore
+      sessionStorage.removeItem(STORAGE_KEY);
+      setPending(null);
     }
   }, []);
 
@@ -98,7 +122,11 @@ export function ResumePendingTransactionBanner({
 
 ResumePendingTransactionBanner.save = (state: PendingTransactionState) => {
   try {
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    const result = PendingTransactionSchema.safeParse(state);
+    if (!result.success) {
+      return;
+    }
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(result.data));
   } catch {
     // ignore
   }


### PR DESCRIPTION
Refactored the pending transaction recovery flow to use runtime schema validation before restoring state from sessionStorage, improving resilience against corrupted, stale, or incompatible persisted data.

Implemented a Zod schema for PendingTransactionState and validated all stored payloads prior to hydration. Invalid or malformed session data is now safely discarded, the corresponding storage entry is cleared, and the component falls back to a clean initial state instead of attempting to render invalid values.

This update aligns the component with the project's existing defensive parsing patterns, eliminating UI inconsistencies caused by unchecked JSON parsing—such as invalid relative timestamps (NaNs ago)—while improving overall reliability and forward compatibility with future schema changes.

Key Improvements
Added runtime Zod validation for persisted pending transaction data.
Replaced unsafe JSON.parse + type casting with schema-safe parsing.
Automatically removes invalid or outdated sessionStorage entries.
Prevents runtime errors caused by missing or malformed required fields.
Eliminated invalid date calculations and broken UI states from corrupted persistence data.
Standardized persistence handling with the existing application validation architecture.
Improved client-side resilience without affecting the normal transaction recovery workflow.

Closes #1409 