### PR TITLE
fix(1403): add error state to usePaginatedListings hook

### DIFF
--- a/src/hooks/__tests__/usePaginatedListings.test.ts
+++ b/src/hooks/__tests__/usePaginatedListings.test.ts
@@ -63,4 +63,36 @@ describe('usePaginatedListings', () => {
     });
     expect(result.current.hasMore).toBe(false);
   });
+
+  it('surfaces error distinctly from hasMore === false on fetch failure', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('Network failure'));
+
+    const { result } = renderHook(() =>
+      usePaginatedListings({}, 9)
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hasMore).toBe(false);
+    expect(result.current.error).toBe('Network failure');
+    expect(result.current.listings).toEqual([]);
+  });
+
+  it('has null error on a successful fetch', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ cards: [{ id: '1' }], total: 1 }),
+    } as Response);
+
+    const { result } = renderHook(() =>
+      usePaginatedListings({}, 9)
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.error).toBeNull();
+  });
 });

--- a/src/hooks/usePaginatedListings.ts
+++ b/src/hooks/usePaginatedListings.ts
@@ -23,6 +23,7 @@ export function usePaginatedListings(
   const [page, setPage] = useState(1);
   const [isLoading, setIsLoading] = useState(false);
   const [hasMore, setHasMore] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [prevParams, setPrevParams] = useState(serializedParams);
 
   // Synchronously reset pagination state during render when query parameters change
@@ -31,6 +32,7 @@ export function usePaginatedListings(
     setPage(1);
     setListings([]);
     setHasMore(true);
+    setError(null);
   }
 
   useEffect(() => {
@@ -66,10 +68,13 @@ export function usePaginatedListings(
           return [...prev, ...filteredNewCards];
         });
         setHasMore(newCards.length === pageSize);
+        setError(null);
       } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
         console.error(e);
         if (active) {
           setHasMore(false);
+          setError(msg);
         }
       } finally {
         if (active) {
@@ -91,5 +96,9 @@ export function usePaginatedListings(
     }
   }, [isLoading, hasMore, disabled]);
 
-  return { listings, isLoading, hasMore, loadMore };
+  /**
+   * Error message from the most recent failed fetch, or `null` if the last
+   * fetch succeeded or no fetch has been attempted yet.
+   */
+  return { listings, isLoading, hasMore, loadMore, error };
 }


### PR DESCRIPTION
Closes #1403

---

Adds an `error: string | null` return value to `usePaginatedListings` so consumers can distinguish a network failure from a genuine end-of-results state (hasMore === false).

**What changed:**
- Added `error` state to the hook, set on catch with the error message, cleared on successful fetch or params reset
- Added two tests: one asserting error is surfaced distinctly from `hasMore === false`, and one asserting error is null on success

**Acceptance criteria checklist:**
- [x] `error: string | null` is returned by the hook
- [x] Error is set on fetch failure and cleared on successful fetch/retry
- [x] Test asserts the hook surfaces error distinctly from `hasMore === false`
- [x] All 4 tests pass (2 existing + 2 new)
- [x] 100% coverage on `usePaginatedListings.ts`