### PR TITLE
fix(AtRiskCommitments): declare thresholds/onThresholdsChange props (#1210)

### DIFF
--- a/src/components/dashboard/AtRiskCommitments.tsx
+++ b/src/components/dashboard/AtRiskCommitments.tsx
@@ -23,9 +23,31 @@ interface AtRiskCommitmentsProps {
   commitments?: Commitment[];
   /** Optional label describing the active time range, e.g. "30 D" or "All". */
   rangeLabel?: string;
+  /**
+   * Partial override of {@link DEFAULT_AT_RISK_THRESHOLDS}. Values missing here fall
+   * back to the component defaults, so callers can tune a single axis without
+   * specifying the other.
+   *
+   * Note: this prop seeds the widget's initial state only. Subsequent changes
+   * to `thresholds` after mount will not re-render the widget — users editing
+   * the thresholds live should use the in-widget "Configure Thresholds" panel
+   * (which fires {@link onThresholdsChange}) or remount with a new `key`.
+   */
+  thresholds?: Partial<AtRiskThresholds>;
+  /**
+   * Invoked with the merged, fully-resolved threshold set after the user clicks
+   * "Apply" in the settings panel. Receives the new value as a complete
+   * {@link AtRiskThresholds} object (not a partial override).
+   */
+  onThresholdsChange?: (thresholds: AtRiskThresholds) => void;
 }
 
-export function AtRiskCommitments({ commitments = [], rangeLabel }: AtRiskCommitmentsProps) {
+export function AtRiskCommitments({
+  commitments = [],
+  rangeLabel,
+  thresholds: thresholdsProp = {},
+  onThresholdsChange,
+}: AtRiskCommitmentsProps) {
   const [atRisk, setAtRisk] = useState<AtRiskCommitment[]>([]);
   const [loading, setLoading] = useState(true);
   const [thresholds, setThresholds] = useState<AtRiskThresholds>({

--- a/src/components/dashboard/AtRiskThresholds.test.tsx
+++ b/src/components/dashboard/AtRiskThresholds.test.tsx
@@ -215,4 +215,63 @@ describe('AtRiskCommitments threshold controls', () => {
       expect(screen.getByText('Needs Attention')).toBeInTheDocument();
     });
   });
+
+  // ─── Regression ────────────────────────────────────────────────────────────
+  // Issue: AtRiskCommitments previously referenced `thresholdsProp` and
+  // `onThresholdsChange` without declaring them in AtRiskCommitmentsProps or
+  // destructuring them from props, causing a ReferenceError at render time
+  // anywhere the widget was mounted. This single test exercises the full
+  // custom-thresholds + callback-fires path so any regression that hides
+  // either prop will crash here.
+  it('regression: mounts with custom thresholds AND fires onThresholdsChange on apply', async () => {
+    const onThresholdsChange = jest.fn();
+    render(
+      <AtRiskCommitments
+        commitments={[base]}
+        // partial override — only one axis; the other should fall back to default
+        thresholds={{ complianceScoreThreshold: 85 }}
+        onThresholdsChange={onThresholdsChange}
+      />
+    );
+
+    // (1) Mount succeeds — proves the component no longer crashes with a
+    //     ReferenceError on thresholdsProp / onThresholdsChange.
+    await waitFor(() =>
+      expect(screen.getByText('Configure Thresholds')).toBeInTheDocument()
+    );
+
+    // (2) Custom threshold is honored as the initial value: base has
+    //     complianceScore 80, so a default of 70 would render healthy. With
+    //     a stricter 85 the commitment must immediately be at risk.
+    await waitFor(() =>
+      expect(screen.getByText('Needs Attention')).toBeInTheDocument()
+    );
+
+    // (3) Settings panel reflects the partial override — compliance input
+    //     shows 85, days input falls back to the default (7).
+    fireEvent.click(screen.getByText('Configure Thresholds'));
+    expect(screen.getByLabelText('Compliance score below (0–100)')).toHaveValue(
+      85
+    );
+    expect(
+      screen.getByLabelText('Days remaining at or below (0–365)')
+    ).toHaveValue(7);
+
+    // (4) Adjusting the days axis (leaving compliance unchanged) and clicking
+    //     Apply must invoke onThresholdsChange with the fully-merged defaults,
+    //     not the partial override previously passed in.
+    fireEvent.change(
+      screen.getByLabelText('Days remaining at or below (0–365)'),
+      { target: { value: '30' } }
+    );
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() => {
+      expect(onThresholdsChange).toHaveBeenCalledTimes(1);
+    });
+    expect(onThresholdsChange).toHaveBeenCalledWith({
+      complianceScoreThreshold: 85, // preserved from initial override
+      daysRemainingThreshold: 30, // just applied
+    });
+  });
 });


