### PR TITLE
fix(contracts): pass default penalty bps to deploy-testnet initialize

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -131,6 +131,9 @@ Required environment variables:
 | `COMMITLABS_ADMIN_ADDRESS` | Admin `G...` address passed to `initialize`. |
 | `COMMITLABS_TOKEN_CONTRACT_ID` | Token `C...` contract id passed to `initialize`. |
 | `COMMITLABS_FEE_RECIPIENT_ADDRESS` | Fee recipient `G...` address passed to `initialize`. |
+| `COMMITLABS_SAFE_DEFAULT_PENALTY_BPS` | Default early-exit penalty (0-10000 bps) for `RiskProfile::Safe`, passed to `initialize`. |
+| `COMMITLABS_BALANCED_DEFAULT_PENALTY_BPS` | Default early-exit penalty (0-10000 bps) for `RiskProfile::Balanced`, passed to `initialize`. |
+| `COMMITLABS_AGGRESSIVE_DEFAULT_PENALTY_BPS` | Default early-exit penalty (0-10000 bps) for `RiskProfile::Aggressive`, passed to `initialize`. |
 
 Optional overrides include `STELLAR_RPC_URL`, `STELLAR_NETWORK_PASSPHRASE`, `COMMITLABS_ENV_FILE`, `COMMITLABS_CONTRACT_MANIFEST`, `COMMITLABS_CONTRACT_PACKAGE`, `COMMITLABS_WASM_PATH`, `COMMITLABS_CONTRACT_ALIAS`, and `DRY_RUN`.
 
@@ -142,6 +145,9 @@ STELLAR_ACCOUNT=deployer \
 COMMITLABS_ADMIN_ADDRESS=G... \
 COMMITLABS_TOKEN_CONTRACT_ID=C... \
 COMMITLABS_FEE_RECIPIENT_ADDRESS=G... \
+COMMITLABS_SAFE_DEFAULT_PENALTY_BPS=200 \
+COMMITLABS_BALANCED_DEFAULT_PENALTY_BPS=300 \
+COMMITLABS_AGGRESSIVE_DEFAULT_PENALTY_BPS=500 \
 ./contracts/scripts/deploy-testnet.sh
 ```
 
@@ -152,6 +158,9 @@ STELLAR_ACCOUNT=deployer \
 COMMITLABS_ADMIN_ADDRESS=G... \
 COMMITLABS_TOKEN_CONTRACT_ID=C... \
 COMMITLABS_FEE_RECIPIENT_ADDRESS=G... \
+COMMITLABS_SAFE_DEFAULT_PENALTY_BPS=200 \
+COMMITLABS_BALANCED_DEFAULT_PENALTY_BPS=300 \
+COMMITLABS_AGGRESSIVE_DEFAULT_PENALTY_BPS=500 \
 ./contracts/scripts/deploy-testnet.sh
 ```
 

--- a/contracts/scripts/deploy-testnet.sh
+++ b/contracts/scripts/deploy-testnet.sh
@@ -53,6 +53,14 @@ validate_contract_id() {
   fi
 }
 
