### PR TITLE
feat: implement differentiated error handling in dispute/resolve routes

### DIFF
--- a/src/app/api/commitments/[id]/dispute/route.ts
+++ b/src/app/api/commitments/[id]/dispute/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { checkRateLimit } from '@/lib/backend/rateLimit';
 import { withApiHandler } from '@/lib/backend/withApiHandler';
 import { ok, methodNotAllowed } from '@/lib/backend/apiResponse';
-import { TooManyRequestsError, ValidationError, NotFoundError, ConflictError } from '@/lib/backend/errors';
+import { TooManyRequestsError, ValidationError, NotFoundError, ConflictError, InternalError } from '@/lib/backend/errors';
 import { getClientIp } from '@/lib/backend/getClientIp';
 import { openDisputeOnChain } from '@/lib/backend/services/contracts';
 import { logDisputeOpened } from '@/lib/backend/logger';
@@ -91,6 +91,16 @@ export const POST = withApiHandler(async (req: NextRequest, { params }: Params) 
             error: error instanceof Error ? error.message : 'Unknown dispute error',
         });
 
-        throw error;
+        if (
+            error instanceof ValidationError ||
+            error instanceof NotFoundError ||
+            error instanceof ConflictError
+        ) {
+            // Known API errors are rethrown as-is to be handled by withApiHandler
+            throw error;
+        }
+
+        // Wrap unknown/unexpected errors in a generic InternalError to prevent leaking internal details
+        throw new InternalError('An unexpected error occurred while opening the dispute');
     }
 });

--- a/src/app/api/commitments/[id]/resolve/route.ts
+++ b/src/app/api/commitments/[id]/resolve/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { checkRateLimit } from '@/lib/backend/rateLimit';
 import { withApiHandler } from '@/lib/backend/withApiHandler';
 import { ok } from '@/lib/backend/apiResponse';
-import { TooManyRequestsError, ValidationError, ConflictError, ForbiddenError } from '@/lib/backend/errors';
+import { TooManyRequestsError, ValidationError, ConflictError, ForbiddenError, InternalError } from '@/lib/backend/errors';
 import { getClientIp } from '@/lib/backend/getClientIp';
 import { resolveDisputeOnChain } from '@/lib/backend/services/contracts';
 import { logDisputeResolved } from '@/lib/backend/logger';
@@ -94,6 +94,16 @@ export const POST = withApiHandler(async (req: NextRequest, { params }: Params) 
             error: error instanceof Error ? error.message : 'Unknown resolution error',
         });
 
-        throw error;
+        if (
+            error instanceof ValidationError ||
+            error instanceof ConflictError ||
+            error instanceof ForbiddenError
+        ) {
+            // Known API errors are rethrown as-is to be handled by withApiHandler
+            throw error;
+        }
+
+        // Wrap unknown/unexpected errors in a generic InternalError to prevent leaking internal details
+        throw new InternalError('An unexpected error occurred while resolving the dispute');
     }
 });


### PR DESCRIPTION
Closes #1370 


This PR resolves an issue with dead-code catch blocks in the dispute and resolve API routes. Previously, the error handling blocks checked for specific API error types but then simply re-threw the error exactly the same way as the fallback, making the type checks a no-op.

## Changes Made
- Added `InternalError` imports to both `dispute/route.ts` and `resolve/route.ts`.
- Restored the explicit `if (error instanceof ...)` checks for known, safe-to-propagate API errors (e.g., `ValidationError`, `NotFoundError`, `ConflictError`).
- Wrapped any unexpected fallback errors in a generic `InternalError` with a standardized message before throwing.

## Why this matters
This ensures that internal details or unhandled exceptions from downstream services (like contract interactions) are not accidentally leaked to the client. The differentiated error handling now functions as originally intended, properly routing known errors to the global API handler while sanitizing unknown ones.