### PR TITLE
fix: resolve recent attestations lint issues

### DIFF
--- a/src/components/RecentAttestationsPanel/RecentAttestationsPanel.module.css
+++ b/src/components/RecentAttestationsPanel/RecentAttestationsPanel.module.css
@@ -127,6 +127,10 @@
 }
 
 .attestationRow {
+  list-style: none;
+}
+
+.attestationButton {
   display: flex;
   align-items: flex-start;
   gap: 14px;
@@ -139,49 +143,50 @@
   text-align: left;
   width: 100%;
   min-height: 44px;
+  color: inherit;
 }
 
-.attestationRow:hover {
+.attestationButton:hover {
   transform: translateY(-2px);
   background: rgba(255, 255, 255, 0.05);
 }
 
-.attestationRow:focus-visible {
+.attestationButton:focus-visible {
   outline: 2px solid rgba(15, 240, 252, 0.6);
   outline-offset: 2px;
 }
 
-.attestationRow:active {
+.attestationButton:active {
   transform: translateY(0);
 }
 
 /* Severity-based background colors */
-.attestationRow.ok {
+.attestationButton.ok {
   background: rgba(5, 223, 114, 0.1);
   border: 0.5px solid rgba(5, 223, 114, 0.2);
 }
 
-.attestationRow.ok:hover {
+.attestationButton.ok:hover {
   background: rgba(5, 223, 114, 0.15);
   border-color: rgba(5, 223, 114, 0.3);
 }
 
-.attestationRow.warning {
+.attestationButton.warning {
   background: rgba(255, 138, 4, 0.1);
   border: 0.5px solid rgba(255, 138, 4, 0.2);
 }
 
-.attestationRow.warning:hover {
+.attestationButton.warning:hover {
   background: rgba(255, 138, 4, 0.15);
   border-color: rgba(255, 138, 4, 0.3);
 }
 
-.attestationRow.violation {
+.attestationButton.violation {
   background: rgba(255, 105, 0, 0.1);
   border: 0.5px solid rgba(255, 105, 0, 0.2);
 }
 
-.attestationRow.violation:hover {
+.attestationButton.violation:hover {
   background: rgba(255, 105, 0, 0.15);
   border-color: rgba(255, 105, 0, 0.3);
 }

--- a/src/components/RecentAttestationsPanel/RecentAttestationsPanel.tsx
+++ b/src/components/RecentAttestationsPanel/RecentAttestationsPanel.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import styles from './RecentAttestationsPanel.module.css'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { useAttestationStream } from '@/hooks/useAttestationStream'
 import {
   buildAttestationCsvContent,
   buildAttestationExportFilename,
@@ -20,7 +21,8 @@ export interface Attestation {
 
 export interface RecentAttestationsPanelProps {
   attestations: Attestation[]
-  commitmentId?: string
+  /** Optional commitment ID to enable real-time SSE streaming of new attestations. */
+  commitmentId?: string | null
   summary: {
     complianceCount: number
     warningCount: number
@@ -28,8 +30,6 @@ export interface RecentAttestationsPanelProps {
   }
   onSelectAttestation: (id: string) => void
   onViewAll: () => void
-  /** Optional commitment ID to enable real-time SSE streaming of new attestations. */
-  commitmentId?: string | null
   /** Set to false to disable streaming even when commitmentId is provided. */
   streamingEnabled?: boolean
 }
@@ -162,26 +162,53 @@ function DownloadIcon() {
 
 export default function RecentAttestationsPanel({
   attestations,
-  commitmentId = '',
-  summary,
+  commitmentId,
   onSelectAttestation,
   onViewAll,
-  commitmentId = null,
   streamingEnabled = true,
 }: RecentAttestationsPanelProps) {
   const [isExporting, setIsExporting] = useState(false)
+  const [displayedAttestations, setDisplayedAttestations] = useState(attestations)
+  const [liveAnnouncement, setLiveAnnouncement] = useState('')
+  const normalizedCommitmentId = commitmentId ?? null
 
-  const handleExportCsv = useCallback(async () => {
-    if (attestations.length === 0) return
+  useEffect(() => {
+    setDisplayedAttestations(attestations)
+  }, [attestations])
+
+  const handleAttestation = useCallback((incomingAttestation: Attestation) => {
+    setDisplayedAttestations((previousAttestations) => {
+      const dedupedAttestations = previousAttestations.filter(
+        (existingAttestation) => existingAttestation.id !== incomingAttestation.id,
+      )
+      return [incomingAttestation, ...dedupedAttestations]
+    })
+    setLiveAnnouncement(`New attestation: ${incomingAttestation.title}`)
+  }, [])
+
+  useAttestationStream({
+    commitmentId: normalizedCommitmentId,
+    enabled: streamingEnabled,
+    onAttestation: handleAttestation,
+  })
+
+  const summaryCounts = {
+    complianceCount: displayedAttestations.filter((attestation) => attestation.severity === 'ok').length,
+    warningCount: displayedAttestations.filter((attestation) => attestation.severity === 'warning').length,
+    violationCount: displayedAttestations.filter((attestation) => attestation.severity === 'violation').length,
+  }
+
+  const handleExportCsv = useCallback(() => {
+    if (displayedAttestations.length === 0) return
     setIsExporting(true)
-    try {
-      const content = buildAttestationCsvContent(attestations)
-      const filename = buildAttestationExportFilename(commitmentId)
-      await downloadCsvContent(content, filename)
-    } finally {
+
+    const content = buildAttestationCsvContent(displayedAttestations)
+    const filename = buildAttestationExportFilename(normalizedCommitmentId ?? '')
+
+    void downloadCsvContent(content, filename).finally(() => {
       setIsExporting(false)
-    }
-  }, [attestations, commitmentId])
+    })
+  }, [displayedAttestations, normalizedCommitmentId])
 
   const getSeverityIcon = (severity: Attestation['severity']) => {
     switch (severity) {
@@ -228,13 +255,13 @@ export default function RecentAttestationsPanel({
             type="button"
             className={styles.exportButton}
             onClick={handleExportCsv}
-            disabled={attestations.length === 0 || isExporting}
+            disabled={displayedAttestations.length === 0 || isExporting}
             aria-label={
-              attestations.length === 0
+              displayedAttestations.length === 0
                 ? 'Export attestations as CSV (no attestations to export)'
                 : 'Export attestations as CSV'
             }
-            aria-disabled={attestations.length === 0 || isExporting}
+            aria-disabled={displayedAttestations.length === 0 || isExporting}
           >
             <DownloadIcon />
             {isExporting ? 'Exporting…' : 'Export CSV'}
@@ -252,55 +279,56 @@ export default function RecentAttestationsPanel({
       </header>
 
       <div className={styles.attestationsList} role="list">
-        {attestations.length === 0 ? (
+        {displayedAttestations.length === 0 ? (
           <div className={styles.emptyState}>
             <EmptyState title="No attestations available" />
           </div>
         ) : (
-          attestations.map((attestation) => (
-            <button
-              key={attestation.id}
-              type="button"
-              className={`${styles.attestationRow} ${getSeverityClass(attestation.severity)}`}
-              onClick={() => onSelectAttestation(attestation.id)}
-              aria-label={`${attestation.severity} attestation: ${attestation.title}`}
-            >
-              <div className={styles.rowLeft} aria-hidden="true">
-                {getSeverityIcon(attestation.severity)}
-              </div>
-              <div className={styles.rowContent}>
-                <h3 className={styles.rowTitle}>{attestation.title}</h3>
-                <p className={styles.rowDescription}>{attestation.description}</p>
-                <p className={styles.rowTxHash}>
-                  TX: {truncateHash(attestation.txHash)}
-                </p>
-              </div>
-              <div className={styles.rowRight}>
-                <span className={styles.rowTimestamp}>
-                  {formatRelativeTime(attestation.timestamp)}
-                </span>
-              </div>
-            </button>
+          displayedAttestations.map((attestation) => (
+            <li key={attestation.id} className={styles.attestationRow}>
+              <button
+                type="button"
+                className={`${styles.attestationButton} ${getSeverityClass(attestation.severity)}`}
+                onClick={() => onSelectAttestation(attestation.id)}
+                aria-label={`${attestation.severity} attestation: ${attestation.title}`}
+              >
+                <div className={styles.rowLeft} aria-hidden="true">
+                  {getSeverityIcon(attestation.severity)}
+                </div>
+                <div className={styles.rowContent}>
+                  <h3 className={styles.rowTitle}>{attestation.title}</h3>
+                  <p className={styles.rowDescription}>{attestation.description}</p>
+                  <p className={styles.rowTxHash}>
+                    TX: {truncateHash(attestation.txHash)}
+                  </p>
+                </div>
+                <div className={styles.rowRight}>
+                  <span className={styles.rowTimestamp}>
+                    {formatRelativeTime(attestation.timestamp)}
+                  </span>
+                </div>
+              </button>
+            </li>
           ))
         )}
       </div>
 
       <footer className={styles.footer}>
         <div className={`${styles.footerColumn} ${styles.footerCompliance}`}>
-          <div className={styles.footerValue} aria-label={`${summary.complianceCount} compliance attestations`}>
-            {summary.complianceCount}
+          <div className={styles.footerValue} aria-label={`${summaryCounts.complianceCount} compliance attestations`}>
+            {summaryCounts.complianceCount}
           </div>
           <div className={styles.footerLabel}>Compliance</div>
         </div>
         <div className={`${styles.footerColumn} ${styles.footerWarning}`}>
-          <div className={styles.footerValue} aria-label={`${summary.warningCount} warning attestations`}>
-            {summary.warningCount}
+          <div className={styles.footerValue} aria-label={`${summaryCounts.warningCount} warning attestations`}>
+            {summaryCounts.warningCount}
           </div>
           <div className={styles.footerLabel}>Warnings</div>
         </div>
         <div className={`${styles.footerColumn} ${styles.footerViolation}`}>
-          <div className={styles.footerValue} aria-label={`${summary.violationCount} violation attestations`}>
-            {summary.violationCount}
+          <div className={styles.footerValue} aria-label={`${summaryCounts.violationCount} violation attestations`}>
+            {summaryCounts.violationCount}
           </div>
           <div className={styles.footerLabel}>Violations</div>
         </div>


### PR DESCRIPTION
 Recent Attestations Panel live-update fix
Description
This PR fixes the Recent Attestations panel by resolving the duplicate commitmentId prop declaration and the undefined live announcement issue that occurred when streamed attestations arrived. The component now renders live updates consistently and provides the expected accessibility announcement for new attestation events.

Dependencies:

None
Closes #1214

Type of Change
 Bug fix (non-breaking change which fixes an issue)
Checklist
 My code follows the code style and standards of this project.
 I have performed a self-review of my code.
 I have commented my code, particularly in hard-to-understand areas.
 I have updated or added documentation where relevant.
 I have added unit/integration tests that prove my fix is effective or that my feature works.
 Any new or modified logic has at least 95% test coverage.
 I have ran the project linter and fixed all error diagnostics.
 I have verified that this change fits within the 96-hour campaign timeframe for contributor assignments.
