### PR TITLE
fix: resolve TS2322 type errors in CommitmentHealthMetrics and Market…

### DIFF
--- a/src/components/MarketplaceHeader/MarketplaceHeader.tsx
+++ b/src/components/MarketplaceHeader/MarketplaceHeader.tsx
@@ -32,6 +32,12 @@ export interface CommitmentSearchResult {
   expiresAt: string
 }
 
+interface MarketplaceStats {
+  activeListings: number;
+  averageYield: number;
+  medianPrice: number;
+}
+
 const SORT_OPTIONS = [
   { value: 'popular', label: 'Most Popular' },
   { value: 'newest', label: 'Newest' },
@@ -78,7 +84,6 @@ export function MarketplaceHeader({
   searchQuery: controlledQuery,
   ownerAddress,
   onResultSelect,
-}: MarketplaceHeaderProps) {
 }: MarketplaceHeaderProps) {
   // ── Sort ───────────────────────────────────────────────────────────────────
   const [sortValue, setSortValue] = useState<SortValue>('popular')

--- a/src/components/dashboard/CommitmentHealthMetrics.tsx
+++ b/src/components/dashboard/CommitmentHealthMetrics.tsx
@@ -145,11 +145,16 @@ export default function CommitmentHealthMetrics({
   );
 
   // Export menu always exports the full (unfiltered) dataset, not just the active range.
+  // Map from the permissive TimeSeriesPoint[] to the exact shapes HealthMetricsExportData requires.
   const exportData: HealthMetricsExportData = {
-    complianceData,
-    drawdownData,
-    valueHistoryData,
-    feeGenerationData,
+    complianceData: complianceData.map((p) => ({ date: p.date, complianceScore: p.complianceScore ?? 0 })),
+    drawdownData: drawdownData.map((p) => ({ date: p.date, drawdownPercent: p.drawdownPercent ?? 0 })),
+    valueHistoryData: valueHistoryData.map((p) => ({
+      date: p.date,
+      currentValue: p.currentValue ?? 0,
+      ...(p.initialAmount !== undefined ? { initialAmount: p.initialAmount } : {}),
+    })),
+    feeGenerationData: feeGenerationData.map((p) => ({ date: p.date, feeAmount: p.feeAmount ?? 0 })),
   };
 
   const hasBenchmark = benchmarkData && benchmarkData.length > 0;
@@ -216,12 +221,16 @@ export default function CommitmentHealthMetrics({
               <EmptyChart rangeLabel={rangeLabel} />
             ) : (
               <HealthMetricsValueHistoryChart
-                data={filteredValueHistory as Array<{ date: string; currentValue: number; initialAmount?: number }>}
-                volatilityPercent={volatilityPercent}
-                lifecycleEvents={lifecycleEvents}
-                exposure={exposure}
-                benchmarkData={benchmarkData}
-                benchmarkLabel={benchmarkLabel}
+                data={filteredValueHistory.map((p) => ({
+                  date: p.date,
+                  currentValue: p.currentValue ?? 0,
+                  ...(p.initialAmount !== undefined ? { initialAmount: p.initialAmount } : {}),
+                }))}
+                {...(volatilityPercent !== undefined ? { volatilityPercent } : {})}
+                {...(lifecycleEvents !== undefined ? { lifecycleEvents } : {})}
+                {...(exposure !== undefined ? { exposure } : {})}
+                {...(benchmarkData !== undefined ? { benchmarkData } : {})}
+                {...(benchmarkLabel !== undefined ? { benchmarkLabel } : {})}
               />
             )}
           </div>
@@ -240,11 +249,14 @@ export default function CommitmentHealthMetrics({
               <EmptyChart rangeLabel={rangeLabel} />
             ) : (
               <HealthMetricsDrawdownChart
-                data={filteredDrawdownHistory as Array<{ date: string; drawdownPercent: number }>}
-                thresholdPercent={thresholdPercent}
-                volatilityPercent={volatilityPercent}
-                lifecycleEvents={lifecycleEvents}
-                exposure={exposure}
+                data={filteredDrawdownHistory.map((p) => ({
+                  date: p.date,
+                  drawdownPercent: p.drawdownPercent ?? 0,
+                }))}
+                {...(thresholdPercent !== undefined ? { thresholdPercent } : {})}
+                {...(volatilityPercent !== undefined ? { volatilityPercent } : {})}
+                {...(lifecycleEvents !== undefined ? { lifecycleEvents } : {})}
+                {...(exposure !== undefined ? { exposure } : {})}
               />
             )}
           </div>
@@ -263,9 +275,11 @@ export default function CommitmentHealthMetrics({
               <EmptyChart rangeLabel={rangeLabel} />
             ) : (
               <HealthMetricsFeeGenerationChart
-                data={filteredFeeGenerationHistory as Array<{ date: string; feeAmount: number }>}
-                volatilityPercent={volatilityPercent}
-                exposure={exposure}
+                data={filteredFeeGenerationHistory.map((p) => ({
+                  date: p.date,
+                  feeAmount: p.feeAmount ?? 0,
+                }))}
+                {...(exposure !== undefined ? { exposure } : {})}
               />
             )}
           </div>
@@ -284,7 +298,10 @@ export default function CommitmentHealthMetrics({
               <EmptyChart rangeLabel={rangeLabel} />
             ) : (
               <HealthMetricsComplianceChart
-                data={filteredComplianceHistory as Array<{ date: string; complianceScore: number }>}
+                data={filteredComplianceHistory.map((p) => ({
+                  date: p.date,
+                  complianceScore: p.complianceScore ?? 0,
+                }))}
               />
             )}
           </div>


### PR DESCRIPTION
…placeHeader

- Replace unsafe 'as' casts with .map() transforms that produce exact shapes each child chart expects (complianceScore, drawdownPercent, currentValue, feeAmount with ?? 0 fallbacks; initialAmount via conditional spread)
- Apply conditional prop spreads for all optional fields to satisfy exactOptionalPropertyTypes (volatilityPercent, lifecycleEvents, exposure, benchmarkData, benchmarkLabel, thresholdPercent)
- Fix exportData object to use .map() transforms matching HealthMetricsExportData
- Remove non-existent volatilityPercent prop from HealthMetricsFeeGenerationChart
- Fix MarketplaceHeader duplicate function signature (TS1128/TS1434)
- Add missing MarketplaceStats interface to MarketplaceHeader

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Closes # (issue number)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Please review the [Developer Guide](https://github.com/Commitlabs-Org/Commitlabs-Frontend/blob/master/DEVELOPER_GUIDE.md) before checking the items below:

- [ ] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [ ] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [ ] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

Please add screenshots, screen recordings, or GIFs showcasing the user interface changes.

## Join the Discussion

Need help or want to chat? Join our [CommitLabs Discord](https://discord.gg/WV7tdYkJk) server.

closes #1213