### PR TITLE
docs: add missing security-critical env vars to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,3 +157,73 @@ COMMITLABS_FEATURE_MARKETPLACE=false
 # redis://localhost:6379
 # redis://:mypassword@redis.example.com:6379/0
 # rediss://:mypassword@redis.example.com:6380/0
+
+# -- Upstash Redis (serverless KV) ---------------------------------------------
+# Used by src/lib/backend/kv.ts when CACHE_ADAPTER=upstash.
+# UPSTASH_REDIS_REST_URL=
+# UPSTASH_REDIS_REST_TOKEN=
+
+# -- Storage provider -----------------------------------------------------------
+# Selects the storage backend used by src/lib/backend/storage.ts.
+# Valid values: "memory" | "redis" | "kv"
+# COMMITLABS_STORAGE_PROVIDER=memory
+
+# -----------------------------------------------------------------------------
+# Admin & Security (server-side only)
+# These variables control admin authorization and sensitive endpoint access.
+# -----------------------------------------------------------------------------
+
+# Comma-separated list of Stellar addresses treated as admins.
+# Used by src/lib/backend/requireAuth.ts for requireAdmin / dispute resolution.
+# ADMIN_ADDRESSES=GABC...,GDEF...
+
+# Bearer token for the admin audit-log endpoint (src/app/api/admin/audit-events/route.ts).
+# The route returns 403 if this is unset. Value is ALWAYS redacted from logs.
+# COMMITLABS_ADMIN_SECRET=
+
+# -----------------------------------------------------------------------------
+# Feature flags — audit log & seed endpoint
+# -----------------------------------------------------------------------------
+
+# Gates the audit-log endpoint on/off (src/lib/backend/auditLog.ts).
+# Set to "true" to enable audit logging.
+# COMMITLABS_FEATURE_AUDIT_LOG=false
+
+# Enables the mock-data seeding endpoint (src/app/api/seed/route.ts).
+# Set to "true" to allow seed requests.
+# SEED_ROUTE_ENABLED=false
+
+# Shared secret required by the seed endpoint (src/app/api/seed/route.ts).
+# Only checked when SEED_ROUTE_ENABLED=true.
+# SEED_SECRET=
+
+# -----------------------------------------------------------------------------
+# Protocol constants (server-side only)
+# Override the defaults baked into src/lib/backend/services/protocolConstants.ts.
+# -----------------------------------------------------------------------------
+
+# JSON array of penalty tier objects for early-exit calculations.
+# COMMITLABS_PENALTY_TIERS_JSON=[{"type":"standard","earlyExitPenaltyPercent":10}]
+
+# -----------------------------------------------------------------------------
+# CORS origins (server-side only)
+# Override the defaults in src/lib/backend/cors.ts.
+# -----------------------------------------------------------------------------
+
+# First-party origins (app pages, admin panels).
+# COMMITLABS_FIRST_PARTY_ORIGINS=https://app.commitlabs.com
+
+# Public API origins (external integrations). Use "*" to allow all.
+# COMMITLABS_PUBLIC_API_ORIGINS=*
+
+# -----------------------------------------------------------------------------
+# SSE tuning (server-side only)
+# Controls polling/keepalive intervals for the commitments events SSE stream
+# (src/app/api/commitments/[id]/events/route.ts).
+# -----------------------------------------------------------------------------
+
+# Poll interval in ms for checking commitment status updates (default: 5000).
+# SSE_POLL_INTERVAL_MS=5000
+
+# Keepalive interval in ms to prevent connection timeout (default: 30000).
+# SSE_KEEPALIVE_INTERVAL_MS=30000


### PR DESCRIPTION
Add ADMIN_ADDRESSES, COMMITLABS_ADMIN_SECRET, SEED_SECRET, SEED_ROUTE_ENABLED, COMMITLABS_FEATURE_AUDIT_LOG, and other undocumented process.env reads to .env.example.

Added variables:
- ADMIN_ADDRESSES (requireAuth.ts — admin allowlist)
- COMMITLABS_ADMIN_SECRET (audit-events route — bearer token)
- COMMITLABS_FEATURE_AUDIT_LOG (auditLog.ts — feature gate)
- SEED_ROUTE_ENABLED / SEED_SECRET (seed endpoint)
- COMMITLABS_STORAGE_PROVIDER (storage.ts)
- COMMITLABS_PENALTY_TIERS_JSON (protocolConstants.ts)
- UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN (kv.ts)
- COMMITLABS_FIRST_PARTY_ORIGINS / COMMITLABS_PUBLIC_API_ORIGINS (cors.ts)
- SSE_POLL_INTERVAL_MS / SSE_KEEPALIVE_INTERVAL_MS (events SSE stream)

Closes #1606