+validate_penalty_bps() {
+  local value="$1"
+  local label="$2"
+  if [[ ! "${value}" =~ ^[0-9]+$ ]] || (( value > 10000 )); then
+    fail "${label} must be an integer between 0 and 10000 (basis points)."
+  fi
+}
+
 upsert_env_var() {
   local key="$1"
   local value="$2"
@@ -143,6 +151,9 @@ initialize_contract() {
     --admin "${COMMITLABS_ADMIN_ADDRESS}"
     --token "${COMMITLABS_TOKEN_CONTRACT_ID}"
     --fee_recipient "${COMMITLABS_FEE_RECIPIENT_ADDRESS}"
+    --safe_default_penalty_bps "${COMMITLABS_SAFE_DEFAULT_PENALTY_BPS}"
+    --balanced_default_penalty_bps "${COMMITLABS_BALANCED_DEFAULT_PENALTY_BPS}"
+    --aggressive_default_penalty_bps "${COMMITLABS_AGGRESSIVE_DEFAULT_PENALTY_BPS}"
   )
 
   if [[ "${DRY_RUN}" == "1" ]]; then
@@ -158,12 +169,18 @@ main() {
   require_env COMMITLABS_ADMIN_ADDRESS
   require_env COMMITLABS_TOKEN_CONTRACT_ID
   require_env COMMITLABS_FEE_RECIPIENT_ADDRESS
+  require_env COMMITLABS_SAFE_DEFAULT_PENALTY_BPS
+  require_env COMMITLABS_BALANCED_DEFAULT_PENALTY_BPS
+  require_env COMMITLABS_AGGRESSIVE_DEFAULT_PENALTY_BPS
 
   [[ -f "${MANIFEST_PATH}" ]] || fail "Contract manifest not found at ${MANIFEST_PATH}"
 
   validate_stellar_address "${COMMITLABS_ADMIN_ADDRESS}" "COMMITLABS_ADMIN_ADDRESS"
   validate_contract_id "${COMMITLABS_TOKEN_CONTRACT_ID}" "COMMITLABS_TOKEN_CONTRACT_ID"
   validate_stellar_address "${COMMITLABS_FEE_RECIPIENT_ADDRESS}" "COMMITLABS_FEE_RECIPIENT_ADDRESS"
+  validate_penalty_bps "${COMMITLABS_SAFE_DEFAULT_PENALTY_BPS}" "COMMITLABS_SAFE_DEFAULT_PENALTY_BPS"
+  validate_penalty_bps "${COMMITLABS_BALANCED_DEFAULT_PENALTY_BPS}" "COMMITLABS_BALANCED_DEFAULT_PENALTY_BPS"
+  validate_penalty_bps "${COMMITLABS_AGGRESSIVE_DEFAULT_PENALTY_BPS}" "COMMITLABS_AGGRESSIVE_DEFAULT_PENALTY_BPS"
 
   if [[ "${DRY_RUN}" != "1" ]]; then
     require_command stellar

--- a/contracts/scripts/deploy-testnet.smoke.mjs
+++ b/contracts/scripts/deploy-testnet.smoke.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 const repoRoot = process.cwd()
-const bashPath = 'C:/Program Files/Git/bin/bash.exe'
+const bashPath = process.platform === 'win32' ? 'C:/Program Files/Git/bin/bash.exe' : 'bash'
 const scriptPath = 'contracts/scripts/deploy-testnet.sh'
 
 function toMsysPath(windowsPath) {
@@ -34,6 +34,9 @@ function run() {
         COMMITLABS_ADMIN_ADDRESS: 'GBQ6M5OBU64ATKSRH4OKW2IFQCB5R6Q73F4VMK6KQ37C5G6GQ6FJTYA3',
         COMMITLABS_TOKEN_CONTRACT_ID: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
         COMMITLABS_FEE_RECIPIENT_ADDRESS: 'GC3C4X5R7N2X7CII7SPRD4U6ZLKZKAJZDW6N4Q4QAV3FJ7Q3N7GJ5P6L',
+        COMMITLABS_SAFE_DEFAULT_PENALTY_BPS: '200',
+        COMMITLABS_BALANCED_DEFAULT_PENALTY_BPS: '300',
+        COMMITLABS_AGGRESSIVE_DEFAULT_PENALTY_BPS: '500',
         COMMITLABS_ENV_FILE: toMsysPath(envFile),
       },
     })
@@ -44,6 +47,22 @@ function run() {
         'NEXT_PUBLIC_COMMITMENT_CORE_CONTRACT=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
       ),
       'dry-run output did not include NEXT_PUBLIC_COMMITMENT_CORE_CONTRACT',
+    )
+    assert(
+      success.stderr.includes('initialize') && success.stderr.includes('--admin'),
+      'dry-run output did not include the initialize invoke command',
+    )
+    assert(
+      /--safe_default_penalty_bps\s+200/.test(success.stderr),
+      'dry-run initialize invoke did not include --safe_default_penalty_bps',
+    )
+    assert(
+      /--balanced_default_penalty_bps\s+300/.test(success.stderr),
+      'dry-run initialize invoke did not include --balanced_default_penalty_bps',
+    )
+    assert(
+      /--aggressive_default_penalty_bps\s+500/.test(success.stderr),
+      'dry-run initialize invoke did not include --aggressive_default_penalty_bps',
     )
 
     const writtenEnv = readFileSync(envFile, 'utf8')


### PR DESCRIPTION
initialize() requires safe/balanced/aggressive default penalty bps alongside admin/token/fee_recipient, but deploy-testnet.sh omitted them from the invoke, so a real (non-DRY_RUN) deploy would fail.

- Add COMMITLABS_{SAFE,BALANCED,AGGRESSIVE}_DEFAULT_PENALTY_BPS env vars, validated as 0-10000 integers like the existing address vars, and pass them through the initialize invoke.
- Document the new vars in the README's required-variables table and dry-run/real-deploy examples.
- Extend the deploy smoke test to assert the dry-run initialize command includes all three penalty flags, and fix its bash lookup to work outside Windows Git Bash so the check actually runs.

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Closes #1401 

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Please review the [Developer Guide](https://github.com/Commitlabs-Org/Commitlabs-Frontend/blob/master/DEVELOPER_GUIDE.md) before checking the items below:

- [ ] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [ ] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [ ] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

Please add screenshots, screen recordings, or GIFs showcasing the user interface changes.

## Join the Discussion

Need help or want to chat? Join our [CommitLabs Discord](https://discord.gg/WV7tdYkJk) server.
