### PR TITLE
feat: make all per-route rate limits env-configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,9 +128,24 @@ COMMITLABS_FEATURE_MARKETPLACE=false
 
 # -- Rate limiting -------------------------------------------------------------
 # Controls the fixed-window rate limits applied to API routes.
-# Write-heavy routes use the WRITE vars; all other routes use the DEFAULT vars.
-# RATE_LIMIT_WRITE_MAX_REQUESTS=10
+# All limits are optional — remove the comment (#) to override a default.
+# Invalid values (non-numeric, zero, negative) fall back to the defaults below
+# so that a misconfigured deployment never accidentally disables rate limiting.
+#
+# Auth routes — kept tight to resist credential-farming and brute-force attacks.
+# Raise these during planned load tests; restore before going back to production.
+# RATE_LIMIT_AUTH_NONCE_MAX_REQUESTS=5     # api/auth/nonce     (default: 5 req / 60 s)
+# RATE_LIMIT_AUTH_NONCE_WINDOW_SECONDS=60
+# RATE_LIMIT_AUTH_VERIFY_MAX_REQUESTS=5    # api/auth/verify    (default: 5 req / 60 s)
+# RATE_LIMIT_AUTH_VERIFY_WINDOW_SECONDS=60
+# RATE_LIMIT_NONCE_ADDRESS_MAX_REQUESTS=3  # auth:nonce:address — per-wallet secondary bucket
+# RATE_LIMIT_NONCE_ADDRESS_WINDOW_SECONDS=300  # (default: 3 req / 300 s)
+#
+# Write-heavy routes — protects on-chain operations and the signing budget.
+# RATE_LIMIT_WRITE_MAX_REQUESTS=10    # api/commitments/{create,settle,early-exit}
 # RATE_LIMIT_WRITE_WINDOW_SECONDS=60
+#
+# Default bucket — fallback for all routes not listed above.
 # RATE_LIMIT_DEFAULT_MAX_REQUESTS=20
 # RATE_LIMIT_DEFAULT_WINDOW_SECONDS=60
 

