### PR TITLE
fix: add fallback to themes[nextIndex] to prevent undefined reaching setTheme

### DIFF
--- a/src/components/theme/ThemeToggle.tsx
+++ b/src/components/theme/ThemeToggle.tsx
@@ -40,7 +40,7 @@ export function ThemeToggle() {
 
   const current = theme ?? 'system'
   const nextIndex = (themes.indexOf(current as typeof themes[number]) + 1) % themes.length
-  const nextTheme = themes[nextIndex]
+  const nextTheme = themes[nextIndex] ?? 'system'
   const Icon = icons[current as keyof typeof icons] ?? Monitor
 
   return (


### PR DESCRIPTION
## Summary

With noUncheckedIndexedAccess enabled in tsconfig, themes[nextIndex] returns string | undefined. The undefined value would flow into setTheme() causing TS2345.

## Fix

Added fallback themes[nextIndex] ?? system consistent with the existing theme ?? system on the line above.

Close #1231