### PR DESCRIPTION
## Description

`AtRiskCommitments` referenced `thresholdsProp` (in the initial `useState`) and `onThresholdsChange` (when applying new thresholds) **without** declaring them in `AtRiskCommitmentsProps` or destructuring them from the component's parameters. Because `thresholdsProp`/`onThresholdsChange` were never bound, the widget threw a `ReferenceError` on first render — so it crashed anywhere it was mounted, including the commitment detail dashboard, making the widget entirely unusable despite the rest of the configurable-threshold feature being wired up.

### What changed

- `src/components/dashboard/AtRiskCommitments.tsx`
  - Added `thresholds?: Partial<AtRiskThresholds>` and `onThresholdsChange?: (thresholds: AtRiskThresholds) => void` to `AtRiskCommitmentsProps`, with JSDoc explaining the partial-override merge contract and the one-shot seeding behavior of `thresholds`.
  - Updated the function signature to destructure the new props alongside the existing `commitments` / `rangeLabel`, with sensible defaults (`thresholds: thresholdsProp = {}`, so the spread against `DEFAULT_AT_RISK_THRESHOLDS` still resolves cleanly).
  - The existing `useState({ ...DEFAULT_AT_RISK_THRESHOLDS, ...thresholdsProp })` and `onThresholdsChange?.(next)` calls now reference real, declared identifiers.
- `src/components/dashboard/AtRiskThresholds.test.tsx`
  - Added one consolidated regression test (`regression: mounts with custom thresholds AND fires onThresholdsChange on apply`) that:
    1. mounts with `thresholds={{ complianceScoreThreshold: 85 }}` and an `onThresholdsChange` spy,
    2. asserts the stricter threshold immediately flags the commitment,
    3. opens the settings panel and verifies the inputs show the override (`85`) plus the default fallback (`7`),
    4. changes the days axis to `30`, clicks Apply, and asserts the callback fires exactly once with `{ complianceScoreThreshold: 85, daysRemainingThreshold: 30 }`.

  This test would crash at mount with the prior `ReferenceError`, so any regression that hides either prop will fail here immediately.

### Acceptance criteria

- [x] `thresholds` / `onThresholdsChange` added to `AtRiskCommitmentsProps`.
- [x] Both destructured in the function signature with sensible defaults.
- [x] Regression test mounts `AtRiskCommitments` with custom thresholds and asserts the callback fires.

### Notes

- Public-API contract matches the existing `docs/AT_RISK_THRESHOLDS.md` reference (`Partial<AtRiskThresholds>` in, full `AtRiskThresholds` out via the callback).
- Existing call sites that only pass `commitments` (e.g. `src/app/commitments/overview/page.tsx`) continue to work — both new props are optional.
- The `thresholds` prop seeds initial `useState` only; later prop changes won't update the widget. This is documented on the JSDoc and pre-existing — not a regression introduced by this fix.

Closes #1210

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files). *(The public API was already documented in `docs/AT_RISK_THRESHOLDS.md`; no doc updates were needed.)*
- [x] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage**. *(Could not verify locally — `node_modules` missing in the change environment; CI must confirm.)*
- [ ] I have ran the project linter. *(Could not verify locally — `node_modules` missing in the change environment; CI must confirm.)*
- [x] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes. *N/A — logic-only fix.*

## Visual Changes (if applicable)

N/A — this is a logic-only fix that resolves a render-time crash; no visual changes are introduced.

## Join the Discussion

Need help or want to chat? Join our [CommitLabs Discord](https://discord.gg/WV7tdYkJk) server.