--- a/docs/backend-rate-limiting.md
+++ b/docs/backend-rate-limiting.md
@@ -1,0 +1,137 @@
+# Backend Rate Limiting
+
+Commitlabs uses a **fixed-window** rate limiter backed by KV (Redis / Upstash).
+Because the API runs as serverless functions, the counter lives in KV rather
+than in-process, so limits are enforced consistently across all instances.
+
+The implementation lives in [`src/lib/backend/rateLimit.ts`](../src/lib/backend/rateLimit.ts).
+
+---
+
+## How it works
+
+1. Every inbound request is keyed on `ratelimit:<routeId>:<clientKey>` in KV.
+2. An `INCR` increments the counter; the first increment also sets the key's TTL
+   to the configured window.
+3. If `count > maxRequests` the route handler returns **HTTP 429** with a
+   `Retry-After` header whose value comes from `getRateLimitWindowSeconds()`.
+4. On KV errors the limiter **fails open** — it returns `true` (allowed) and
+   logs the error, so a Redis outage does not block legitimate traffic.
+
+---
+
+## Route buckets
+
+Each named bucket below maps to one or more API routes.  Every bucket has its
+own env var pair so operators can tune each one independently.
+
+### Auth routes
+
+These carry the tightest defaults because they guard the wallet-signature
+authentication flow.  Loosening them reduces friction for load tests but
+increases exposure to credential-farming and brute-force attacks; restore
+production values before disabling the override.
+
+| Route | Default limit | Env vars |
+|---|---|---|
+| `api/auth/nonce` | 5 req / 60 s | `RATE_LIMIT_AUTH_NONCE_MAX_REQUESTS` / `RATE_LIMIT_AUTH_NONCE_WINDOW_SECONDS` |
+| `api/auth/verify` | 5 req / 60 s | `RATE_LIMIT_AUTH_VERIFY_MAX_REQUESTS` / `RATE_LIMIT_AUTH_VERIFY_WINDOW_SECONDS` |
+
+**Why tight?**  Nonce generation is the prerequisite step for wallet-signature
+auth.  An attacker who can farm nonces at will can probe signing behaviour or
+attempt replay attacks.  `api/auth/verify` is the credential-check endpoint;
+limiting it slows down automated signature-guessing.
+
+### Per-address nonce bucket
+
+| Route / key | Default limit | Env vars |
+|---|---|---|
+| `auth:nonce:address` | 3 req / 300 s | `RATE_LIMIT_NONCE_ADDRESS_MAX_REQUESTS` / `RATE_LIMIT_NONCE_ADDRESS_WINDOW_SECONDS` |
+
+This is a **secondary bucket** applied per wallet address on top of the
+per-IP bucket for `api/auth/nonce`.  It prevents a single wallet address from
+farming nonces even when multiple requests come from the same shared IP (e.g.
+a corporate NAT or a proxy farm).
+
+### Write-heavy commitment routes
+
+| Route | Default limit | Env vars |
+|---|---|---|
+| `api/commitments/create` | 10 req / 60 s | `RATE_LIMIT_WRITE_MAX_REQUESTS` / `RATE_LIMIT_WRITE_WINDOW_SECONDS` |
+| `api/commitments/settle` | 10 req / 60 s | (same pair) |
+| `api/commitments/early-exit` | 10 req / 60 s | (same pair) |
+
+On-chain write operations are irreversible and gas-intensive.  The shared write
+bucket protects both the Soroban network and the operator's signing budget.
+
+### Default bucket (all other routes)
+
+| Route | Default limit | Env vars |
+|---|---|---|
+| everything else | 20 req / 60 s | `RATE_LIMIT_DEFAULT_MAX_REQUESTS` / `RATE_LIMIT_DEFAULT_WINDOW_SECONDS` |
+
+General read/query routes are cheaper to serve, so the ceiling is higher, but
+still bounded to deter scraping and denial-of-service.
+
+---
+
+## Environment variable reference
+
+All variables are optional.  When absent or set to an invalid value
+(non-numeric, zero, or negative) the default shown below is used silently,
+ensuring rate limiting is never accidentally disabled by a misconfiguration.
+
+| Variable | Default | Notes |
+|---|---|---|
+| `RATE_LIMIT_AUTH_NONCE_MAX_REQUESTS` | `5` | |
+| `RATE_LIMIT_AUTH_NONCE_WINDOW_SECONDS` | `60` | |
+| `RATE_LIMIT_AUTH_VERIFY_MAX_REQUESTS` | `5` | |
+| `RATE_LIMIT_AUTH_VERIFY_WINDOW_SECONDS` | `60` | |
+| `RATE_LIMIT_NONCE_ADDRESS_MAX_REQUESTS` | `3` | |
+| `RATE_LIMIT_NONCE_ADDRESS_WINDOW_SECONDS` | `300` | 5-minute window |
+| `RATE_LIMIT_WRITE_MAX_REQUESTS` | `10` | Shared by all three write routes |
+| `RATE_LIMIT_WRITE_WINDOW_SECONDS` | `60` | |
+| `RATE_LIMIT_DEFAULT_MAX_REQUESTS` | `20` | |
+| `RATE_LIMIT_DEFAULT_WINDOW_SECONDS` | `60` | |
+
+See [`.env.example`](../.env.example) for commented-out examples of all ten
+variables.
+
+---
+
+## Operator runbook
+
+### Temporarily raising limits for a load test
+
+```bash
+# In .env.local (or your deployment's secret store):
+RATE_LIMIT_AUTH_NONCE_MAX_REQUESTS=50
+RATE_LIMIT_AUTH_NONCE_WINDOW_SECONDS=60
+RATE_LIMIT_AUTH_VERIFY_MAX_REQUESTS=50
+RATE_LIMIT_AUTH_VERIFY_WINDOW_SECONDS=60
+```
+
+Restart the server for the change to take effect.  **Remove or revert** these
+overrides before the deployment goes back to handling real user traffic.
+
+### Confirming active limits at runtime
+
+`buildLimits()` is called on every request — there is no cached copy.  The
+currently effective limits can be observed by adding a temporary `console.log`
+inside `buildLimits()` in a development environment, or by instrumenting the
+KV calls in staging.
+
+### KV outage behaviour
+
+The limiter calls `kv.incr()` and `kv.expire()`.  If either throws, the catch
+block in `checkRateLimit` logs the error and returns `true` (allow), so users
+are never blocked because Redis is down.  Monitor KV errors via the application
+logs or your observability stack.
+
+---
+
+## Related documents
+
+- [Backend Security Checklist](./backend-security-checklist.md) — section 12 covers the rate-limiting PR review items.
+- [Backend API Reference](./backend-api-reference.md) — 429 response format and `Retry-After` semantics.
+- [Backend Storage](./backend-storage.md) — KV adapter configuration (Redis / Upstash / in-memory).

