### PR TITLE
refactor: read the session lifetime from an env var

### DIFF
--- a/src/lib/backend/sessionCookies.test.ts
+++ b/src/lib/backend/sessionCookies.test.ts
@@ -1,13 +1,39 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { NextResponse } from 'next/server';
 import { applySessionCookie, clearSessionCookie } from './sessionCookies';
 import { SESSION_COOKIE_NAME } from './session';
 
 describe('sessionCookies', () => {
+  afterEach(() => {
+    delete process.env.SESSION_COOKIE_MAX_AGE_SECONDS;
+  });
+
   it('applySessionCookie sets cl_session on the response', () => {
     const res = NextResponse.json({ ok: true });
     applySessionCookie(res, 'sess_test_value');
     expect(res.cookies.get(SESSION_COOKIE_NAME)?.value).toBe('sess_test_value');
+  });
+
+  it('applySessionCookie defaults maxAge to one week when SESSION_COOKIE_MAX_AGE_SECONDS is unset', () => {
+    const ONE_WEEK_SEC = 60 * 60 * 24 * 7;
+    const res = NextResponse.json({ ok: true });
+    applySessionCookie(res, 'sess_default');
+    expect(res.cookies.get(SESSION_COOKIE_NAME)?.maxAge).toBe(ONE_WEEK_SEC);
+  });
+
+  it('applySessionCookie reads maxAge from SESSION_COOKIE_MAX_AGE_SECONDS env var', () => {
+    process.env.SESSION_COOKIE_MAX_AGE_SECONDS = '3600';
+    const res = NextResponse.json({ ok: true });
+    applySessionCookie(res, 'sess_env_override');
+    expect(res.cookies.get(SESSION_COOKIE_NAME)?.maxAge).toBe(3600);
+  });
+
+  it('applySessionCookie falls back to one week for non-positive SESSION_COOKIE_MAX_AGE_SECONDS', () => {
+    const ONE_WEEK_SEC = 60 * 60 * 24 * 7;
+    process.env.SESSION_COOKIE_MAX_AGE_SECONDS = '0';
+    const res = NextResponse.json({ ok: true });
+    applySessionCookie(res, 'sess_bad_value');
+    expect(res.cookies.get(SESSION_COOKIE_NAME)?.maxAge).toBe(ONE_WEEK_SEC);
   });
 
   it('clearSessionCookie clears cl_session', () => {

--- a/src/lib/backend/sessionCookies.ts
+++ b/src/lib/backend/sessionCookies.ts
@@ -3,8 +3,19 @@ import { SESSION_COOKIE_NAME } from './session';
 
 const ONE_WEEK_SEC = 60 * 60 * 24 * 7;
 
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 function isProduction(): boolean {
   return process.env.NODE_ENV === 'production';
+}
+
+function sessionCookieMaxAge(): number {
+  return envInt('SESSION_COOKIE_MAX_AGE_SECONDS', ONE_WEEK_SEC);
 }
 
 /**
@@ -16,7 +27,7 @@ export function applySessionCookie(response: NextResponse, sessionId: string): v
     sameSite: 'lax',
     secure: isProduction(),
     path: '/',
-    maxAge: ONE_WEEK_SEC,
+    maxAge: sessionCookieMaxAge(),
   });
 }
 


### PR DESCRIPTION
read the session lifetime from an env var (e.g. SESSION_COOKIE_MAX_AGE_SECONDS) with ONE_WEEK_SEC as the fallback default, and add a test for the override.

closes #1299 