### PR TITLE
docs: replace leaked local file links and guard docs

### DIFF
--- a/docs/CREATE_WIZARD_TOUR.md
+++ b/docs/CREATE_WIZARD_TOUR.md
@@ -11,11 +11,11 @@ The guided tour is built with a modular, highly testable structure:
    - Fetches and stores the "seen" flag off-chain via the `GET / PUT /api/user/preferences` user-preferences API.
    - Falls back to `localStorage` when no wallet is connected.
    - Triggers step transitions automatically when moving across wizard steps.
-   - Location: [useGuidedTour.ts](file:///home/sudodave/Commitlabs-Frontend/src/hooks/useGuidedTour.ts)
+   - Location: [useGuidedTour.ts](../src/hooks/useGuidedTour.ts)
 
 2. **`GuidedTour` (Container Component)**
    - A declarative wrapper component that receives tour status and configuration, rendering the active step.
-   - Location: [GuidedTour.tsx](file:///home/sudodave/Commitlabs-Frontend/src/components/onboarding/GuidedTour.tsx)
+   - Location: [GuidedTour.tsx](../src/components/onboarding/GuidedTour.tsx)
 
 3. **`TourStep` (UI component)**
    - Tracks target selectors in the DOM and anchors tooltips dynamically (handles window resizes, scrolling, viewport constraints).
@@ -23,7 +23,7 @@ The guided tour is built with a modular, highly testable structure:
    - Focus traps keyboard navigation inside the tooltip (loops focus between controls).
    - Listens to global keyboard keys (`Escape` to skip/dismiss, `ArrowLeft` / `ArrowRight` for back/next navigation).
    - Respects `prefers-reduced-motion` to disable transitions for users with motion sensitivities.
-   - Location: [TourStep.tsx](file:///home/sudodave/Commitlabs-Frontend/src/components/onboarding/TourStep.tsx)
+   - Location: [TourStep.tsx](../src/components/onboarding/TourStep.tsx)
 
 ## Step Flow
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
       "eslint --fix"
+    ],
+    "docs/**/*.{md,mdx}": [
+      "node scripts/check-docs-file-urls.mjs"
     ]
   },
   "dependencies": {

--- a/scripts/check-docs-file-urls.mjs
+++ b/scripts/check-docs-file-urls.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+const args = process.argv.slice(2)
+const defaultDocsRoot = path.resolve(process.cwd(), 'docs')
+
+function isDocsFile(filePath) {
+  return filePath.startsWith('docs/') || filePath.startsWith('./docs/') || filePath.startsWith(defaultDocsRoot)
+}
+
+function collectTargets() {
+  if (args.length > 0) {
+    return args.filter((arg) => isDocsFile(arg))
+  }
+
+  return []
+}
+
+const targets = collectTargets()
+
+if (targets.length === 0) {
+  console.log('No documentation files supplied; skipping file:// URL check.')
+  process.exit(0)
+}
+
+const offenders = []
+
+for (const target of targets) {
+  const resolvedPath = path.isAbsolute(target) ? target : path.resolve(process.cwd(), target)
+
+  if (!existsSync(resolvedPath)) {
+    continue
+  }
+
+  const contents = readFileSync(resolvedPath, 'utf8')
+  if (contents.includes('file:///')) {
+    offenders.push(resolvedPath)
+  }
+}
+
+if (offenders.length > 0) {
+  console.error('Found file:// links in documentation files:')
+  for (const offender of offenders) {
+    console.error(`- ${offender}`)
+  }
+  process.exit(1)
+}
+
+console.log('Documentation file URL check passed.')


### PR DESCRIPTION
# docs: replace leaked local file links and guard docs

## Summary
This PR removes hardcoded local filesystem paths from the guided tour documentation and adds a guard to prevent future file:// links in docs from being committed.

## What changed
- Replaced the three leaked absolute local file URLs in CREATE_WIZARD_TOUR.md with repo-relative markdown links
- Added a lightweight docs guard script that rejects file:// links in documentation files
- Hooked the guard into the existing staged-file workflow so it runs during pre-commit checks

## Why
The documentation previously contained contributor-specific absolute Linux paths, which are broken and expose local filesystem information. This change makes the references portable and adds a repeatable safeguard against recurrence.

Closes: #1584 