### PR TITLE
feat: add cachePrivacy option to ApiHandlerOptions

### DIFF
--- a/src/lib/backend/withApiHandler.ts
+++ b/src/lib/backend/withApiHandler.ts
@@ -14,6 +14,16 @@ type RouteHandler = (
 interface ApiHandlerOptions {
   cors?: CorsRoutePolicy;
   enableETag?: boolean;
+  /**
+   * Controls the Cache-Control privacy directive emitted on ETag responses.
+   * Use 'public' only for routes whose data is identical for all users (e.g.
+   * static reference data). Routes returning user-specific data (wallet lists,
+   * preferences, etc.) must use 'private' so shared caches/CDNs cannot serve
+   * one user's response to another.
+   *
+   * Defaults to 'private'.
+   */
+  cachePrivacy?: "public" | "private";
 }
 
 function finalizeResponse(
@@ -57,18 +67,20 @@ export function withApiHandler(
         if (data) {
           const etag = generateETag(data);
           const ifNoneMatch = req.headers.get("if-none-match");
+          const privacy = options.cachePrivacy ?? "private";
+          const cacheControl = `${privacy}, max-age=0, must-revalidate`;
           
           if (etagMatches(ifNoneMatch, etag)) {
             // Return 304 Not Modified
             const notModifiedResponse = new NextResponse(null, { status: 304 });
             notModifiedResponse.headers.set("ETag", etag);
-            notModifiedResponse.headers.set("Cache-Control", "public, max-age=0, must-revalidate");
+            notModifiedResponse.headers.set("Cache-Control", cacheControl);
             return finalizeResponse(req, notModifiedResponse, correlationId, options.cors);
           }
           
           // Add ETag to successful response
           response.headers.set("ETag", etag);
-          response.headers.set("Cache-Control", "public, max-age=0, must-revalidate");
+          response.headers.set("Cache-Control", cacheControl);
         }
       }
       

--- a/tests/api/withApiHandler.etag.test.ts
+++ b/tests/api/withApiHandler.etag.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 import { withApiHandler } from '../../src/lib/backend/withApiHandler';
 import { generateETag } from '../../src/lib/backend/etag';
@@ -6,13 +6,13 @@ import { generateETag } from '../../src/lib/backend/etag';
 // Mock dependencies
 vi.mock('../../src/lib/backend/apiResponse', () => ({
   getCorrelationId: () => 'test-correlation-id',
-  fail: (code: string, message: string, details?: unknown, status?: number, retryAfter?: number, correlationId?: string) => {
+  fail: (code: string, message: string, details?: unknown, status?: number, _retryAfter?: number, _correlationId?: string) => {
     return new NextResponse(JSON.stringify({ code, message, details }), { status: status || 500 });
   },
 }));
 
 vi.mock('../../src/lib/backend/cors', () => ({
-  applyCorsPolicy: (req: any, response: Response) => response,
+  applyCorsPolicy: (_req: NextRequest, response: Response) => response,
   enforceCorsRequestPolicy: () => {},
 }));
 
@@ -53,7 +53,7 @@ describe('withApiHandler - ETag Integration', () => {
 
       expect(response.status).toBe(304);
       expect(response.headers.get('ETag')).toBe(expectedETag);
-      expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, must-revalidate');
+      expect(response.headers.get('Cache-Control')).toBe('private, max-age=0, must-revalidate');
     });
 
     it('should return 200 with new data when If-None-Match does not match', async () => {
@@ -247,7 +247,7 @@ describe('withApiHandler - ETag Integration', () => {
       expect(response.headers.has('x-request-id')).toBe(true);
     });
 
-    it('should include Cache-Control header with ETag', async () => {
+    it('should include Cache-Control header with ETag defaulting to private', async () => {
       const testData = { id: 1 };
 
       const handler = withApiHandler(async () => {
@@ -257,7 +257,7 @@ describe('withApiHandler - ETag Integration', () => {
       const req = new NextRequest('http://localhost/api/test');
       const response = await handler(req, { params: {} });
 
-      expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, must-revalidate');
+      expect(response.headers.get('Cache-Control')).toBe('private, max-age=0, must-revalidate');
     });
 
     it('should handle empty array responses', async () => {
@@ -340,6 +340,86 @@ describe('withApiHandler - ETag Integration', () => {
 
       expect(response.status).toBe(500);
       expect(response.headers.has('ETag')).toBe(false);
+    });
+  });
+
+  describe('ETag with cachePrivacy option', () => {
+    it('should emit private Cache-Control by default (no cachePrivacy specified)', async () => {
+      const testData = { wallet: '0xabc', balance: 100 };
+
+      const handler = withApiHandler(async () => {
+        return NextResponse.json(testData, { status: 200 });
+      }, { enableETag: true });
+
+      const req = new NextRequest('http://localhost/api/wallet/balance');
+      const response = await handler(req, { params: {} });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Cache-Control')).toBe('private, max-age=0, must-revalidate');
+    });
+
+    it('should emit private Cache-Control when cachePrivacy is explicitly set to private', async () => {
+      const testData = { wallet: '0xabc', preferences: { theme: 'dark' } };
+
+      const handler = withApiHandler(async () => {
+        return NextResponse.json(testData, { status: 200 });
+      }, { enableETag: true, cachePrivacy: 'private' });
+
+      const req = new NextRequest('http://localhost/api/wallet/preferences');
+      const response = await handler(req, { params: {} });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Cache-Control')).toBe('private, max-age=0, must-revalidate');
+    });
+
+    it('should emit public Cache-Control when cachePrivacy is set to public', async () => {
+      const testData = { rates: { USDC: 1.0, XLM: 0.12 } };
+
+      const handler = withApiHandler(async () => {
+        return NextResponse.json(testData, { status: 200 });
+      }, { enableETag: true, cachePrivacy: 'public' });
+
+      const req = new NextRequest('http://localhost/api/rates');
+      const response = await handler(req, { params: {} });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, must-revalidate');
+    });
+
+    it('should carry private Cache-Control through to a 304 response by default', async () => {
+      const testData = { wallet: '0xabc', commitments: [{ id: 1 }] };
+      const currentETag = generateETag(testData);
+
+      const handler = withApiHandler(async () => {
+        return NextResponse.json(testData, { status: 200 });
+      }, { enableETag: true });
+
+      const req = new NextRequest('http://localhost/api/wallet/commitments', {
+        headers: { 'If-None-Match': currentETag },
+      });
+
+      const response = await handler(req, { params: {} });
+
+      expect(response.status).toBe(304);
+      expect(response.headers.get('Cache-Control')).toBe('private, max-age=0, must-revalidate');
+    });
+
+    it('should carry public Cache-Control through to a 304 response when cachePrivacy is public', async () => {
+      const testData = { rates: { USDC: 1.0, XLM: 0.12 } };
+      const currentETag = generateETag(testData);
+
+      const handler = withApiHandler(async () => {
+        return NextResponse.json(testData, { status: 200 });
+      }, { enableETag: true, cachePrivacy: 'public' });
+
+      const req = new NextRequest('http://localhost/api/rates', {
+        headers: { 'If-None-Match': currentETag },
+      });
+
+      const response = await handler(req, { params: {} });
+
+      expect(response.status).toBe(304);
+      expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, must-revalidate');
     });
   });
 


### PR DESCRIPTION
- Add cachePrivacy: 'public' | 'private' to ApiHandlerOptions (defaults to 'private')
- Update Cache-Control header in both 200 and 304 ETag branches to use the option
- Update existing Cache-Control assertions to reflect the new private default
- Add 5 new cachePrivacy tests covering default/explicit private and public for 200 and 304 responses

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Closes # (issue number)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Please review the [Developer Guide](https://github.com/Commitlabs-Org/Commitlabs-Frontend/blob/master/DEVELOPER_GUIDE.md) before checking the items below:

- [ ] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [ ] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [ ] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

Please add screenshots, screen recordings, or GIFs showcasing the user interface changes.

## Join the Discussion

Need help or want to chat? Join our [CommitLabs Discord](https://discord.gg/WV7tdYkJk) server.

closes #1321