### PR TITLE
fix: guard protected routes with wallet auth

### DIFF
--- a/src/app/__tests__/protected-route-layouts.test.tsx
+++ b/src/app/__tests__/protected-route-layouts.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+import React from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import CreateLayout from '@/app/create/layout'
+import SettingsLayout from '@/app/settings/layout'
+import CommitmentsLayout from '@/app/commitments/layout'
+import { WalletProvider } from '@/components/auth/WalletProvider'
+
+const pathnameMock = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => pathnameMock(),
+}))
+
+describe('route auth guards', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    delete window.freighterApi
+    pathnameMock.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.body.style.overflow = ''
+  })
+
+  it.each([
+    {
+      name: 'create',
+      pathname: '/create',
+      Layout: CreateLayout,
+      content: 'Create page body',
+    },
+    {
+      name: 'settings',
+      pathname: '/settings',
+      Layout: SettingsLayout,
+      content: 'Settings page body',
+    },
+    {
+      name: 'commitments',
+      pathname: '/commitments',
+      Layout: CommitmentsLayout,
+      content: 'Commitments page body',
+    },
+  ])('shows the wallet prompt for the $name route when disconnected', ({ pathname, Layout, content }) => {
+    pathnameMock.mockReturnValue(pathname)
+
+    render(
+      <WalletProvider>
+        <Layout>
+          <div>{content}</div>
+        </Layout>
+      </WalletProvider>
+    )
+
+    expect(screen.queryByText(content)).toBeNull()
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Connect your wallet to continue' })).toBeTruthy()
+  })
+})

--- a/src/app/commitments/layout.tsx
+++ b/src/app/commitments/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import ProtectedRouteLayout from '@/components/auth/ProtectedRouteLayout'
 
 export const metadata: Metadata = {
   title: 'My Commitments — CommitLabs',
@@ -35,5 +36,5 @@ export default function CommitmentsLayout({
 }: {
   children: React.ReactNode
 }) {
-  return children
+  return <ProtectedRouteLayout>{children}</ProtectedRouteLayout>
 }

--- a/src/app/create/layout.tsx
+++ b/src/app/create/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import ProtectedRouteLayout from '@/components/auth/ProtectedRouteLayout'
 
 export const metadata: Metadata = {
   title: 'Create Commitment — CommitLabs',
@@ -35,5 +36,5 @@ export default function CreateLayout({
 }: {
   children: React.ReactNode
 }) {
-  return children
+  return <ProtectedRouteLayout>{children}</ProtectedRouteLayout>
 }

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import ProtectedRouteLayout from '@/components/auth/ProtectedRouteLayout'
 
 export const metadata: Metadata = {
   title: 'Settings — CommitLabs',
@@ -35,5 +36,5 @@ export default function SettingsLayout({
 }: {
   children: React.ReactNode
 }) {
-  return children
+  return <ProtectedRouteLayout>{children}</ProtectedRouteLayout>
 }


### PR DESCRIPTION
# fix: guard protected routes with wallet auth

## Summary
This PR ensures the documented wallet auth guard is actually mounted for the protected route layouts.

## What changed
- Wrapped the create, settings, and commitments route layouts with the existing protected route/auth guard
- Added regression tests to verify a disconnected visitor sees the wallet connect prompt instead of protected page content for each of those routes

## Why
Previously, the route layouts returned their children directly and never mounted the wallet gate, so disconnected visitors could access these routes without being prompted to connect their wallet.

## Testing
- Added a regression test covering:
  - /create
  - /settings
  - /commitments

Closes: #1583