### PR TITLE
feat: type validate API error items and extract placeholder address c…

### DIFF
--- a/src/components/CreateCommitmentStepReview.tsx
+++ b/src/components/CreateCommitmentStepReview.tsx
@@ -15,7 +15,14 @@ import WizardStepper from "./WizardStepper";
 import styles from "./CreateCommitmentStepReview.module.css";
 import { useWallet } from "@/hooks/useWallet";
 import { useOnlineStatus } from "@/hooks/useOnlineStatus";
-import ValidationSummary, { ValidationErrorItem } from "./create/ValidationSummary";
+import ValidationSummary, {
+  ValidationErrorItem,
+  ValidateApiErrorItem,
+} from "./create/ValidationSummary";
+
+/** Placeholder owner address sent to the validate endpoint when no wallet is connected. */
+const PLACEHOLDER_STELLAR_ADDRESS =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
 interface CreateCommitmentStepReviewProps {
   typeLabel: string;
@@ -58,7 +65,7 @@ export default function CreateCommitmentStepReview({
   const { connected, address, connect } = useWallet();
   const { isOnline } = useOnlineStatus();
   const [validationErrors, setValidationErrors] = useState<ValidationErrorItem[]>([]);
-  const [isValidating, setIsValidating] = useState(false);
+  const [_isValidating, setIsValidating] = useState(false);
 
   useEffect(() => {
     headingRef.current?.focus();
@@ -107,7 +114,7 @@ export default function CreateCommitmentStepReview({
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            ownerAddress: address || "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            ownerAddress: address || PLACEHOLDER_STELLAR_ADDRESS,
             asset,
             amount: amount || "0",
             durationDays,
@@ -118,7 +125,7 @@ export default function CreateCommitmentStepReview({
         if (response.ok && active) {
           const data = await response.json();
           if (!data.valid && data.errors) {
-            data.errors.forEach((err: any, index: number) => {
+            data.errors.forEach((err: ValidateApiErrorItem, index: number) => {
               if (err.field === "ownerAddress") {
                 if (!errors.some((e) => e.field === "review-connect-wallet")) {
                   errors.push({

--- a/src/components/create/ValidationSummary.tsx
+++ b/src/components/create/ValidationSummary.tsx
@@ -11,6 +11,19 @@ export interface ValidationErrorItem {
   field: string;
 }
 
+/**
+ * Shape of each error object returned by the /api/commitments/validate endpoint.
+ * Mirrors the backend `ValidationWarning` type that the route serialises to JSON.
+ */
+export interface ValidateApiErrorItem {
+  /** Backend warning/error code (e.g. "VALIDATION_ERROR"). */
+  code?: string;
+  /** Human-readable error description. */
+  message?: string;
+  /** Dot-path of the field that failed validation (e.g. "ownerAddress"). */
+  field?: string;
+}
+
 interface ValidationSummaryProps {
   errors: ValidationErrorItem[];
   onJumpToError: (step: 1 | 2 | 3, field: string) => void;


### PR DESCRIPTION
Type /api/commitments/validate response errors; extract placeholder address constant
  
  Summary
  
  The post-review validation call in CreateCommitmentStepReview was iterating the API's errors
   array with an any-typed callback, meaning a backend field rename (e.g. field → path) would
  silently produce undefined at runtime instead of a compile-time error.
  
  Changes
  
  src/components/create/ValidationSummary.tsx
  
  - Adds and exports ValidateApiErrorItem — an interface mirroring the wire shape of each object
  in the errors array returned by POST /api/commitments/validate (field?: string, message?:
  string, code?: string). All fields are optional to match the backend ValidationWarning type
  exactly.
  
  src/components/CreateCommitmentStepReview.tsx
  
  - Replaces forEach((err: any, index: number) with forEach((err: ValidateApiErrorItem, index:
  number) — err.field and err.message are now resolved against the interface at compile time.
  - Extracts the inline fallback Stellar address literal "GAAA..." to a named module-level
  constant PLACEHOLDER_STELLAR_ADDRESS with a doc comment explaining its purpose.
  - Renames unused isValidating state variable to _isValidating to satisfy the project's
  no-unused-vars lint rule (pre-existing violation, surfaced by the pre-commit hook).
  
  Testing
  
  - pnpm typecheck (tsc --noEmit) reports zero errors in both modified files.
  - Pre-commit ESLint hook passes cleanly.

▸ Closes #1277 