--- a/docs/backend-security-checklist.md
+++ b/docs/backend-security-checklist.md
@@ -150,9 +150,16 @@ npm audit
 ## 12. Rate Limiting
 
 - [ ] Write-heavy routes (`POST /api/commitments`, `POST /api/commitments/[id]/fund`, `POST /api/commitments/[id]/settle`, `POST /api/commitments/[id]/early-exit`) are protected by per-IP rate limiting
+- [ ] Auth routes (`POST /api/auth/nonce`, `POST /api/auth/verify`) use the tighter auth-route limits, not the default bucket
 - [ ] Rate limits are applied via `checkRateLimit(ip, routeId)` using `getClientIp` for key derivation
 - [ ] 429 responses include a `Retry-After` header populated from `getRateLimitWindowSeconds(routeId)`
-- [ ] Rate limit thresholds are configurable via env vars (`RATE_LIMIT_WRITE_MAX_REQUESTS`, `RATE_LIMIT_WRITE_WINDOW_SECONDS`, etc.) — not hardcoded
+- [ ] All per-route rate limit thresholds are configurable via env vars — not hardcoded. The full set of variables is:
+  - Auth: `RATE_LIMIT_AUTH_NONCE_MAX_REQUESTS`, `RATE_LIMIT_AUTH_NONCE_WINDOW_SECONDS`
+  - Auth: `RATE_LIMIT_AUTH_VERIFY_MAX_REQUESTS`, `RATE_LIMIT_AUTH_VERIFY_WINDOW_SECONDS`
+  - Per-address nonce: `RATE_LIMIT_NONCE_ADDRESS_MAX_REQUESTS`, `RATE_LIMIT_NONCE_ADDRESS_WINDOW_SECONDS`
+  - Write routes: `RATE_LIMIT_WRITE_MAX_REQUESTS`, `RATE_LIMIT_WRITE_WINDOW_SECONDS`
+  - Default bucket: `RATE_LIMIT_DEFAULT_MAX_REQUESTS`, `RATE_LIMIT_DEFAULT_WINDOW_SECONDS`
+  - See [docs/backend-rate-limiting.md](./backend-rate-limiting.md) for defaults and security rationale.
 - [ ] The rate limiter fails open on KV errors (does not block legitimate traffic during Redis outages)
 - [ ] In production, `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are set so limits are shared across serverless instances
 - [ ] New write routes added to the API have a corresponding named entry in `rateLimit.ts` LIMITS (not relying on the default)

--- a/src/lib/backend/rateLimit.ts
+++ b/src/lib/backend/rateLimit.ts
@@ -6,11 +6,34 @@ import { getKV } from "./kv";
  * Uses a fixed-window rate limiting strategy stored in KV (Redis/Upstash).
  * This works across multiple serverless instances.
  *
- * Limits are configurable via environment variables:
- *   RATE_LIMIT_WRITE_MAX_REQUESTS   — max requests per window for write routes (default: 10)
- *   RATE_LIMIT_WRITE_WINDOW_SECONDS — window size in seconds for write routes (default: 60)
- *   RATE_LIMIT_DEFAULT_MAX_REQUESTS — max requests per window for all other routes (default: 20)
- *   RATE_LIMIT_DEFAULT_WINDOW_SECONDS — window size in seconds for all other routes (default: 60)
+ * ALL per-route limits are configurable via environment variables so that
+ * operators can tune them without a code redeploy (e.g. during load tests,
+ * capacity planning, or incident response).  Every variable falls back to a
+ * security-reviewed default when absent or set to an invalid value.
+ *
+ * ┌─────────────────────────────────────────────────┬─────────────────────────────────┬──────────────┬───────────────────────────────────────────────────────────────────────────────────────────┐
+ * │ Environment variable                            │ Route / bucket                  │ Default      │ Security rationale                                                                        │
+ * ├─────────────────────────────────────────────────┼─────────────────────────────────┼──────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
+ * │ RATE_LIMIT_AUTH_NONCE_MAX_REQUESTS              │ api/auth/nonce                  │ 5 / 60 s     │ Nonce generation is a prerequisite for wallet-signature auth; low limit prevents         │
+ * │ RATE_LIMIT_AUTH_NONCE_WINDOW_SECONDS            │                                 │              │ mass-nonce-farming that could be used to probe signing behaviour.                          │
+ * ├─────────────────────────────────────────────────┼─────────────────────────────────┼──────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
+ * │ RATE_LIMIT_AUTH_VERIFY_MAX_REQUESTS             │ api/auth/verify                 │ 5 / 60 s     │ Signature-verify is the credential-check endpoint; tight limits slow down automated        │
+ * │ RATE_LIMIT_AUTH_VERIFY_WINDOW_SECONDS           │                                 │              │ credential-stuffing and brute-force signature guessing.                                    │
+ * ├─────────────────────────────────────────────────┼─────────────────────────────────┼──────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
+ * │ RATE_LIMIT_NONCE_ADDRESS_MAX_REQUESTS           │ auth:nonce:address              │ 3 / 300 s    │ Per-address secondary bucket applied on top of the IP bucket; prevents a single wallet   │
+ * │ RATE_LIMIT_NONCE_ADDRESS_WINDOW_SECONDS         │                                 │              │ address from farming nonces even when behind a shared IP (e.g. corporate NAT).            │
+ * ├─────────────────────────────────────────────────┼─────────────────────────────────┼──────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
+ * │ RATE_LIMIT_WRITE_MAX_REQUESTS                   │ api/commitments/create          │ 10 / 60 s    │ On-chain write operations are irreversible and gas-intensive; the shared write bucket    │
+ * │ RATE_LIMIT_WRITE_WINDOW_SECONDS                 │ api/commitments/settle          │              │ protects both the Soroban network and the operator's signing budget.                      │
+ * │                                                 │ api/commitments/early-exit      │              │                                                                                           │
+ * ├─────────────────────────────────────────────────┼─────────────────────────────────┼──────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
+ * │ RATE_LIMIT_DEFAULT_MAX_REQUESTS                 │ all other routes (fallback)     │ 20 / 60 s    │ General read/query routes; higher ceiling than write routes because they are cheaper to  │
+ * │ RATE_LIMIT_DEFAULT_WINDOW_SECONDS               │                                 │              │ serve, but still bounded to deter scraping and denial-of-service.                         │
+ * └─────────────────────────────────────────────────┴─────────────────────────────────┴──────────────┴───────────────────────────────────────────────────────────────────────────────────────────┘
+ *
+ * Invalid values (non-numeric, zero, negative) are silently replaced with the
+ * documented default so that a misconfigured deployment never accidentally
+ * disables rate limiting.
  */
 
 function envInt(name: string, fallback: number): number {
@@ -21,15 +44,25 @@ function envInt(name: string, fallback: number): number {
 }
 
 function buildLimits(): Record<string, { windowMs: number; maxRequests: number }> {
+  // Auth routes — low defaults to resist credential-farming and brute-force
+  const authNonceMax = envInt("RATE_LIMIT_AUTH_NONCE_MAX_REQUESTS", 5);
+  const authNonceWindowSec = envInt("RATE_LIMIT_AUTH_NONCE_WINDOW_SECONDS", 60);
+  const authVerifyMax = envInt("RATE_LIMIT_AUTH_VERIFY_MAX_REQUESTS", 5);
+  const authVerifyWindowSec = envInt("RATE_LIMIT_AUTH_VERIFY_WINDOW_SECONDS", 60);
+  // Per-address nonce bucket — longer window than the IP bucket
+  const nonceAddressMax = envInt("RATE_LIMIT_NONCE_ADDRESS_MAX_REQUESTS", 3);
+  const nonceAddressWindowSec = envInt("RATE_LIMIT_NONCE_ADDRESS_WINDOW_SECONDS", 300);
+  // Write-heavy routes — tighter limits to protect on-chain operations
   const writeMax = envInt("RATE_LIMIT_WRITE_MAX_REQUESTS", 10);
   const writeWindowSec = envInt("RATE_LIMIT_WRITE_WINDOW_SECONDS", 60);
+  // Default bucket for all other routes
   const defaultMax = envInt("RATE_LIMIT_DEFAULT_MAX_REQUESTS", 20);
   const defaultWindowSec = envInt("RATE_LIMIT_DEFAULT_WINDOW_SECONDS", 60);
 
   return {
-    "api/auth/nonce": { windowMs: 60 * 1000, maxRequests: 5 },
-    "api/auth/verify": { windowMs: 60 * 1000, maxRequests: 5 },
-    "auth:nonce:address": { windowMs: 5 * 60 * 1000, maxRequests: 3 },
+    "api/auth/nonce": { windowMs: authNonceWindowSec * 1000, maxRequests: authNonceMax },
+    "api/auth/verify": { windowMs: authVerifyWindowSec * 1000, maxRequests: authVerifyMax },
+    "auth:nonce:address": { windowMs: nonceAddressWindowSec * 1000, maxRequests: nonceAddressMax },
     // Write-heavy routes — tighter limits to protect on-chain operations
     "api/commitments/create": { windowMs: writeWindowSec * 1000, maxRequests: writeMax },
     "api/commitments/settle": { windowMs: writeWindowSec * 1000, maxRequests: writeMax },

--- a/tests/lib/backend/rateLimit.test.ts
+++ b/tests/lib/backend/rateLimit.test.ts
@@ -1,69 +1,209 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { checkRateLimit, getRateLimitWindowSeconds } from '@/src/lib/backend/rateLimit';
-import { getKV, KVStore } from '@/src/lib/backend/kv';
+import { checkRateLimit, getRateLimitWindowSeconds } from '@/lib/backend/rateLimit';
 
-// Mock getKV to return a fresh in‑memory store for each test suite
-vi.mock('@/src/lib/backend/kv', async () => {
-  const actual = await vi.importActual('@/src/lib/backend/kv');
-  const { MemoryKVStore } = actual;
-  const kvInstance = new MemoryKVStore();
-  return {
-    getKV: () => kvInstance,
-    KVStore: actual.KVStore,
-  };
-});
+// ── mock KV store ─────────────────────────────────────────────────────────────
+// Use a plain mock object — avoids the vi.mock hoisting / importActual issue
+// that arises when instantiating class constructors inside a factory.
+
+const mockKv = {
+  incr: vi.fn(),
+  expire: vi.fn(),
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+  getdel: vi.fn(),
+};
+
+vi.mock('@/lib/backend/kv', () => ({
+  getKV: () => mockKv,
+}));
 
 const TEST_ROUTE = 'api/commitments/create';
 const TEST_KEY = 'test-user';
 
 beforeEach(() => {
-  vi.useFakeTimers();
+  vi.clearAllMocks();
+  mockKv.expire.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
-  vi.runOnlyPendingTimers();
 });
 
 describe('rateLimit', () => {
   it('increments count and allows up to limit', async () => {
-    const max = Number(process.env.RATE_LIMIT_WRITE_MAX_REQUESTS ?? 10);
+    const max = 10; // default write max
     for (let i = 1; i <= max; i++) {
+      mockKv.incr.mockResolvedValueOnce(i);
       const allowed = await checkRateLimit(TEST_KEY, TEST_ROUTE);
       expect(allowed).toBe(true);
     }
     // next request should be blocked
+    mockKv.incr.mockResolvedValueOnce(max + 1);
     const blocked = await checkRateLimit(TEST_KEY, TEST_ROUTE);
     expect(blocked).toBe(false);
   });
 
-  it('resets counter after window expiry', async () => {
-    // first request increments and sets expiry
+  it('sets TTL on the first request (count === 1)', async () => {
+    mockKv.incr.mockResolvedValue(1);
     await checkRateLimit(TEST_KEY, TEST_ROUTE);
-    // fast‑forward past the window
-    const windowSec = getRateLimitWindowSeconds(TEST_ROUTE);
-    vi.advanceTimersByTime(windowSec * 1000 + 1);
-    // counter should be reset, allowing a new request
+    expect(mockKv.expire).toHaveBeenCalledWith(
+      `ratelimit:${TEST_ROUTE}:${TEST_KEY}`,
+      60,
+    );
+  });
+
+  it('does not reset TTL on subsequent requests', async () => {
+    mockKv.incr.mockResolvedValue(5);
+    await checkRateLimit(TEST_KEY, TEST_ROUTE);
+    expect(mockKv.expire).not.toHaveBeenCalled();
+  });
+
+  it('honors env overrides for write routes', async () => {
+    const originalMax = process.env.RATE_LIMIT_WRITE_MAX_REQUESTS;
+    process.env.RATE_LIMIT_WRITE_MAX_REQUESTS = '2';
+
+    mockKv.incr.mockResolvedValueOnce(1);
+    expect(await checkRateLimit(TEST_KEY, TEST_ROUTE)).toBe(true);
+    mockKv.incr.mockResolvedValueOnce(2);
+    expect(await checkRateLimit(TEST_KEY, TEST_ROUTE)).toBe(true);
+    mockKv.incr.mockResolvedValueOnce(3);
+    expect(await checkRateLimit(TEST_KEY, TEST_ROUTE)).toBe(false);
+
+    process.env.RATE_LIMIT_WRITE_MAX_REQUESTS = originalMax ?? '';
+  });
+
+  it('falls back to default on invalid env values', async () => {
+    const originalMax = process.env.RATE_LIMIT_WRITE_MAX_REQUESTS;
+    process.env.RATE_LIMIT_WRITE_MAX_REQUESTS = '-5';
+
+    // default is 10 — count of 10 should be allowed
+    mockKv.incr.mockResolvedValueOnce(10);
+    expect(await checkRateLimit('another-user', TEST_ROUTE)).toBe(true);
+
+    process.env.RATE_LIMIT_WRITE_MAX_REQUESTS = originalMax ?? '';
+  });
+
+  it('fails open (allows request) when KV throws', async () => {
+    mockKv.incr.mockRejectedValue(new Error('Redis connection failed'));
     const allowed = await checkRateLimit(TEST_KEY, TEST_ROUTE);
     expect(allowed).toBe(true);
   });
+});
 
-  it('honors env overrides and falls back on invalid values', async () => {
-    // set valid overrides
-    process.env.RATE_LIMIT_WRITE_MAX_REQUESTS = '2';
-    process.env.RATE_LIMIT_WRITE_WINDOW_SECONDS = '1';
-    const allowed1 = await checkRateLimit(TEST_KEY, TEST_ROUTE);
-    const allowed2 = await checkRateLimit(TEST_KEY, TEST_ROUTE);
-    expect(allowed1).toBe(true);
-    expect(allowed2).toBe(true);
-    const blocked = await checkRateLimit(TEST_KEY, TEST_ROUTE);
-    expect(blocked).toBe(false);
+describe('auth-route env overrides', () => {
+  // Restore env vars after each test so they don't bleed into other suites.
+  afterEach(() => {
+    [
+      'RATE_LIMIT_AUTH_NONCE_MAX_REQUESTS',
+      'RATE_LIMIT_AUTH_NONCE_WINDOW_SECONDS',
+      'RATE_LIMIT_AUTH_VERIFY_MAX_REQUESTS',
+      'RATE_LIMIT_AUTH_VERIFY_WINDOW_SECONDS',
+      'RATE_LIMIT_NONCE_ADDRESS_MAX_REQUESTS',
+      'RATE_LIMIT_NONCE_ADDRESS_WINDOW_SECONDS',
+    ].forEach((k) => delete process.env[k]);
+  });
 
-    // invalid overrides should fallback to defaults (10 requests, 60s window)
-    process.env.RATE_LIMIT_WRITE_MAX_REQUESTS = '-5';
-    process.env.RATE_LIMIT_WRITE_WINDOW_SECONDS = 'abc';
-    const newKey = 'another-user';
-    const allowedDefault = await checkRateLimit(newKey, TEST_ROUTE);
-    expect(allowedDefault).toBe(true);
+  // ── api/auth/nonce ────────────────────────────────────────────────────────
+
+  it('api/auth/nonce: respects RATE_LIMIT_AUTH_NONCE_MAX_REQUESTS', async () => {
+    process.env.RATE_LIMIT_AUTH_NONCE_MAX_REQUESTS = '2';
+    const key = 'nonce-ip-1';
+
+    mockKv.incr.mockResolvedValueOnce(1);
+    expect(await checkRateLimit(key, 'api/auth/nonce')).toBe(true);
+    mockKv.incr.mockResolvedValueOnce(2);
+    expect(await checkRateLimit(key, 'api/auth/nonce')).toBe(true);
+    mockKv.incr.mockResolvedValueOnce(3);
+    expect(await checkRateLimit(key, 'api/auth/nonce')).toBe(false);
+  });
+
+  it('api/auth/nonce: getRateLimitWindowSeconds respects RATE_LIMIT_AUTH_NONCE_WINDOW_SECONDS', () => {
+    process.env.RATE_LIMIT_AUTH_NONCE_WINDOW_SECONDS = '30';
+    expect(getRateLimitWindowSeconds('api/auth/nonce')).toBe(30);
+  });
+
+  it('api/auth/nonce: falls back to default max (5) on invalid env value', async () => {
+    process.env.RATE_LIMIT_AUTH_NONCE_MAX_REQUESTS = 'bad';
+    const key = 'nonce-ip-fallback';
+
+    // count of 5 should be allowed, 6 blocked
+    mockKv.incr.mockResolvedValueOnce(5);
+    expect(await checkRateLimit(key, 'api/auth/nonce')).toBe(true);
+    mockKv.incr.mockResolvedValueOnce(6);
+    expect(await checkRateLimit(key, 'api/auth/nonce')).toBe(false);
+  });
+
+  it('api/auth/nonce: falls back to default window (60 s) on invalid env value', () => {
+    process.env.RATE_LIMIT_AUTH_NONCE_WINDOW_SECONDS = '-99';
+    expect(getRateLimitWindowSeconds('api/auth/nonce')).toBe(60);
+  });
+
+  // ── api/auth/verify ───────────────────────────────────────────────────────
+
+  it('api/auth/verify: respects RATE_LIMIT_AUTH_VERIFY_MAX_REQUESTS', async () => {
+    process.env.RATE_LIMIT_AUTH_VERIFY_MAX_REQUESTS = '2';
+    const key = 'verify-ip-1';
+
+    mockKv.incr.mockResolvedValueOnce(1);
+    expect(await checkRateLimit(key, 'api/auth/verify')).toBe(true);
+    mockKv.incr.mockResolvedValueOnce(2);
+    expect(await checkRateLimit(key, 'api/auth/verify')).toBe(true);
+    mockKv.incr.mockResolvedValueOnce(3);
+    expect(await checkRateLimit(key, 'api/auth/verify')).toBe(false);
+  });
+
+  it('api/auth/verify: getRateLimitWindowSeconds respects RATE_LIMIT_AUTH_VERIFY_WINDOW_SECONDS', () => {
+    process.env.RATE_LIMIT_AUTH_VERIFY_WINDOW_SECONDS = '45';
+    expect(getRateLimitWindowSeconds('api/auth/verify')).toBe(45);
+  });
+
+  it('api/auth/verify: falls back to default max (5) on invalid env value', async () => {
+    process.env.RATE_LIMIT_AUTH_VERIFY_MAX_REQUESTS = '0';
+    const key = 'verify-ip-fallback';
+
+    mockKv.incr.mockResolvedValueOnce(5);
+    expect(await checkRateLimit(key, 'api/auth/verify')).toBe(true);
+    mockKv.incr.mockResolvedValueOnce(6);
+    expect(await checkRateLimit(key, 'api/auth/verify')).toBe(false);
+  });
+
+  it('api/auth/verify: falls back to default window (60 s) on invalid env value', () => {
+    process.env.RATE_LIMIT_AUTH_VERIFY_WINDOW_SECONDS = 'nan';
+    expect(getRateLimitWindowSeconds('api/auth/verify')).toBe(60);
+  });
+
+  // ── auth:nonce:address ────────────────────────────────────────────────────
+
+  it('auth:nonce:address: respects RATE_LIMIT_NONCE_ADDRESS_MAX_REQUESTS', async () => {
+    process.env.RATE_LIMIT_NONCE_ADDRESS_MAX_REQUESTS = '2';
+    const key = 'addr-GTEST';
+
+    mockKv.incr.mockResolvedValueOnce(1);
+    expect(await checkRateLimit(key, 'auth:nonce:address')).toBe(true);
+    mockKv.incr.mockResolvedValueOnce(2);
+    expect(await checkRateLimit(key, 'auth:nonce:address')).toBe(true);
+    mockKv.incr.mockResolvedValueOnce(3);
+    expect(await checkRateLimit(key, 'auth:nonce:address')).toBe(false);
+  });
+
+  it('auth:nonce:address: getRateLimitWindowSeconds respects RATE_LIMIT_NONCE_ADDRESS_WINDOW_SECONDS', () => {
+    process.env.RATE_LIMIT_NONCE_ADDRESS_WINDOW_SECONDS = '120';
+    expect(getRateLimitWindowSeconds('auth:nonce:address')).toBe(120);
+  });
+
+  it('auth:nonce:address: falls back to default max (3) on invalid env value', async () => {
+    process.env.RATE_LIMIT_NONCE_ADDRESS_MAX_REQUESTS = '-1';
+    const key = 'addr-fallback';
+
+    mockKv.incr.mockResolvedValueOnce(3);
+    expect(await checkRateLimit(key, 'auth:nonce:address')).toBe(true);
+    mockKv.incr.mockResolvedValueOnce(4);
+    expect(await checkRateLimit(key, 'auth:nonce:address')).toBe(false);
+  });
+
+  it('auth:nonce:address: falls back to default window (300 s) on invalid env value', () => {
+    process.env.RATE_LIMIT_NONCE_ADDRESS_WINDOW_SECONDS = 'abc';
+    expect(getRateLimitWindowSeconds('auth:nonce:address')).toBe(300);
   });
 });


### PR DESCRIPTION
Previously, the auth/nonce limits in buildLimits() were hardcoded literals while write-route limits used envInt(). This split made it non-obvious which limits an operator could tune without a redeploy.

Changes:
- src/lib/backend/rateLimit.ts: all 10 limits now read from env vars via envInt() with security-reviewed fallbacks; JSDoc updated with a full reference table (env var → route → default → rationale)
- .env.example: document all 10 RATE_LIMIT_* vars with comments
- docs/backend-rate-limiting.md: new dedicated reference doc covering the five named buckets, env var table, and operator runbook
- docs/backend-security-checklist.md: fix item 12 to list all 10 vars and link to the new doc (previously listed only 4)
- tests/lib/backend/rateLimit.test.ts: fix pre-existing broken mock pattern and add 12 new tests for the auth/nonce env var pairs

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Closes # (issue number)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Please review the [Developer Guide](https://github.com/Commitlabs-Org/Commitlabs-Frontend/blob/master/DEVELOPER_GUIDE.md) before checking the items below:

- [ ] My code follows the code style and standards of this project (strict TypeScript, components/functions/constants naming conventions).
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated or added documentation where relevant (`DEVELOPER_GUIDE.md`, `README.md`, or inline files).
- [ ] I have added unit/integration tests that prove my fix is effective or that my feature works.
- [ ] Any new or modified logic has **at least 95% test coverage** (verified via `pnpm run test:coverage` or `npm run test:coverage`).
- [ ] I have ran the project linter (`pnpm lint` or `npm run lint`) and fixed all error diagnostics.
- [ ] I have verified that this change fits within the **96-hour campaign timeframe** for contributor assignments.
- [ ] I have attached screenshots/videos showing the before and after states for any visual or UI changes.

## Visual Changes (if applicable)

Please add screenshots, screen recordings, or GIFs showcasing the user interface changes.

## Join the Discussion

Need help or want to chat? Join our [CommitLabs Discord](https://discord.gg/WV7tdYkJk) server.

closes #1302