### PR TITLE
fix(api): handle seed endpoint envelope

### DIFF
--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { ok, methodNotAllowed } from '@/lib/backend/apiResponse';
 import { createCorsOptionsHandler, type CorsRoutePolicy } from '@/lib/backend/cors';
+import { ForbiddenError, InternalError, NotFoundError } from '@/lib/backend/errors';
 import { isSeedAllowed, seedMockData } from '@/lib/backend/seed';
 import { withApiHandler } from '@/lib/backend/withApiHandler';
 
@@ -12,7 +13,9 @@ export const OPTIONS = createCorsOptionsHandler(SEED_CORS_POLICY);
 
 export const POST = withApiHandler(async (req: NextRequest, _context, correlationId) => {
   if (!isSeedAllowed()) {
-    return ok({ message: 'Not Found' }, 404, undefined, correlationId);
+    // Issue #1372: throw so withApiHandler builds a `success: false`
+    // envelope via fail(), instead of ok()'s `success: true` for a 404.
+    throw new NotFoundError('Route');
   }
 
   const secret = req.headers.get('x-seed-secret');
@@ -20,10 +23,10 @@ export const POST = withApiHandler(async (req: NextRequest, _context, correlatio
 
   if (!result.seeded) {
     if (result.message === 'Invalid seed secret.') {
-      return ok({ message: result.message }, 403, undefined, correlationId);
+      throw new ForbiddenError(result.message);
     }
 
-    return ok({ message: result.message }, 500, undefined, correlationId);
+    throw new InternalError(result.message);
   }
 
   return ok({ message: result.message }, 200, undefined, correlationId);

--- a/tests/api/seed.test.ts
+++ b/tests/api/seed.test.ts
@@ -168,6 +168,7 @@ describe("POST /api/seed route", () => {
     const res = await POST(req);
     const result = await parseResponse(res);
     expect(result.status).toBe(404);
+    expect(result.data.success).toBe(false);
   });
 
   it("returns 404 when SEED_ROUTE_ENABLED is not set", async () => {
@@ -177,6 +178,7 @@ describe("POST /api/seed route", () => {
     const res = await POST(req);
     const result = await parseResponse(res);
     expect(result.status).toBe(404);
+    expect(result.data.success).toBe(false);
   });
 
   it("returns 404 when SEED_ROUTE_ENABLED=false", async () => {
@@ -186,6 +188,7 @@ describe("POST /api/seed route", () => {
     const res = await POST(req);
     const result = await parseResponse(res);
     expect(result.status).toBe(404);
+    expect(result.data.success).toBe(false);
   });
 
   it("returns 403 when secret is required but wrong header supplied", async () => {
@@ -202,6 +205,7 @@ describe("POST /api/seed route", () => {
     const res = await POST(req);
     const result = await parseResponse(res);
     expect(result.status).toBe(403);
+    expect(result.data.success).toBe(false);
   });
 
   it("returns 403 when secret is required but no header supplied", async () => {
@@ -215,6 +219,7 @@ describe("POST /api/seed route", () => {
     const res = await POST(req);
     const result = await parseResponse(res);
     expect(result.status).toBe(403);
+    expect(result.data.success).toBe(false);
   });
 
   it("returns 200 in development with flag set and no secret configured", async () => {
@@ -258,6 +263,7 @@ describe("POST /api/seed route", () => {
     const res = await POST(req);
     const result = await parseResponse(res);
     expect(result.status).toBe(500);
-    expect(result.data.data.message).toMatch(/write error/);
+    expect(result.data.success).toBe(false);
+    expect(result.data.error.message).toMatch(/write error/);
   });
 });


### PR DESCRIPTION
## Summary
- Fix seed endpoint envelope handling
- Update seed API tests
- Ensure seed endpoint behaves correctly for the expected request format

## Testing
- ✅ Ran unit tests locally
- ✅ Lint passed closes #1372.
