### PR TITLE
fix(services): restore contracts.ts and its backend deps deleted by 1…

### DIFF
--- a/1602-restore-backend-contracts.patch
+++ b/1602-restore-backend-contracts.patch
@@ -1,0 +1,3334 @@
+diff --git a/src/lib/backend/auth.ts b/src/lib/backend/auth.ts
+new file mode 100644
+index 00000000..cb3afef8
+--- /dev/null
++++ b/src/lib/backend/auth.ts
+@@ -0,0 +1,289 @@
++import { randomBytes } from "crypto";
++import Stellar from "@stellar/stellar-sdk";
++import { getKV } from "./kv";
++
++export interface NonceRecord {
++  nonce: string;
++  address: string;
++  createdAt: Date;
++  expiresAt: Date;
++}
++
++interface SessionRecord {
++  token: string;
++  address: string;
++  csrfToken: string;
++  createdAt: Date;
++  expiresAt: Date;
++}
++
++export interface SignatureVerificationRequest {
++  address: string;
++  signature: string;
++  message: string;
++}
++
++export interface SignatureVerificationResult {
++  valid: boolean;
++  address?: string;
++  error?: string;
++}
++
++const NONCE_TTL_SECONDS = 5 * 60;
++const SESSION_TTL = 24 * 60 * 60 * 1000;
++
++const sessionStore = new Map<string, SessionRecord>();
++
++export function generateNonce(): string {
++  return randomBytes(16).toString("hex");
++}
++
++export async function storeNonce(
++  address: string,
++  nonce: string,
++): Promise<NonceRecord> {
++  const now = new Date();
++  const expiresAt = new Date(now.getTime() + NONCE_TTL_SECONDS * 1000);
++
++  const record: NonceRecord = {
++    nonce,
++    address,
++    createdAt: now,
++    expiresAt,
++  };
++
++  await getKV().set(`auth:nonce:${nonce}`, record, NONCE_TTL_SECONDS);
++  return record;
++}
++
++export async function getNonceRecord(
++  nonce: string,
++): Promise<NonceRecord | null> {
++  return await getKV().get<NonceRecord>(`auth:nonce:${nonce}`);
++}
++
++export async function consumeNonce(nonce: string): Promise<boolean> {
++  const record = await getKV().getdel<NonceRecord>(`auth:nonce:${nonce}`);
++  return !!record;
++}
++
++function decodeSignature(signature: string): Buffer {
++  const trimmed = signature.trim();
++  if (/^[0-9a-f]+$/i.test(trimmed) && trimmed.length % 2 === 0) {
++    return Buffer.from(trimmed, "hex");
++  }
++  return Buffer.from(trimmed, "base64");
++}
++
++export function verifyStellarSignature(
++  address: string,
++  signature: string,
++  message: string,
++): SignatureVerificationResult {
++  try {
++    if (!address || !signature || !message) {
++      return { valid: false, error: "Missing required fields" };
++    }
++
++    const isValidAddress =
++      typeof Stellar.StrKey?.isValidEd25519PublicKey === "function" &&
++      Stellar.StrKey.isValidEd25519PublicKey(address);
++
++    if (!isValidAddress) {
++      return { valid: false, error: "Invalid Stellar address" };
++    }
++
++    const keypair = Stellar.Keypair.fromPublicKey(address);
++    const verified = keypair.verify(
++      Buffer.from(message, "utf8"),
++      decodeSignature(signature),
++    );
++
++    return verified
++      ? { valid: true, address }
++      : { valid: false, error: "Invalid signature" };
++  } catch (error) {
++    return {
++      valid: false,
++      error: error instanceof Error ? error.message : "Unknown verification error",
++    };
++  }
++}
++
++export async function verifySignatureWithNonce(
++  request: SignatureVerificationRequest,
++): Promise<SignatureVerificationResult> {
++  try {
++    const { address, signature, message } = request;
++    let nonce: string;
++
++    if (message.startsWith("[CommitLabs Auth V2]")) {
++      const domainMatch = message.match(/Domain: ([^\n]+)/);
++      const nonceMatch = message.match(/Nonce: ([a-f0-9]+)/);
++      const expiresMatch = message.match(/ExpiresAt: ([^\n]+)/);
++
++      if (!domainMatch || !nonceMatch || !expiresMatch) {
++        return { valid: false, error: "Invalid V2 message format" };
++      }
++
++      if (domainMatch[1].trim() !== "commitlabs.org") {
++        return { valid: false, error: "Domain mismatch" };
++      }
++
++      if (new Date() > new Date(expiresMatch[1].trim())) {
++        return { valid: false, error: "Challenge message expired" };
++      }
++
++      nonce = nonceMatch[1];
++    } else {
++      const nonceMatch = message.match(/Sign in to CommitLabs:\s*([a-f0-9]+)/i);
++      if (!nonceMatch) {
++        return { valid: false, error: "Invalid message format" };
++      }
++      nonce = nonceMatch[1];
++    }
++
++    const nonceRecord = await getNonceRecord(nonce);
++    if (!nonceRecord) {
++      return { valid: false, error: "Invalid or expired nonce" };
++    }
++
++    if (nonceRecord.address !== address) {
++      return { valid: false, error: "Nonce address mismatch" };
++    }
++
++    const verificationResult = verifyStellarSignature(address, signature, message);
++    if (!verificationResult.valid) {
++      return verificationResult;
++    }
++
++    const consumed = await consumeNonce(nonce);
++    if (!consumed) {
++      return {
++        valid: false,
++        error: "Nonce already consumed or expired during verification",
++      };
++    }
++
++    return {
++      valid: true,
++      address,
++    };
++  } catch (error) {
++    return {
++      valid: false,
++      error: error instanceof Error ? error.message : "Unknown verification error",
++    };
++  }
++}
++
++export function generateChallengeMessage(
++  nonce: string,
++  domain = "commitlabs.org",
++): string {
++  const issuedAt = new Date().toISOString();
++  const expiresAt = new Date(Date.now() + NONCE_TTL_SECONDS * 1000).toISOString();
++  return `[CommitLabs Auth V2]\nDomain: ${domain}\nNonce: ${nonce}\nIssuedAt: ${issuedAt}\nExpiresAt: ${expiresAt}`;
++}
++
++export function createSessionToken(address: string): string {
++  const token = `session_${randomBytes(16).toString("hex")}`;
++  const csrfToken = randomBytes(16).toString("hex");
++  const now = new Date();
++  const expiresAt = new Date(now.getTime() + SESSION_TTL);
++
++  sessionStore.set(token, {
++    token,
++    address,
++    csrfToken,
++    createdAt: now,
++    expiresAt,
++  });
++
++  return token;
++}
++
++export function verifySessionToken(token: string): {
++  valid: boolean;
++  address?: string;
++  csrfToken?: string;
++  error?: string;
++} {
++  const record = sessionStore.get(token);
++
++  if (!record) {
++    return { valid: false, error: "Session not found" };
++  }
++
++  if (record.expiresAt < new Date()) {
++    sessionStore.delete(token);
++    return { valid: false, error: "Session expired" };
++  }
++
++  return {
++    valid: true,
++    address: record.address,
++    csrfToken: record.csrfToken,
++  };
++}
++
++export function revokeSession(token: string): boolean {
++  return sessionStore.delete(token);
++}
++
++export interface PublicSessionInfo {
++  id: string;
++  address: string;
++  createdAt: string;
++  expiresAt: string;
++}
++
++/**
++ * Return all non-expired sessions for a given address, excluding the current token.
++ */
++export function listOtherSessions(
++  currentToken: string,
++): PublicSessionInfo[] {
++  const now = new Date();
++  const current = sessionStore.get(currentToken);
++  if (!current) return [];
++
++  const result: PublicSessionInfo[] = [];
++  for (const [token, record] of sessionStore.entries()) {
++    if (token === currentToken) continue;
++    if (record.address !== current.address) continue;
++    if (record.expiresAt < now) {
++      sessionStore.delete(token);
++      continue;
++    }
++    result.push({
++      id: token,
++      address: record.address,
++      createdAt: record.createdAt.toISOString(),
++      expiresAt: record.expiresAt.toISOString(),
++    });
++  }
++  return result;
++}
++
++/**
++ * Revoke all sessions for the same address except the current token.
++ * Returns the number of sessions revoked.
++ */
++export function revokeOtherSessions(currentToken: string): number {
++  const current = sessionStore.get(currentToken);
++  if (!current) return 0;
++
++  let count = 0;
++  for (const [token, record] of sessionStore.entries()) {
++    if (token === currentToken) continue;
++    if (record.address !== current.address) continue;
++    sessionStore.delete(token);
++    count++;
++  }
++  return count;
++}
++
++export function _clearStores(): void {
++  sessionStore.clear();
++}
+diff --git a/src/lib/backend/cache/factory.ts b/src/lib/backend/cache/factory.ts
+new file mode 100644
+index 00000000..bb6f8097
+--- /dev/null
++++ b/src/lib/backend/cache/factory.ts
+@@ -0,0 +1,31 @@
++import type { CacheAdapter } from './index';
++import { MemoryAdapter } from './memory';
++import { RedisAdapter } from './redis';
++
++function createAdapter(): CacheAdapter {
++  const forced = process.env.CACHE_ADAPTER;
++  const redisUrl = process.env.REDIS_URL;
++
++  const useRedis =
++    forced === 'redis' ||
++    (forced !== 'memory' &&
++      process.env.NODE_ENV === 'production' &&
++      !!redisUrl);
++
++  if (useRedis) {
++    if (!redisUrl) {
++      throw new Error(
++        'REDIS_URL must be set when CACHE_ADAPTER=redis or in production with Redis enabled.',
++      );
++    }
++    return new RedisAdapter(redisUrl);
++  }
++
++  return new MemoryAdapter();
++}
++
++/**
++ * Module-level singleton. Created once at startup.
++ * In tests, replace via: vi.mock('@/lib/backend/cache/factory', () => ({ cache: mockCache }))
++ */
++export const cache: CacheAdapter = createAdapter();
+diff --git a/src/lib/backend/cache/index.ts b/src/lib/backend/cache/index.ts
+new file mode 100644
+index 00000000..568d277b
+--- /dev/null
++++ b/src/lib/backend/cache/index.ts
+@@ -0,0 +1,46 @@
++/*
++ * Cache adapter module for Commitlabs backend.
++ *
++ * Two adapters ship with this module:
++ *   - MemoryAdapter  default for NODE_ENV=test|development. Zero dependencies,
++ *                    TTL enforced on read, safe to use across test runs.
++ *   - RedisAdapter   used when NODE_ENV=production and REDIS_URL is set (or when
++ *                    CACHE_ADAPTER=redis is explicitly set). Requires ioredis:
++ *                    `npm install ioredis`
++ *
++ * The active adapter is selected in factory.ts at module load time. To override
++ * the default selection set CACHE_ADAPTER=redis|memory in your environment.
++ *
++ * All keys are namespaced under "commitlabs:" to avoid collisions with other
++ * tenants sharing the same Redis instance.
++ */
++
++export interface CacheAdapter {
++  get<T>(key: string): Promise<T | null>;
++  set<T>(key: string, value: T, ttlSeconds: number): Promise<void>;
++  delete(key: string): Promise<void>;
++  /** Remove every key whose name starts with `prefix`. */
++  invalidate(prefix: string): Promise<void>;
++}
++
++export const CacheKey = {
++  commitment: (id: string) => `commitlabs:commitment:${id}`,
++  userCommitments: (ownerAddress: string) =>
++    `commitlabs:user-commitments:${ownerAddress}`,
++  marketplaceListings: (queryHash: string) =>
++    `commitlabs:marketplace:listings:${queryHash}`,
++  marketplaceStats: () => "commitlabs:marketplace:stats",
++  commitmentSearch: (queryHash: string) =>
++    `commitlabs:commitment-search:${queryHash}`,
++  marketplaceStats: () => "commitlabs:marketplace:stats",
++} as const;
++
++/** TTL in seconds — keep short so stale chain data doesn't linger. */
++export const CacheTTL = {
++  COMMITMENT_DETAIL: 30,
++  USER_COMMITMENTS: 20,
++  MARKETPLACE_LISTINGS: 15,
++  MARKETPLACE_STATS: 30,
++  /** Short TTL for search results — keeps filters responsive while avoiding stale data. */
++  COMMITMENT_SEARCH: 15,
++} as const;
+diff --git a/src/lib/backend/cache/memory.ts b/src/lib/backend/cache/memory.ts
+new file mode 100644
+index 00000000..ab4fb418
+--- /dev/null
++++ b/src/lib/backend/cache/memory.ts
+@@ -0,0 +1,43 @@
++import type { CacheAdapter } from './index';
++
++interface Entry<T> {
++  value: T;
++  expiresAt: number;
++}
++
++export class MemoryAdapter implements CacheAdapter {
++  private readonly store = new Map<string, Entry<unknown>>();
++
++  async get<T>(key: string): Promise<T | null> {
++    const entry = this.store.get(key);
++    if (!entry) return null;
++    if (Date.now() > entry.expiresAt) {
++      this.store.delete(key);
++      return null;
++    }
++    return entry.value as T;
++  }
++
++  async set<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
++    this.store.set(key, { value, expiresAt: Date.now() + ttlSeconds * 1_000 });
++  }
++
++  async delete(key: string): Promise<void> {
++    this.store.delete(key);
++  }
++
++  async invalidate(prefix: string): Promise<void> {
++    for (const key of this.store.keys()) {
++      if (key.startsWith(prefix)) this.store.delete(key);
++    }
++  }
++
++  /** Wipes all entries — useful in test beforeEach hooks. */
++  clear(): void {
++    this.store.clear();
++  }
++
++  size(): number {
++    return this.store.size;
++  }
++}
+diff --git a/src/lib/backend/cache/redis.ts b/src/lib/backend/cache/redis.ts
+new file mode 100644
+index 00000000..00e56e52
+--- /dev/null
++++ b/src/lib/backend/cache/redis.ts
+@@ -0,0 +1,104 @@
++import type { CacheAdapter } from './index';
++import { logError } from '@/lib/backend/logger';
++
++/*
++ * RedisAdapter wraps ioredis. Install it before enabling this adapter:
++ *   npm install ioredis
++ *
++ * The client is created lazily so the module loads cleanly even when ioredis
++ * is absent — the error only surfaces at runtime when production traffic
++ * actually tries to use this adapter.
++ *
++ * REDIS_URL may include credentials:
++ *   redis://:password@host:6379/0
++ *   rediss://:password@host:6379/0   (TLS)
++ * ioredis parses the URL and sets up authentication automatically.
++ */
++
++// Declared here for type inference without importing ioredis at module load.
++type IoRedis = {
++  get(key: string): Promise<string | null>;
++  set(key: string, value: string, ex: 'EX', seconds: number): Promise<unknown>;
++  del(...keys: string[]): Promise<unknown>;
++  scan(
++    cursor: string,
++    matchArg: 'MATCH',
++    pattern: string,
++    countArg: 'COUNT',
++    count: number,
++  ): Promise<[string, string[]]>;
++  quit(): Promise<unknown>;
++};
++
++export class RedisAdapter implements CacheAdapter {
++  private client: IoRedis | null = null;
++
++  constructor(private readonly redisUrl: string) {}
++
++  private getClient(): IoRedis {
++    if (!this.client) {
++      // eslint-disable-next-line @typescript-eslint/no-require-imports
++      const Redis = require('ioredis');
++      this.client = new Redis(this.redisUrl, {
++        lazyConnect: true,
++        enableReadyCheck: false,
++        maxRetriesPerRequest: 2,
++      }) as IoRedis;
++    }
++    return this.client;
++  }
++
++  async get<T>(key: string): Promise<T | null> {
++    try {
++      const raw = await this.getClient().get(key);
++      if (raw === null) return null;
++      return JSON.parse(raw) as T;
++    } catch (err) {
++      logError(undefined, '[RedisAdapter] get failed', err as Error, { key });
++      return null; // fail open — fall through to chain read
++    }
++  }
++
++  async set<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
++    try {
++      await this.getClient().set(key, JSON.stringify(value), 'EX', ttlSeconds);
++    } catch (err) {
++      logError(undefined, '[RedisAdapter] set failed', err as Error, { key });
++    }
++  }
++
++  async delete(key: string): Promise<void> {
++    try {
++      await this.getClient().del(key);
++    } catch (err) {
++      logError(undefined, '[RedisAdapter] delete failed', err as Error, { key });
++    }
++  }
++
++  async invalidate(prefix: string): Promise<void> {
++    try {
++      const client = this.getClient();
++      let cursor = '0';
++      do {
++        const [next, keys] = await client.scan(
++          cursor,
++          'MATCH',
++          `${prefix}*`,
++          'COUNT',
++          100,
++        );
++        cursor = next;
++        if (keys.length > 0) await client.del(...keys);
++      } while (cursor !== '0');
++    } catch (err) {
++      logError(undefined, '[RedisAdapter] invalidate failed', err as Error, {
++        prefix,
++      });
++    }
++  }
++
++  async disconnect(): Promise<void> {
++    await this.client?.quit();
++    this.client = null;
++  }
++}
+diff --git a/src/lib/backend/counters/adapters.ts b/src/lib/backend/counters/adapters.ts
+new file mode 100644
+index 00000000..e7263a24
+--- /dev/null
++++ b/src/lib/backend/counters/adapters.ts
+@@ -0,0 +1,14 @@
++export interface CountersAdapter {
++  incrementRateLimitBlocks(): void;
++  incrementAuthFailures(): void;
++  incrementChainFailures(): void;
++  incrementSuccessfulActions(): void;
++  getMetrics(): Promise<{
++    rate_limit_blocks: number;
++    auth_failures: number;
++    chain_failures: number;
++    successful_actions: number;
++    timestamp: string;
++  }>;
++  reset(): void; // For testing purposes
++}
+\ No newline at end of file
+diff --git a/src/lib/backend/counters/inMemory.ts b/src/lib/backend/counters/inMemory.ts
+new file mode 100644
+index 00000000..fc15c07f
+--- /dev/null
++++ b/src/lib/backend/counters/inMemory.ts
+@@ -0,0 +1,47 @@
++import { CountersAdapter } from './adapters';
++
++export class InMemoryCounters implements CountersAdapter {
++  private rateLimitBlocks = 0;
++  private authFailures = 0;
++  private chainFailures = 0;
++  private successfulActions = 0;
++
++  incrementRateLimitBlocks(): void {
++    this.rateLimitBlocks++;
++  }
++
++  incrementAuthFailures(): void {
++    this.authFailures++;
++  }
++
++  incrementChainFailures(): void {
++    this.chainFailures++;
++  }
++
++  incrementSuccessfulActions(): void {
++    this.successfulActions++;
++  }
++
++  async getMetrics(): Promise<{
++    rate_limit_blocks: number;
++    auth_failures: number;
++    chain_failures: number;
++    successful_actions: number;
++    timestamp: string;
++  }> {
++    return {
++      rate_limit_blocks: this.rateLimitBlocks,
++      auth_failures: this.authFailures,
++      chain_failures: this.chainFailures,
++      successful_actions: this.successfulActions,
++      timestamp: new Date().toISOString(),
++    };
++  }
++
++  reset(): void {
++    this.rateLimitBlocks = 0;
++    this.authFailures = 0;
++    this.chainFailures = 0;
++    this.successfulActions = 0;
++  }
++}
+\ No newline at end of file
+diff --git a/src/lib/backend/counters/persistent.ts b/src/lib/backend/counters/persistent.ts
+new file mode 100644
+index 00000000..debfe671
+--- /dev/null
++++ b/src/lib/backend/counters/persistent.ts
+@@ -0,0 +1,77 @@
++import { CountersAdapter } from './adapters';
++
++// We'll use ioredis as the Redis client. In a real setup, you would install ioredis.
++// For the purpose of this task, we assume it's available or we mock it in tests.
++import Redis from 'ioredis';
++
++export class PersistentCounters implements CountersAdapter {
++  private redis: Redis;
++  private readonly keyPrefix = 'commitlabs:metrics:';
++
++  constructor(redisUrl: string = process.env.REDIS_URL || 'redis://localhost:6379') {
++    this.redis = new Redis(redisUrl);
++  }
++
++  private async getKey(name: string): Promise<string> {
++    return `${this.keyPrefix}${name}`;
++  }
++
++  async incrementRateLimitBlocks(): void {
++    const key = await this.getKey('rate_limit_blocks');
++    await this.redis.incr(key);
++  }
++
++  async incrementAuthFailures(): void {
++    const key = await this.getKey('auth_failures');
++    await this.redis.incr(key);
++  }
++
++  async incrementChainFailures(): void {
++    const key = await this.getKey('chain_failures');
++    await this.redis.incr(key);
++  }
++
++  async incrementSuccessfulActions(): void {
++    const key = await this.getKey('successful_actions');
++    await this.redis.incr(key);
++  }
++
++  async getMetrics(): Promise<{
++    rate_limit_blocks: number;
++    auth_failures: number;
++    chain_failures: number;
++    successful_actions: number;
++    timestamp: string;
++  }> {
++    const [rateLimitBlocks, authFailures, chainFailures, successfulActions] = await this.redis.mget(
++      await this.getKey('rate_limit_blocks'),
++      await this.getKey('auth_failures'),
++      await this.getKey('chain_failures'),
++      await this.getKey('successful_actions')
++    );
++
++    return {
++      rate_limit_blocks: parseInt(rateLimitBlocks || '0', 10),
++      auth_failures: parseInt(authFailures || '0', 10),
++      chain_failures: parseInt(chainFailures || '0', 10),
++      successful_actions: parseInt(successfulActions || '0', 10),
++      timestamp: new Date().toISOString(),
++    };
++  }
++
++  async reset(): void {
++    // Only for testing: delete the keys
++    const keys = [
++      await this.getKey('rate_limit_blocks'),
++      await this.getKey('auth_failures'),
++      await this.getKey('chain_failures'),
++      await this.getKey('successful_actions'),
++    ];
++    await this.redis.del(...keys);
++  }
++
++  // Close the Redis connection when the application shuts down (if needed)
++  async close(): Promise<void> {
++    await this.redis.quit();
++  }
++}
+\ No newline at end of file
+diff --git a/src/lib/backend/counters/provider.ts b/src/lib/backend/counters/provider.ts
+new file mode 100644
+index 00000000..dd15ef34
+--- /dev/null
++++ b/src/lib/backend/counters/provider.ts
+@@ -0,0 +1,45 @@
++import { CountersAdapter } from './adapters';
++import { InMemoryCounters } from './inMemory';
++import { PersistentCounters } from './persistent';
++
++let countersInstance: CountersAdapter | null = null;
++
++/**
++ * Get the counters adapter instance based on the environment.
++ * In development/test, use in-memory counters.
++ * In production, use persistent counters (Redis).
++ */
++export function getCountersAdapter(): CountersAdapter {
++  if (countersInstance) {
++    return countersInstance;
++  }
++
++  const nodeEnv = process.env.NODE_ENV || 'development';
++  
++  // In development and test environments, use in-memory counters
++  if (nodeEnv === 'development' || nodeEnv === 'test') {
++    countersInstance = new InMemoryCounters();
++  } else {
++    // In production, use persistent counters (Redis)
++    countersInstance = new PersistentCounters();
++  }
++  
++  return countersInstance;
++}
++
++/**
++ * Set the counters instance directly (useful for testing with mocks)
++ */
++export function setCountersAdapter(instance: CountersAdapter): void {
++  countersInstance = instance;
++}
++
++/**
++ * Reset the counters instance (mainly for testing)
++ */
++export function resetCountersAdapter(): void {
++  if (countersInstance) {
++    countersInstance.reset();
++  }
++  countersInstance = null;
++}
+\ No newline at end of file
+diff --git a/src/lib/backend/csv.ts b/src/lib/backend/csv.ts
+new file mode 100644
+index 00000000..a375fdc3
+--- /dev/null
++++ b/src/lib/backend/csv.ts
+@@ -0,0 +1,63 @@
++const FORMULA_PREFIX_PATTERN = /^[=+\-@]/;
++
++export type CsvRow = Array<string | null | undefined>;
++
++export function escapeCsvField(value: string | null | undefined): string {
++  const normalizedValue = value == null ? '' : String(value);
++  const safeValue = FORMULA_PREFIX_PATTERN.test(normalizedValue)
++    ? `'${normalizedValue}`
++    : normalizedValue;
++  const escapedValue = safeValue.replace(/"/g, '""');
++  const shouldWrap =
++    escapedValue.includes(',') ||
++    escapedValue.includes('"') ||
++    escapedValue.includes('\n') ||
++    /^[\s]|[\s]$/.test(escapedValue);
++
++  return shouldWrap ? `"${escapedValue}"` : escapedValue;
++}
++
++/**
++ * Formats a single CSV row and terminates it with CRLF.
++ * Shared by `buildCsv` and `createCsvStream` so the injection guard
++ * (see `escapeCsvField`) is applied identically in both code paths.
++ */
++export function formatCsvRow(row: CsvRow): string {
++  return `${row.map(escapeCsvField).join(',')}\r\n`;
++}
++
++export function buildCsv(headers: string[], rows: CsvRow[]): string {
++  return [headers, ...rows].map(formatCsvRow).join('');
++}
++
++/**
++ * Returns a ReadableStream that emits the CSV header row first, then one
++ * chunk per data row. Accepts a sync or async iterable so callers can pass
++ * an in-memory array today or a paginated/streamed source in the future
++ * without changing this helper.
++ *
++ * Errors thrown by the iterable are forwarded to `controller.error`, which
++ * aborts the response. The client will see a truncated download; the caller
++ * is responsible for ensuring upstream errors are surfaced before streaming
++ * starts when possible.
++ */
++export function createCsvStream(
++  headers: string[],
++  rows: Iterable<CsvRow> | AsyncIterable<CsvRow>,
++): ReadableStream<Uint8Array> {
++  const encoder = new TextEncoder();
++
++  return new ReadableStream<Uint8Array>({
++    async start(controller) {
++      try {
++        controller.enqueue(encoder.encode(formatCsvRow(headers)));
++        for await (const row of rows as AsyncIterable<CsvRow>) {
++          controller.enqueue(encoder.encode(formatCsvRow(row)));
++        }
++        controller.close();
++      } catch (err) {
++        controller.error(err);
++      }
++    },
++  });
++}
+\ No newline at end of file
+diff --git a/src/lib/backend/errorCodes.ts b/src/lib/backend/errorCodes.ts
+new file mode 100644
+index 00000000..7f8ac5d3
+--- /dev/null
++++ b/src/lib/backend/errorCodes.ts
+@@ -0,0 +1,317 @@
++/**
++ * Centralized registry of backend error codes.
++ *
++ * This registry serves as the single source of truth for all error codes used
++ * across the backend API. Each error code is documented with:
++ * - HTTP status code
++ * - Semantic meaning
++ * - Recommended client handling strategy
++ * - Retriable status and retry guidance
++ *
++ * @see docs/backend-error-codes.md for detailed documentation
++ */
++
++export interface ErrorCodeDefinition {
++  /** Error code identifier used in API responses. */
++  code: string;
++  /** HTTP status code. */
++  statusCode: number;
++  /** Human-readable meaning of the error. */
++  meaning: string;
++  /** Recommended client handling strategy. */
++  clientHandling: string;
++  /** Whether the error is retriable with exponential backoff. */
++  retriable: boolean;
++  /** Description of what triggers this error. */
++  description: string;
++}
++
++/**
++ * Complete registry of backend error codes.
++ * Organized by HTTP status code for easy lookup.
++ */
++export const ERROR_CODE_REGISTRY: Record<string, ErrorCodeDefinition> = {
++  // ─── 400 Bad Request ──────────────────────────────────────────────────────
++  BAD_REQUEST: {
++    code: "BAD_REQUEST",
++    statusCode: 400,
++    meaning: "The request was malformed or contains invalid syntax.",
++    clientHandling:
++      "Display a generic error message to the user. Check request headers, content-type, and method. Do not retry.",
++    retriable: false,
++    description:
++      "Triggered when the HTTP request is malformed, has invalid headers, or violates the API protocol.",
++  },
++
++  NOT_MATURED: {
++    code: "NOT_MATURED",
++    statusCode: 400,
++    meaning: "Commitment has not matured yet and cannot be settled.",
++    clientHandling:
++      "Check the maturity date of the commitment before attempting to settle. Do not retry until maturity.",
++    retriable: false,
++    description:
++      "Triggered when a user or caller attempts to settle a commitment that has not reached its expiration time, or lacks expiry information.",
++  },
++
++  // ─── 400 Validation Error ─────────────────────────────────────────────────
++  VALIDATION_ERROR: {
++    code: "VALIDATION_ERROR",
++    statusCode: 400,
++    meaning: "Request body or query parameters failed validation.",
++    clientHandling:
++      "Display specific validation error details to the user (from error.details). Highlight invalid fields in forms. Do not retry.",
++    retriable: false,
++    description:
++      "Triggered when request data fails schema validation, type checking, or business rule validation.",
++  },
++
++  // ─── 401 Unauthorized ─────────────────────────────────────────────────────
++  UNAUTHORIZED: {
++    code: "UNAUTHORIZED",
++    statusCode: 401,
++    meaning: "Authentication credentials are missing, invalid, or expired.",
++    clientHandling:
++      "Redirect user to login page. Attempt token refresh if refresh token is available. Clear stored credentials.",
++    retriable: true,
++    description:
++      "Triggered when the request lacks valid authentication (missing token, invalid signature, or expired session).",
++  },
++
++  // ─── 403 Forbidden ────────────────────────────────────────────────────────
++  FORBIDDEN: {
++    code: "FORBIDDEN",
++    statusCode: 403,
++    meaning: "Authenticated but lacks permission to perform the action.",
++    clientHandling:
++      "Display permission denied message. Do not retry. Log the attempt for audit purposes. Suggest alternatives if available.",
++    retriable: false,
++    description:
++      "Triggered when the authenticated user does not have the required role, scope, or permission for the requested action.",
++  },
++
++  // ─── 404 Not Found ────────────────────────────────────────────────────────
++  NOT_FOUND: {
++    code: "NOT_FOUND",
++    statusCode: 404,
++    meaning: "The requested resource does not exist.",
++    clientHandling:
++      'Display "not found" message. Offer user navigation options or search functionality. Do not retry.',
++    retriable: false,
++    description:
++      "Triggered when a resource lookup returns no result (e.g., commitment ID, user, marketplace item not found).",
++  },
++
++  // ─── 409 Conflict ─────────────────────────────────────────────────────────
++  CONFLICT: {
++    code: "CONFLICT",
++    statusCode: 409,
++    meaning: "Request conflicts with current resource state.",
++    clientHandling:
++      "Display conflict message with details. Prompt user to refresh data and retry, or take alternative action. Fetch latest state before retrying.",
++    retriable: true,
++    description:
++      "Triggered when an action violates state constraints (e.g., resource already exists, already settled, or locked by another user).",
++  },
++
++  // ─── 422 Unprocessable Entity ─────────────────────────────────────────────
++  UNPROCESSABLE_ENTITY: {
++    code: "UNPROCESSABLE_ENTITY",
++    statusCode: 422,
++    meaning: "Request is syntactically valid but semantically unprocessable.",
++    clientHandling:
++      "Display semantic error details to user. Check business logic constraints (e.g., invalid amount ranges, allocation rules). Do not retry with same data.",
++    retriable: false,
++    description:
++      "Triggered when request passes basic validation but violates complex business rules or constraints.",
++  },
++
++  // ─── 429 Too Many Requests ───────────────────────────────────────────────
++  TOO_MANY_REQUESTS: {
++    code: "TOO_MANY_REQUESTS",
++    statusCode: 429,
++    meaning: "Client has exceeded the rate limit.",
++    clientHandling:
++      "Implement exponential backoff with jitter. Respect Retry-After header. Display rate limit warning to user. Defer non-critical requests.",
++    retriable: true,
++    description:
++      "Triggered when a client exceeds configured rate limits (per user, IP, or endpoint). Response includes Retry-After header.",
++  },
++
++  // ─── 500 Internal Server Error ────────────────────────────────────────────
++  INTERNAL_ERROR: {
++    code: "INTERNAL_ERROR",
++    statusCode: 500,
++    meaning: "Unexpected server-side failure.",
++    clientHandling:
++      "Display generic error message. Implement exponential backoff. Log error for debugging. Offer user to retry or contact support.",
++    retriable: true,
++    description:
++      "Triggered when the server encounters an unhandled exception or unexpected failure during request processing.",
++  },
++
++  // ─── 502 Bad Gateway ──────────────────────────────────────────────────────
++  BAD_GATEWAY: {
++    code: "BAD_GATEWAY",
++    statusCode: 502,
++    meaning: "Invalid response from upstream server or service.",
++    clientHandling:
++      "Display service unavailable message. Implement exponential backoff. Retry the request after a delay.",
++    retriable: true,
++    description:
++      "Triggered when the API server receives an invalid response from an upstream service (e.g., blockchain node, database).",
++  },
++
++  // ─── 503 Service Unavailable ──────────────────────────────────────────────
++  SERVICE_UNAVAILABLE: {
++    code: "SERVICE_UNAVAILABLE",
++    statusCode: 503,
++    meaning:
++      "Service is temporarily unavailable (maintenance, overload, or degradation).",
++    clientHandling:
++      "Display maintenance or temporarily unavailable message. Implement exponential backoff. Respect Retry-After header.",
++    retriable: true,
++    description:
++      "Triggered when the server is under heavy load, undergoing maintenance, or experiencing degraded service.",
++  },
++
++  // ─── 504 Gateway Timeout ──────────────────────────────────────────────────
++  GATEWAY_TIMEOUT: {
++    code: "GATEWAY_TIMEOUT",
++    statusCode: 504,
++    meaning: "Upstream service or gateway did not respond in time.",
++    clientHandling:
++      "Display timeout message. Implement exponential backoff. Retry the request with longer timeout or circuit breaker.",
++    retriable: true,
++    description:
++      "Triggered when an upstream service (e.g., blockchain, external API) does not respond within the configured timeout.",
++  },
++
++  // ─── Domain-Specific Codes ────────────────────────────────────────────────
++  BLOCKCHAIN_UNAVAILABLE: {
++    code: "BLOCKCHAIN_UNAVAILABLE",
++    statusCode: 503,
++    meaning: "Blockchain service is temporarily unavailable.",
++    clientHandling:
++      "Display message that blockchain is temporarily unreachable. Implement exponential backoff. Retry after a delay.",
++    retriable: true,
++    description:
++      "Triggered when the backend cannot connect to or communicate with the blockchain network or RPC provider.",
++  },
++
++  BLOCKCHAIN_CALL_FAILED: {
++    code: "BLOCKCHAIN_CALL_FAILED",
++    statusCode: 500,
++    meaning: "Blockchain operation failed (e.g., revert, invalid transaction).",
++    clientHandling:
++      "Display detailed error message from blockchain. Offer user to review transaction details or contact support.",
++    retriable: false,
++    description:
++      "Triggered when a blockchain transaction reverts, execution fails, or returns invalid state. Usually not retriable.",
++  },
++};
++
++/**
++ * Type-safe error code selector.
++ * Use this instead of string literals to ensure only registered codes are used.
++ */
++export type RegisteredErrorCode = keyof typeof ERROR_CODE_REGISTRY;
++
++/**
++ * Get error code definition by code string.
++ * Throws if code is not registered.
++ */
++export function getErrorCodeDefinition(code: string): ErrorCodeDefinition {
++  const definition = ERROR_CODE_REGISTRY[code];
++  if (!definition) {
++    throw new Error(
++      `Unregistered error code: ${code}. All error codes must be defined in ERROR_CODE_REGISTRY.`,
++    );
++  }
++  return definition;
++}
++
++/**
++ * Get all error codes grouped by HTTP status code.
++ */
++export function getErrorCodesByStatus(): Record<number, ErrorCodeDefinition[]> {
++  const grouped: Record<number, ErrorCodeDefinition[]> = {};
++  Object.values(ERROR_CODE_REGISTRY).forEach((definition) => {
++    const status = definition.statusCode;
++    if (!grouped[status]) {
++      grouped[status] = [];
++    }
++    grouped[status].push(definition);
++  });
++  return grouped;
++}
++
++/**
++ * Validate that all error codes in the registry are unique (no duplicates).
++ * Duplicate detection checks the `.code` field on each definition value, not
++ * the object key. JavaScript object literals silently discard duplicate keys,
++ * so key-counting can never find a collision; two distinct keys that both carry
++ * the same `.code` string represent a real, detectable duplicate.
++ * Call this in tests to enforce registry integrity.
++ */
++export function validateErrorCodeRegistry(): {
++  valid: boolean;
++  duplicates: string[];
++  errors: string[];
++} {
++  const definitions = Object.values(ERROR_CODE_REGISTRY);
++  const codeValues = definitions.map((def) => def.code);
++  const seen = new Set<string>();
++  const duplicateSet = new Set<string>();
++  for (const codeValue of codeValues) {
++    if (seen.has(codeValue)) {
++      duplicateSet.add(codeValue);
++    } else {
++      seen.add(codeValue);
++    }
++  }
++  const duplicates = [...duplicateSet];
++
++  const errors: string[] = [];
++
++  // Check for duplicate codes
++  if (duplicates.length > 0) {
++    errors.push(
++      `Duplicate error codes found: ${[...new Set(duplicates)].join(", ")}`,
++    );
++  }
++
++  // Check for empty code strings
++  Object.values(ERROR_CODE_REGISTRY).forEach((def) => {
++    if (!def.code || def.code.trim() === "") {
++      errors.push(`Empty error code found`);
++    }
++  });
++
++  // Check for required fields in each definition
++  Object.entries(ERROR_CODE_REGISTRY).forEach(([key, def]) => {
++    if (!def.code) errors.push(`Missing 'code' field in ${key}`);
++    if (!def.meaning) errors.push(`Missing 'meaning' field in ${key}`);
++    if (!def.clientHandling)
++      errors.push(`Missing 'clientHandling' field in ${key}`);
++    if (def.description === undefined || def.description === null) {
++      errors.push(`Missing 'description' field in ${key}`);
++    }
++    if (typeof def.retriable !== "boolean") {
++      errors.push(`Invalid 'retriable' field in ${key}`);
++    }
++    if (
++      typeof def.statusCode !== "number" ||
++      def.statusCode < 400 ||
++      def.statusCode >= 600
++    ) {
++      errors.push(`Invalid 'statusCode' in ${key}`);
++    }
++  });
++
++  return {
++    valid: errors.length === 0,
++    duplicates,
++    errors,
++  };
++}
+diff --git a/src/lib/backend/errors.ts b/src/lib/backend/errors.ts
+new file mode 100644
+index 00000000..861c22f3
+--- /dev/null
++++ b/src/lib/backend/errors.ts
+@@ -0,0 +1,372 @@
++/**
++ * Error handling module.
++ *
++ * Defines typed error classes that correspond to HTTP status codes.
++ * Each error class maps to a definition in the centralized error code registry.
++ *
++ * @see errorCodes.ts for the centralized error code registry and documentation
++ */
++
++import { ERROR_CODE_REGISTRY } from "./errorCodes";
++
++// ─── Base API error ───────────────────────────────────────────────────────────
++
++export class ApiError extends Error {
++  constructor(
++    public readonly message: string,
++    public readonly code: string,
++    public readonly statusCode: number,
++    public readonly details?: unknown,
++    public readonly retryAfterSeconds?: number,
++  ) {
++    super(message);
++    this.name = "ApiError";
++  }
++}
++
++// ─── Named subclasses ─────────────────────────────────────────────────────────
++
++/** 400 — malformed or invalid request input. */
++export class BadRequestError extends ApiError {
++  constructor(message = "Bad request.", details?: unknown) {
++    super(message, "BAD_REQUEST", 400, details);
++    this.name = "BadRequestError";
++  }
++}
++
++/** 400 — request body / query params failed validation. */
++export class ValidationError extends ApiError {
++  constructor(message = "Invalid request data.", details?: unknown) {
++    super(message, "VALIDATION_ERROR", 400, details);
++    this.name = "ValidationError";
++  }
++}
++
++/** 401 — missing or invalid authentication credentials. */
++export class UnauthorizedError extends ApiError {
++  constructor(message = "Authentication required.", details?: unknown) {
++    super(message, "UNAUTHORIZED", 401, details);
++    this.name = "UnauthorizedError";
++  }
++}
++
++/** 403 — authenticated but not permitted to perform the action. */
++export class ForbiddenError extends ApiError {
++  constructor(
++    message = "You do not have permission to perform this action.",
++    details?: unknown,
++  ) {
++    super(message, "FORBIDDEN", 403, details);
++    this.name = "ForbiddenError";
++  }
++}
++
++/** 403 — CSRF token missing, invalid, or cross-site request when using cookie session. */
++export class CsrfValidationError extends ApiError {
++    constructor(message = 'Invalid or missing CSRF token.', details?: unknown) {
++        super(message, 'CSRF_INVALID', 403, details);
++        this.name = 'CsrfValidationError';
++    }
++}
++
++/** 404 — requested resource does not exist. */
++export class NotFoundError extends ApiError {
++  constructor(resource = "Resource", details?: unknown) {
++    super(`${resource} not found.`, "NOT_FOUND", 404, details);
++    this.name = "NotFoundError";
++  }
++}
++
++/** 409 — request conflicts with current state (e.g. duplicate). */
++export class ConflictError extends ApiError {
++  constructor(message = "A conflict occurred.", details?: unknown) {
++    super(message, "CONFLICT", 409, details);
++    this.name = "ConflictError";
++  }
++}
++
++/** 413 — request entity is larger than the server is willing to process. */
++export class PayloadTooLargeError extends ApiError {
++  constructor(message = "Request body is too large.", details?: unknown) {
++    super(message, "PAYLOAD_TOO_LARGE", 413, details);
++    this.name = "PayloadTooLargeError";
++  }
++}
++
++/** 429 — client has exceeded the allowed request rate. */
++export class TooManyRequestsError extends ApiError {
++  constructor(
++    message = "Too many requests. Please try again later.",
++    details?: unknown,
++    retryAfterSeconds = 60,
++  ) {
++    super(message, "TOO_MANY_REQUESTS", 429, details, retryAfterSeconds);
++    this.name = "TooManyRequestsError";
++  }
++}
++
++/** 503 — service is temporarily unavailable. */
++export class ServiceUnavailableError extends ApiError {
++  constructor(
++    message = "The service is temporarily unavailable. Please try again later.",
++    details?: unknown,
++    retryAfterSeconds = 30,
++  ) {
++    super(message, "SERVICE_UNAVAILABLE", 503, details, retryAfterSeconds);
++    this.name = "ServiceUnavailableError";
++  }
++}
++
++/** 500 — unexpected server-side failure. */
++export class InternalError extends ApiError {
++  constructor(
++    message = "An unexpected error occurred. Please try again later.",
++    details?: unknown,
++  ) {
++    super(message, "INTERNAL_ERROR", 500, details);
++    this.name = "InternalError";
++  }
++}
++
++// ─── HTTP status → error code mapping ───────────────────────────────────────
++
++/**
++ * Map of HTTP status codes to their canonical error code strings.
++ *
++ * @deprecated Use ERROR_CODE_REGISTRY from errorCodes.ts for detailed error
++ * documentation including meaning, client handling, and retriable status.
++ *
++ * @see ERROR_CODE_REGISTRY
++ */
++export const HTTP_ERROR_CODES: Record<number, string> = {
++  400: "BAD_REQUEST",
++  401: "UNAUTHORIZED",
++  403: "FORBIDDEN",
++  404: "NOT_FOUND",
++  409: "CONFLICT",
++  413: "PAYLOAD_TOO_LARGE",
++  422: "UNPROCESSABLE_ENTITY",
++  429: "TOO_MANY_REQUESTS",
++  500: "INTERNAL_ERROR",
++  502: "BAD_GATEWAY",
++  503: "SERVICE_UNAVAILABLE",
++  504: "GATEWAY_TIMEOUT",
++};
++
++// ─── Legacy BackendError (kept for backward compatibility) ────────────────────
++
++export type BackendErrorCode =
++  | "BAD_REQUEST"
++  | "NOT_MATURED"
++  | "VALIDATION_ERROR"
++  | "UNAUTHORIZED"
++  | "FORBIDDEN"
++  | "NOT_FOUND"
++  | "CONFLICT"
++  | "PAYLOAD_TOO_LARGE"
++  | "TOO_MANY_REQUESTS"
++  | "SERVICE_UNAVAILABLE"
++  | "GATEWAY_TIMEOUT"
++  | "BLOCKCHAIN_UNAVAILABLE"
++  | "BLOCKCHAIN_CALL_FAILED"
++  | "INTERNAL_ERROR";
++
++export interface BackendErrorOptions {
++  code: BackendErrorCode;
++  message: string;
++  status: number;
++  details?: Record<string, unknown>;
++  cause?: unknown;
++}
++
++export class BackendError extends Error {
++  readonly code: BackendErrorCode;
++  readonly status: number;
++  readonly details?: Record<string, unknown>;
++  readonly cause?: unknown;
++
++  constructor(options: BackendErrorOptions) {
++    super(options.message);
++    this.name = "BackendError";
++    this.code = options.code;
++    this.status = options.status;
++    this.details = options.details;
++    this.cause = options.cause;
++  }
++}
++
++export interface BackendErrorResponseBody {
++  error: {
++    code: BackendErrorCode;
++    message: string;
++    details?: Record<string, unknown>;
++  };
++}
++
++export function isBackendError(value: unknown): value is BackendError {
++  return value instanceof BackendError;
++}
++
++function asRecord(value: unknown): Record<string, unknown> {
++  return value && typeof value === "object"
++    ? (value as Record<string, unknown>)
++    : {};
++}
++
++function isRetryableStatus(status: number): boolean {
++  return [429, 503, 504].includes(status);
++}
++
++function classifyBackendError(
++  error: unknown,
++):
++  | {
++      code: BackendErrorCode;
++      status: number;
++      message: string;
++      retryable: boolean;
++    }
++  | undefined {
++  const errMessage = error instanceof Error ? error.message : String(error);
++  const errStr = errMessage.toLowerCase();
++
++  if (
++    errStr.includes("timeout") ||
++    errStr.includes("deadline") ||
++    errStr.includes("timed out")
++  ) {
++    return {
++      code: "GATEWAY_TIMEOUT",
++      status: 504,
++      message:
++        "The blockchain operation timed out. It may still be processed later.",
++      retryable: true,
++    };
++  }
++
++  if (
++    errStr.includes("429") ||
++    errStr.includes("rate limit") ||
++    errStr.includes("too many requests")
++  ) {
++    return {
++      code: "TOO_MANY_REQUESTS",
++      status: 429,
++      message: "Rate limit exceeded for blockchain calls. Please try again later.",
++      retryable: true,
++    };
++  }
++
++  if (
++    errStr.includes("503") ||
++    errStr.includes("service unavailable") ||
++    errStr.includes("temporarily unavailable")
++  ) {
++    return {
++      code: "SERVICE_UNAVAILABLE",
++      status: 503,
++      message: "Blockchain service is temporarily unavailable. Please try again later.",
++      retryable: true,
++    };
++  }
++
++  if (errStr.includes("not found") || errStr.includes("404")) {
++    return {
++      code: "NOT_FOUND",
++      status: 404,
++      message: "The requested resource was not found on the blockchain.",
++      retryable: false,
++    };
++  }
++
++  if (
++    errStr.includes("insufficient") ||
++    errStr.includes("invalid") ||
++    errStr.includes("malformed")
++  ) {
++    return {
++      code: "VALIDATION_ERROR",
++      status: 400,
++      message:
++        "The transaction was rejected due to invalid parameters or state.",
++      retryable: false,
++    };
++  }
++
++  return undefined;
++}
++
++export function normalizeBackendError(
++  error: unknown,
++  fallback: Omit<BackendErrorOptions, "cause">,
++): BackendError {
++  if (isBackendError(error)) {
++    const details = {
++      ...asRecord(error.details),
++      ...asRecord(fallback.details),
++    };
++    const retryable =
++      asRecord(error.details).retryable === true ||
++      isRetryableStatus(error.status);
++
++    return new BackendError({
++      code: error.code,
++      message: error.message,
++      status: error.status,
++      details: {
++        ...details,
++        retryable,
++      },
++      cause: error,
++    });
++  }
++
++  const classified =
++    fallback.code === "BLOCKCHAIN_CALL_FAILED"
++      ? classifyBackendError(error)
++      : undefined;
++
++  const status = classified?.status ?? fallback.status;
++  const code = classified?.code ?? fallback.code;
++  const message = classified?.message ?? fallback.message;
++  const retryable = classified?.retryable ?? isRetryableStatus(fallback.status);
++
++  return new BackendError({
++    code,
++    message,
++    status,
++    details: {
++      ...asRecord(fallback.details),
++      retryable,
++    },
++    cause: error,
++  });
++}
++
++export function toBackendErrorResponse(
++  error: BackendError,
++): BackendErrorResponseBody {
++  return {
++    error: {
++      code: error.code,
++      message: error.message,
++      details: error.details,
++    },
++  };
++}
++
++// ─── Error code registry exports ──────────────────────────────────────────────
++
++/**
++ * Re-export error code registry utilities for easy access throughout the application.
++ *
++ * @see errorCodes.ts for full registry and documentation
++ */
++export {
++  ERROR_CODE_REGISTRY,
++  getErrorCodeDefinition,
++  getErrorCodesByStatus,
++  validateErrorCodeRegistry,
++  type ErrorCodeDefinition,
++  type RegisteredErrorCode,
++} from "./errorCodes";
+diff --git a/src/lib/backend/logger.ts b/src/lib/backend/logger.ts
+new file mode 100644
+index 00000000..a0e7a018
+--- /dev/null
++++ b/src/lib/backend/logger.ts
+@@ -0,0 +1,220 @@
++import { NextRequest } from 'next/server';
++import { randomUUID } from 'crypto';
++import { redact } from './redact';
++
++type LogLevel = 'info' | 'warn' | 'error' | 'debug';
++/**
++ * Lightweight analytics-friendly logger for backend events.
++ *
++ * These helpers are intentionally simple because the actual business logic
++ * lives elsewhere. When the app moves into production we could replace the
++ * `emit` implementation with something that forwards events to an analytics
++ * service (Mixpanel, Segment, Datadog, etc.).
++ *
++ * For now we simply write a structured JSON string to the console so that
++ * developers and automated tests can verify that the correct hooks are being
++ * invoked.
++ */
++
++export interface AnalyticsPayload {
++    [key: string]: unknown;
++}
++
++interface LogEntry {
++    level: LogLevel;
++    message: string;
++    timestamp: string;
++    requestId?: string;
++    context?: Record<string, unknown>;
++    error?: {
++        name: string;
++        message: string;
++        stack?: string;
++    };
++}
++
++interface AnalyticsEvent {
++    event: string;
++    timestamp: string;
++    requestId?: string;
++    context?: Record<string, unknown>;
++    payload?: AnalyticsPayload;
++    error?: {
++        name: string;
++        message: string;
++        stack?: string;
++    };
++}
++
++const requestIds = new WeakMap<Request | NextRequest, string>();
++
++export function getRequestId(req?: Request | NextRequest): string {
++    if (!req) return randomUUID();
++    let rid: string | undefined | null = req.headers.get('x-request-id');
++    if (rid) return rid;
++
++    rid = requestIds.get(req);
++    if (!rid) {
++        rid = randomUUID();
++        requestIds.set(req, rid);
++    }
++    return rid || '';
++}
++
++export function getOrCreateRequestId(req?: Request | NextRequest): string {
++    return getRequestId(req);
++}
++
++function formatEntry(entry: LogEntry): string {
++    // Redact sensitive information from log entries
++    const redactedEntry = {
++        ...entry,
++        context: entry.context ? redact(entry.context) : undefined,
++        error: entry.error ? redact(entry.error) : undefined
++    };
++    return JSON.stringify(redactedEntry);
++}
++
++function createLogEntry(
++    level: LogLevel,
++    req: Request | NextRequest | undefined | string,
++    message: string,
++    context?: Record<string, unknown>,
++    error?: Error
++): LogEntry {
++    let requestId: string | undefined;
++    if (typeof req === 'string') {
++        requestId = req;
++    } else if (req) {
++        requestId = getRequestId(req);
++    }
++
++    const entry: LogEntry = {
++        level,
++        message,
++        timestamp: new Date().toISOString(),
++        requestId,
++    };
++
++    if (context) entry.context = context;
++
++    if (error) {
++        entry.error = {
++            name: error.name,
++            message: error.message,
++            stack: error.stack,
++        };
++    }
++
++    return entry;
++}
++
++export function logInfo(req: Request | NextRequest | undefined | string, message: string, context?: Record<string, unknown>): void {
++    const entry = createLogEntry('info', req, message, context);
++    console.log(formatEntry(entry));
++}
++
++export function logWarn(req: Request | NextRequest | undefined | string, message: string, context?: Record<string, unknown>): void {
++    const entry = createLogEntry('warn', req, message, context);
++    console.warn(formatEntry(entry));
++}
++
++export function logError(req: Request | NextRequest | undefined | string, message: string, error?: Error, context?: Record<string, unknown>): void {
++    const entry = createLogEntry('error', req, message, context, error);
++    console.error(formatEntry(entry));
++}
++
++export function logDebug(req: Request | NextRequest | undefined | string, message: string, context?: Record<string, unknown>): void {
++    if (process.env.NODE_ENV === 'development') {
++        const entry = createLogEntry('debug', req, message, context);
++        console.debug(formatEntry(entry));
++    }
++}
++
++function emit(event: AnalyticsEvent) {
++    // In development we use console.log; in production this might be a call
++    // to an external service or to a logging library that understands
++    // structured events.
++    const redactedEvent = {
++        ...event,
++        context: event.context ? redact(event.context) : undefined,
++        payload: event.payload ? redact(event.payload) : undefined,
++        error: event.error ? redact(event.error) : undefined
++    };
++    console.log(JSON.stringify(redactedEvent));
++}
++
++export function logCommitmentCreated(payload: AnalyticsPayload = {}) {
++    emit({
++        event: 'CommitmentCreated',
++        timestamp: new Date().toISOString(),
++        payload
++    });
++}
++
++export function logCommitmentSettled(payload: AnalyticsPayload = {}) {
++    emit({
++        event: 'CommitmentSettled',
++        timestamp: new Date().toISOString(),
++        payload
++    });
++}
++
++export function logEarlyExit(payload: AnalyticsPayload = {}) {
++    emit({
++        event: 'CommitmentEarlyExit',
++        timestamp: new Date().toISOString(),
++        payload
++    });
++}
++
++export function logAttestation(payload: AnalyticsPayload = {}) {
++    emit({
++        event: 'AttestationReceived',
++        timestamp: new Date().toISOString(),
++        payload
++    });
++}
++
++export function logListingCancelled(payload: AnalyticsPayload = {}) {
++    emit({
++        event: 'ListingCancelled',
++        timestamp: new Date().toISOString(),
++        payload
++    });
++}
++
++export function logListingCancellationFailed(payload: AnalyticsPayload = {}) {
++    emit({
++        event: 'ListingCancellationFailed',
++        timestamp: new Date().toISOString(),
++        payload
++    });
++}
++
++export function logDisputeOpened(payload: AnalyticsPayload = {}) {
++    emit({
++        event: 'DisputeOpened',
++        timestamp: new Date().toISOString(),
++        payload
++    });
++}
++
++export function logDisputeResolved(payload: AnalyticsPayload = {}) {
++    emit({
++        event: 'DisputeResolved',
++        timestamp: new Date().toISOString(),
++        payload
++    });
++}
++
++export const logger = {
++    info: (message: string, context?: Record<string, unknown>) =>
++        logInfo(undefined, message, context),
++    warn: (message: string, context?: Record<string, unknown>) =>
++        logWarn(undefined, message, context),
++    error: (message: string, context?: Record<string, unknown>) =>
++        logError(undefined, message, undefined, context),
++    debug: (message: string, context?: Record<string, unknown>) =>
++        logDebug(undefined, message, context),
++};
+diff --git a/src/lib/backend/rateLimit.ts b/src/lib/backend/rateLimit.ts
+new file mode 100644
+index 00000000..023fbc68
+--- /dev/null
++++ b/src/lib/backend/rateLimit.ts
+@@ -0,0 +1,84 @@
++import { getKV } from "./kv";
++
++/**
++ * Rate Limiting Strategy for Commitlabs Public API Endpoints.
++ *
++ * Uses a fixed-window rate limiting strategy stored in KV (Redis/Upstash).
++ * This works across multiple serverless instances.
++ *
++ * Limits are configurable via environment variables:
++ *   RATE_LIMIT_WRITE_MAX_REQUESTS   — max requests per window for write routes (default: 10)
++ *   RATE_LIMIT_WRITE_WINDOW_SECONDS — window size in seconds for write routes (default: 60)
++ *   RATE_LIMIT_DEFAULT_MAX_REQUESTS — max requests per window for all other routes (default: 20)
++ *   RATE_LIMIT_DEFAULT_WINDOW_SECONDS — window size in seconds for all other routes (default: 60)
++ */
++
++function envInt(name: string, fallback: number): number {
++  const raw = process.env[name];
++  if (!raw) return fallback;
++  const parsed = parseInt(raw, 10);
++  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
++}
++
++function buildLimits(): Record<string, { windowMs: number; maxRequests: number }> {
++  const writeMax = envInt("RATE_LIMIT_WRITE_MAX_REQUESTS", 10);
++  const writeWindowSec = envInt("RATE_LIMIT_WRITE_WINDOW_SECONDS", 60);
++  const defaultMax = envInt("RATE_LIMIT_DEFAULT_MAX_REQUESTS", 20);
++  const defaultWindowSec = envInt("RATE_LIMIT_DEFAULT_WINDOW_SECONDS", 60);
++
++  return {
++    "api/auth/nonce": { windowMs: 60 * 1000, maxRequests: 5 },
++    "api/auth/verify": { windowMs: 60 * 1000, maxRequests: 5 },
++    "auth:nonce:address": { windowMs: 5 * 60 * 1000, maxRequests: 3 },
++    // Write-heavy routes — tighter limits to protect on-chain operations
++    "api/commitments/create": { windowMs: writeWindowSec * 1000, maxRequests: writeMax },
++    "api/commitments/settle": { windowMs: writeWindowSec * 1000, maxRequests: writeMax },
++    "api/commitments/early-exit": { windowMs: writeWindowSec * 1000, maxRequests: writeMax },
++    default: { windowMs: defaultWindowSec * 1000, maxRequests: defaultMax },
++  };
++}
++
++/**
++ * Returns the configured window duration in seconds for a given route.
++ * Used to populate the Retry-After header on 429 responses.
++ */
++export function getRateLimitWindowSeconds(routeId: string): number {
++  const limits = buildLimits();
++  const config = limits[routeId] ?? limits.default;
++  return Math.ceil(config.windowMs / 1000);
++}
++
++export async function checkRateLimit(
++  key: string,
++  routeId: string,
++): Promise<boolean> {
++  const isDev = process.env.NODE_ENV === "development";
++  const kv = getKV();
++  const redisKey = `ratelimit:${routeId}:${key}`;
++  const limits = buildLimits();
++  const config = limits[routeId] ?? limits.default;
++
++  try {
++    const count = await kv.incr(redisKey);
++
++    if (count === 1) {
++      await kv.expire(redisKey, Math.ceil(config.windowMs / 1000));
++    }
++
++    const isAllowed = count <= config.maxRequests;
++
++    if (isDev && !isAllowed) {
++      console.warn(
++        `[RateLimit] Rate limit exceeded for ${routeId} (key: ${key}). Count: ${count}, Limit: ${config.maxRequests}`,
++      );
++    }
++
++    return isAllowed;
++  } catch (error) {
++    console.error(
++      `[RateLimit] Error checking rate limit for ${routeId}:`,
++      error,
++    );
++    return true;
++  }
++}
+diff --git a/src/lib/backend/redact.ts b/src/lib/backend/redact.ts
+new file mode 100644
+index 00000000..092409a4
+--- /dev/null
++++ b/src/lib/backend/redact.ts
+@@ -0,0 +1,138 @@
++/**
++ * Redaction utility for sensitive fields in backend logs and analytics.
++ * 
++ * This utility prevents accidental logging of sensitive information like signatures,
++ * tokens, nonces, and other security-sensitive values.
++ */
++
++import { SENSITIVE_FIELDS } from '@/lib/shared/sensitiveFields'
++
++const DEFAULT_DENYLIST = SENSITIVE_FIELDS
++
++/**
++ * Configuration options for redaction
++ */
++interface RedactOptions {
++  /** Custom denylist of field names to redact */
++  denylist?: string[]
++  /** Custom replacement string for redacted values */
++  replacement?: string
++  /** Whether to perform case-insensitive matching */
++  caseInsensitive?: boolean
++}
++
++/**
++ * Redacts sensitive values from objects, arrays, and primitives
++ * 
++ * @param data - The data to redact
++ * @param options - Configuration options
++ * @returns Redacted data with sensitive values replaced
++ */
++export function redact<T = unknown>(data: T, options: RedactOptions = {}): T {
++  const {
++    denylist = [],
++    replacement = '[REDACTED]',
++    caseInsensitive = true
++  } = options
++
++  // Combine default denylist with custom denylist
++  const denylistSet = new Set(
++    [...DEFAULT_DENYLIST, ...denylist].map(key =>
++      caseInsensitive ? key.toLowerCase() : key
++    )
++  )
++
++  // Create case-insensitive matcher if enabled
++  const shouldRedact = caseInsensitive
++    ? (key: string): boolean => {
++        const lowerKey = key.toLowerCase()
++        return denylistSet.has(lowerKey)
++      }
++    : (key: string): boolean => denylistSet.has(key)
++
++  return redactValue(data, shouldRedact, replacement)
++}
++
++/**
++ * Recursively redacts values in data structures
++ */
++function redactValue<T = unknown>(
++  data: T,
++  shouldRedact: (key: string) => boolean,
++  replacement: string
++): T {
++  if (data === null || data === undefined) {
++    return data
++  }
++
++  // Handle primitives
++  if (typeof data !== 'object') {
++    return data
++  }
++
++  // Handle arrays
++  if (Array.isArray(data)) {
++    return data.map(item => redactValue(item, shouldRedact, replacement)) as T
++  }
++
++  // Handle Date objects
++  if (data instanceof Date) {
++    return data
++  }
++
++  // Handle Error objects
++  if (data instanceof Error) {
++    const redactedError = new Error(redactValue(data.message, shouldRedact, replacement) as string)
++    redactedError.name = data.name
++    redactedError.stack = data.stack
++    return redactedError as T
++  }
++
++  // Handle plain objects
++  if (typeof data === 'object') {
++    const result: Record<string, unknown> = {}
++    
++    for (const [key, value] of Object.entries(data)) {
++      if (shouldRedact(key)) {
++        result[key] = replacement
++      } else {
++        result[key] = redactValue(value, shouldRedact, replacement)
++      }
++    }
++    
++    return result as T
++  }
++
++  return data
++}
++
++/**
++ * Utility function to create a redacted version of an object with custom denylist
++ */
++export function createRedacted<T extends Record<string, unknown>>(
++  data: T,
++  sensitiveFields: string[]
++): Partial<T> {
++  return redact(data, { denylist: sensitiveFields }) as Partial<T>
++}
++
++/**
++ * Checks if a field name is considered sensitive
++ */
++export function isSensitiveField(fieldName: string): boolean {
++  return DEFAULT_DENYLIST.has(fieldName.toLowerCase())
++}
++
++/**
++ * Adds a field to the default denylist (for runtime configuration)
++ */
++export function addToDenylist(fieldName: string): void {
++  DEFAULT_DENYLIST.add(fieldName.toLowerCase())
++}
++
++/**
++ * Removes a field from the default denylist (for runtime configuration)
++ */
++export function removeFromDenylist(fieldName: string): void {
++  DEFAULT_DENYLIST.delete(fieldName.toLowerCase())
++}
+diff --git a/src/lib/backend/services/contracts.ts b/src/lib/backend/services/contracts.ts
+new file mode 100644
+index 00000000..fa718d4c
+--- /dev/null
++++ b/src/lib/backend/services/contracts.ts
+@@ -0,0 +1,1343 @@
++import {
++  Account,
++  Address,
++  BASE_FEE,
++  Contract,
++  Keypair,
++  SorobanRpc,
++  TransactionBuilder,
++  nativeToScVal,
++  scValToNative,
++} from "@stellar/stellar-sdk";
++import {
++  BackendError,
++  BackendErrorCode,
++  normalizeBackendError,
++} from "@/lib/backend/errors";
++import { getBackendConfig } from "@/lib/backend/config";
++import { logInfo } from "@/lib/backend/logger";
++import { cache } from "@/lib/backend/cache/factory";
++import { CacheKey, CacheTTL } from "@/lib/backend/cache/index";
++import { getCountersAdapter } from "@/lib/backend/counters/provider";
++
++export type ChainCommitmentStatus =
++  | "CREATED"
++  | "ACTIVE"
++  | "SETTLED"
++  | "VIOLATED"
++  | "EARLY_EXIT"
++  | "DISPUTED"
++  | "UNKNOWN";
++
++export interface CreateCommitmentOnChainParams {
++  ownerAddress: string;
++  asset: string;
++  amount: string;
++  durationDays: number;
++  maxLossBps: number;
++  metadata?: Record<string, unknown>;
++}
++
++export interface LoggingContext {
++  requestId?: string;
++  commitmentId?: string;
++}
++
++export interface ChainCommitment {
++  id: string;
++  ownerAddress: string;
++  asset: string;
++  amount: string;
++  status: ChainCommitmentStatus;
++  complianceScore: number;
++  currentValue: string;
++  feeEarned: string;
++  violationCount: number;
++  createdAt?: string;
++  expiresAt?: string;
++  contractVersion?: string;
++}
++
++export interface CreateCommitmentOnChainResult {
++  commitmentId: string;
++  commitment: ChainCommitment;
++  txHash?: string;
++}
++
++export interface RecordAttestationOnChainParams {
++  commitmentId: string;
++  attestorAddress: string;
++  complianceScore: number;
++  violation: boolean;
++  feeEarned?: string;
++  timestamp?: string;
++  details?: Record<string, unknown>;
++}
++
++export interface RecordAttestationOnChainResult {
++  attestationId: string;
++  commitmentId: string;
++  complianceScore: number;
++  violation: boolean;
++  feeEarned: string;
++  recordedAt: string;
++  txHash?: string;
++}
++
++export interface SettleCommitmentOnChainParams {
++  commitmentId: string;
++  callerAddress?: string;
++}
++
++export interface SettleCommitmentOnChainResult {
++  settlementAmount: string;
++  txHash?: string;
++  reference?: string;
++  finalStatus: string;
++}
++
++export interface DisputeOnChainParams {
++  commitmentId: string;
++  reason: string;
++  evidence?: string;
++  callerAddress: string;
++}
++
++export interface DisputeOnChainResult {
++  commitmentId: string;
++  disputeId: string;
++  status: string;
++  txHash?: string;
++  disputedAt: string;
++}
++
++export interface ResolveDisputeOnChainParams {
++  commitmentId: string;
++  resolution: "resolved_in_favor_of_owner" | "resolved_in_favor_of_counterparty" | "dismissed";
++  notes?: string;
++  resolverAddress: string;
++}
++
++export interface ResolveDisputeOnChainResult {
++  commitmentId: string;
++  disputeId: string;
++  resolution: string;
++  finalStatus: string;
++  txHash?: string;
++  resolvedAt: string;
++}
++
++export interface EarlyExitCommitmentOnChainParams {
++  commitmentId: string;
++  callerAddress?: string;
++}
++
++export interface EarlyExitCommitmentOnChainResult {
++  exitAmount: string;
++  penaltyAmount: string;
++  finalStatus: string;
++  txHash?: string;
++  reference?: string;
++}
++
++export interface FundEscrowOnChainParams {
++  commitmentId: string;
++  callerAddress?: string;
++}
++
++export interface FundEscrowOnChainResult {
++  commitmentId: string;
++  txHash?: string;
++  contractVersion?: string;
++  reference?: string;
++}
++
++type ContractCallMode = "read" | "write";
++interface ContractInvocationResult {
++  value: unknown;
++  txHash?: string;
++  version?: string;
++}
++
++/**
++ * Scaling factor for compliance scores sent to/from the blockchain.
++ * Compliance scores are stored on-chain as integers in the range [0, 100]
++ * to avoid floating-point precision issues. When writing to the chain,
++ * scores are divided by this scale; when reading from the chain, they
++ * are multiplied by this scale to restore the original value.
++ *
++ * Example: A compliance score of 85 is stored as 0.85 on-chain,
++ * and read back as 85 in the application.
++ */
++const ANALYTICS_SCALE = 100;
++
++// --- Retry helper types & implementation ----------------------------------
++export interface RetryOptions {
++  maxAttempts: number;
++  baseDelayMs: number;
++  maxDelayMs: number;
++  maxTotalBackoffMs: number;
++  backoffMultiplier: number;
++  isRetryable: (err: unknown) => boolean;
++  random?: () => number;
++  sleep?: (ms: number) => Promise<void>;
++  onRetry?: (info: { attempt: number; delayMs: number; error: unknown }) => void;
++}
++
++/**
++ * Bounded retry/backoff budget applied to read-mode contract calls via
++ * {@link invokeReadContractMethod}. Write calls are never retried (see
++ * {@link assertRetrySafe}) and so do not use this config.
++ */
++const READ_RETRY_CONFIG: Omit<RetryOptions, "isRetryable" | "onRetry"> = {
++  maxAttempts: 3,
++  baseDelayMs: 200,
++  maxDelayMs: 2_000,
++  maxTotalBackoffMs: 5_000,
++  backoffMultiplier: 2,
++};
++
++/**
++ * Bounded exponential backoff with optional jitter.
++ * Calls `op(attempt)` where attempt is 1-based. Throws the final error
++ * when retries are exhausted or when budget would be exceeded.
++ */
++export async function retryWithBackoff<T>(
++  op: (attempt: number) => Promise<T>,
++  options: RetryOptions,
++): Promise<T> {
++  const {
++    maxAttempts,
++    baseDelayMs,
++    maxDelayMs,
++    maxTotalBackoffMs,
++    backoffMultiplier,
++    isRetryable,
++    random = () => Math.random(),
++    sleep = (ms: number) => new Promise((r) => setTimeout(r, ms)),
++    onRetry,
++  } = options;
++
++  let totalBackoff = 0;
++
++  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
++    try {
++      return await op(attempt);
++    } catch (err) {
++      const isLast = attempt >= maxAttempts;
++      if (!isRetryable(err) || isLast) {
++        throw err;
++      }
++
++      // Ceiling for this attempt's backoff (based on attempt index)
++      const rawCeiling = baseDelayMs * Math.pow(backoffMultiplier, attempt - 1);
++      const ceiling = Math.min(rawCeiling, maxDelayMs);
++
++      // jitter between ceiling/2 and ceiling
++      const delay = Math.round(ceiling / 2 + (random() ?? 0) * (ceiling / 2));
++
++      // If adding this delay would exceed budget, stop retrying and rethrow
++      if (maxTotalBackoffMs !== undefined && totalBackoff + delay > maxTotalBackoffMs) {
++        throw err;
++      }
++
++      onRetry?.({ attempt, delayMs: delay, error: err });
++      await sleep(delay);
++      totalBackoff += delay;
++      // continue to next attempt
++    }
++  }
++
++  // Should never reach here, but satisfy TS
++  throw new Error('retryWithBackoff: exhausted retries');
++}
++
++/**
++ * Classifier for whether a contract/RPC error is retryable for idempotent reads.
++ */
++export function isRetryableContractError(error: unknown): boolean {
++  const msg = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
++
++  if (msg.includes('timeout') || msg.includes('timed out') || msg.includes('deadline')) return true;
++  if (msg.includes('429') || msg.includes('rate limit') || msg.includes('too many requests')) return true;
++  if (msg.includes('not found') || msg.includes('404')) return false;
++  if (msg.includes('invalid') || msg.includes('malformed')) return false;
++
++  // BackendError handling
++  if (error instanceof BackendError) {
++    const status = (error as BackendError).status;
++    if ([429, 503, 504].includes(status)) return true;
++    return false;
++  }
++
++  // Fallback: treat generic network/gateway failures as retryable
++  if (msg.includes('socket hang up') || msg.includes('econnreset') || msg.includes('connection reset')) return true;
++  if (/5\d\d/.test(msg)) return true; // 5xx
++
++  return false;
++}
++
++/**
++ * Guard that forbids retrying write-mode invocations after the first attempt.
++ */
++export function assertRetrySafe(mode: ContractCallMode, attempt: number): void {
++  if (mode === 'read') return;
++  if (mode === 'write' && attempt === 1) return;
++
++  throw new BackendError({
++    code: 'BLOCKCHAIN_CALL_FAILED',
++    message: 'A write-mode contract invocation must never be retried.',
++    status: 500,
++  });
++}
++
++
++function getRpcUrl(): string {
++  return getBackendConfig().sorobanRpcUrl;
++}
++
++function getNetworkPassphrase(): string {
++  return getBackendConfig().networkPassphrase;
++}
++
++
++function getContractId(kind: "commitmentCore" | "attestationEngine"): string {
++  const config = getBackendConfig();
++  if (kind === "commitmentCore") {
++    return config.contractAddresses.commitmentCore;
++  }
++  return config.contractAddresses.attestationEngine;
++}
++
++function getSourceKeypair(): Keypair | null {
++  const secret = process.env.SOROBAN_SERVER_SECRET_KEY;
++  if (!secret) {
++    return null;
++  }
++  return Keypair.fromSecret(secret);
++}
++
++function getSourcePublicKey(): string | null {
++  const keypair = getSourceKeypair();
++  if (keypair) {
++    return keypair.publicKey();
++  }
++
++  return process.env.SOROBAN_SOURCE_ACCOUNT || null;
++}
++
++
++function getSorobanServer(): SorobanRpc.Server {
++  const url = getRpcUrl();
++  return new SorobanRpc.Server(url, { allowHttp: url.startsWith("http://") });
++}
++
++function asRecord(value: unknown): Record<string, unknown> {
++  return value && typeof value === "object"
++    ? (value as Record<string, unknown>)
++    : {};
++}
++
++function asString(value: unknown, fallback = ""): string {
++  if (typeof value === "string") {
++    return value;
++  }
++  if (typeof value === "number" || typeof value === "bigint") {
++    return String(value);
++  }
++  return fallback;
++}
++
++function asNumber(value: unknown, fallback = 0): number {
++  if (typeof value === "number" && Number.isFinite(value)) {
++    return value;
++  }
++  if (typeof value === "string") {
++    const parsed = Number(value);
++    if (Number.isFinite(parsed)) {
++      return parsed;
++    }
++  }
++  return fallback;
++}
++
++function normalizeStatus(value: unknown): ChainCommitmentStatus {
++  const raw = asString(value, "UNKNOWN").toUpperCase();
++  if (
++    raw === "CREATED" ||
++    raw === "ACTIVE" ||
++    raw === "SETTLED" ||
++    raw === "VIOLATED" ||
++    raw === "EARLY_EXIT" ||
++    raw === "DISPUTED"
++  ) {
++    return raw;
++  }
++  return "UNKNOWN";
++}
++
++/**
++ * Normalizes blockchain-related errors into stable BackendError types.
++ * Maps RPC failures, simulation errors, and timeouts to appropriate status codes.
++ * Ensures that sensitive raw RPC details are not leaked to the client.
++ */
++function parseChainCommitment(value: unknown): ChainCommitment {
++  const raw = asRecord(value);
++  const id = asString(raw.id ?? raw.commitmentId);
++
++  if (!id) {
++    throw new BackendError({
++      code: "BLOCKCHAIN_CALL_FAILED",
++      message: "Soroban returned a commitment without an id.",
++      status: 502,
++      details: { raw },
++    });
++  }
++
++  return {
++    id,
++    ownerAddress: asString(raw.ownerAddress ?? raw.owner_address),
++    asset: asString(raw.asset),
++    amount: asString(raw.amount, "0"),
++    status: normalizeStatus(raw.status),
++    complianceScore: asNumber(raw.complianceScore ?? raw.compliance_score) * ANALYTICS_SCALE,
++    currentValue: asString(
++      raw.currentValue ?? raw.current_value ?? raw.amount,
++      "0",
++    ),
++    feeEarned: asString(raw.feeEarned ?? raw.fees_earned, "0"),
++    violationCount: asNumber(raw.violationCount ?? raw.violation_count),
++    createdAt: asString(raw.createdAt ?? raw.created_at) || undefined,
++    expiresAt: asString(raw.expiresAt ?? raw.expires_at) || undefined,
++    contractVersion: (getBackendConfig() as { activeVersion?: string }).activeVersion,
++  };
++}
++
++function parseCreateCommitmentResult(
++  value: unknown,
++  txHash?: string,
++): CreateCommitmentOnChainResult {
++  if (typeof value === "string") {
++    return {
++      commitmentId: value,
++      commitment: {
++        id: value,
++        ownerAddress: "",
++        asset: "",
++        amount: "0",
++        status: "UNKNOWN",
++        complianceScore: 0,
++        currentValue: "0",
++        feeEarned: "0",
++        violationCount: 0,
++      },
++      txHash,
++    };
++  }
++
++  const raw = asRecord(value);
++  const parsedCommitment = parseChainCommitment(raw.commitment ?? raw);
++
++  return {
++    commitmentId: parsedCommitment.id,
++    commitment: parsedCommitment,
++    txHash: asString(raw.txHash) || txHash,
++  };
++}
++
++function parseAttestationResult(
++  value: unknown,
++  txHash?: string,
++): RecordAttestationOnChainResult {
++  const raw = asRecord(value);
++  const attestationId = asString(raw.attestationId ?? raw.id);
++  const commitmentId = asString(raw.commitmentId ?? raw.commitment_id);
++
++  if (!attestationId || !commitmentId) {
++    throw new BackendError({
++      code: "BLOCKCHAIN_CALL_FAILED",
++      message: "Soroban returned an invalid attestation payload.",
++      status: 502,
++      details: { raw },
++    });
++  }
++
++  return {
++    attestationId,
++    commitmentId,
++    complianceScore: asNumber(raw.complianceScore ?? raw.compliance_score) * ANALYTICS_SCALE,
++    violation: Boolean(raw.violation),
++    feeEarned: asString(raw.feeEarned ?? raw.fees_earned, "0"),
++    recordedAt:
++      asString(raw.recordedAt ?? raw.recorded_at) || new Date().toISOString(),
++    txHash: asString(raw.txHash) || txHash,
++  };
++}
++
++function parseCommitmentList(value: unknown): ChainCommitment[] {
++  if (!Array.isArray(value)) {
++    return [];
++  }
++
++  return value.map((item) => parseChainCommitment(item));
++}
++
++function getRpcTimeoutMs(): number {
++  const raw = process.env.SOROBAN_RPC_TIMEOUT_MS;
++  const parsed = raw ? Number(raw) : NaN;
++  return Number.isFinite(parsed) && parsed > 0 ? parsed : 15_000;
++}
++
++function withRpcTimeout<T>(
++  promise: Promise<T>,
++  methodName: string,
++  timeoutMs = getRpcTimeoutMs(),
++): Promise<T> {
++  return new Promise<T>((resolve, reject) => {
++    const timer = setTimeout(() => {
++      reject(
++        new BackendError({
++          code: "GATEWAY_TIMEOUT",
++          message: "The blockchain operation timed out. It may still be processed later.",
++          status: 504,
++          details: {
++            methodName,
++            timeoutMs,
++            retryable: true,
++          },
++        }),
++      );
++    }, timeoutMs);
++
++    promise.then(
++      (value) => {
++        clearTimeout(timer);
++        resolve(value);
++      },
++      (error) => {
++        clearTimeout(timer);
++        reject(error);
++      },
++    );
++  });
++}
++
++async function waitForTransactionResult(
++  server: SorobanRpc.Server,
++  hash: string,
++  timeoutMs = 15_000,
++): Promise<unknown> {
++  const startedAt = Date.now();
++  while (Date.now() - startedAt < timeoutMs) {
++    const tx = await withRpcTimeout(
++      server.getTransaction(hash),
++      "getTransaction",
++      timeoutMs,
++    );
++    if (tx.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
++      return tx.returnValue ? scValToNative(tx.returnValue) : null;
++    }
++    if (tx.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
++      throw normalizeBackendError(new Error("Transaction execution failed"), {
++        code: "BLOCKCHAIN_CALL_FAILED",
++        message: "Soroban transaction failed.",
++        status: 502,
++        details: { hash, txStatus: tx.status },
++      });
++    }
++
++    await new Promise((resolve) => {
++      setTimeout(resolve, 600);
++    });
++  }
++
++  throw normalizeBackendError(new Error("RPC Timeout"), {
++    code: "BLOCKCHAIN_CALL_FAILED",
++    message: "Timed out waiting for Soroban transaction result.",
++    status: 504,
++    details: { hash },
++  });
++}
++
++async function invokeContractMethod(
++  contractId: string,
++  methodName: string,
++  params: unknown[],
++  mode: ContractCallMode,
++  attempt = 1,
++): Promise<ContractInvocationResult> {
++  // Guard: a write transaction must be submitted exactly once. Retrying one
++  // (attempt > 1) risks a double submission, so it is rejected before any
++  // network work is performed. Direct (non-retried) calls always pass
++  // attempt = 1 and are unaffected.
++  assertRetrySafe(mode, attempt);
++
++  if (!contractId) {
++    throw new BackendError({
++      code: "BLOCKCHAIN_UNAVAILABLE",
++      message: "Missing Soroban contract configuration.",
++      status: 500,
++      details: { methodName },
++    });
++  }
++
++  const sourcePublicKey = getSourcePublicKey();
++  if (!sourcePublicKey) {
++    throw new BackendError({
++      code: "BLOCKCHAIN_UNAVAILABLE",
++      message: "Missing SOROBAN source account configuration.",
++      status: 500,
++      details: { methodName },
++    });
++  }
++
++  const server = getSorobanServer();
++  const contract = new Contract(contractId);
++  const account =
++    mode === "write"
++      ? await withRpcTimeout(
++          server.getAccount(sourcePublicKey),
++          `${methodName}.getAccount`,
++        )
++      : new Account(sourcePublicKey, "0");
++  const operation = contract.call(
++    methodName,
++    ...params.map((value) => nativeToScVal(value)),
++  );
++
++  const tx = new TransactionBuilder(account, {
++    fee: String(BASE_FEE),
++    networkPassphrase: getNetworkPassphrase(),
++  })
++    .addOperation(operation)
++    .setTimeout(30)
++    .build();
++
++  const simulation = await withRpcTimeout(
++    server.simulateTransaction(tx),
++    `${methodName}.simulateTransaction`,
++  );
++  if (SorobanRpc.Api.isSimulationError(simulation)) {
++    throw normalizeBackendError(new Error(simulation.error), {
++      code: "BLOCKCHAIN_CALL_FAILED",
++      message: `Soroban simulation failed for ${methodName}.`,
++      status: 502,
++      details: { methodName },
++    });
++  }
++
++  if (mode === "read") {
++    return {
++      value: simulation.result ? scValToNative(simulation.result.retval) : null,
++      version: getBackendConfig().activeVersion,
++    };
++  }
++
++  const sourceKeypair = getSourceKeypair();
++  if (!sourceKeypair) {
++    throw new BackendError({
++      code: "BLOCKCHAIN_UNAVAILABLE",
++      message: "Missing SOROBAN_SERVER_SECRET_KEY for write contract calls.",
++      status: 500,
++      details: { methodName },
++    });
++  }
++
++  const preparedTx = await withRpcTimeout(
++    server.prepareTransaction(tx),
++    `${methodName}.prepareTransaction`,
++  );
++  preparedTx.sign(sourceKeypair);
++  const sendResult = await withRpcTimeout(
++    server.sendTransaction(preparedTx),
++    "sendTransaction",
++  );
++  const txHash = sendResult.hash;
++
++  const onChainValue = await waitForTransactionResult(server, txHash);
++  return { value: onChainValue, txHash, version: getBackendConfig().activeVersion };
++}
++
++/**
++ * Read-only counterpart of {@link invokeContractMethod} that adds bounded
++ * retry-with-exponential-backoff for transient RPC failures.
++ *
++ * Use this for ALL read-mode contract calls. The call mode is hard-coded to
++ * "read", so a write transaction can never be submitted — let alone
++ * re-submitted — through this path. Write calls must keep calling
++ * `invokeContractMethod(..., "write")` directly so each runs exactly once.
++ *
++ * Only failures classified retryable by {@link isRetryableContractError} are
++ * retried; attempts and total backoff are capped by {@link READ_RETRY_CONFIG}.
++ * The final error is propagated unchanged, so a caller's `incrementChainFailures`
++ * runs exactly once, only after retries are exhausted.
++ */
++async function invokeReadContractMethod(
++  contractId: string,
++  methodName: string,
++  params: unknown[],
++): Promise<ContractInvocationResult> {
++  return retryWithBackoff(
++    (attempt) =>
++      invokeContractMethod(contractId, methodName, params, "read", attempt),
++    {
++      ...READ_RETRY_CONFIG,
++      isRetryable: (error) =>
++        !(
++          error instanceof BackendError &&
++          error.code === "GATEWAY_TIMEOUT" &&
++          asRecord(error.details).timeoutMs !== undefined
++        ) && isRetryableContractError(error),
++      onRetry: ({ attempt, delayMs, error }) => {
++        logInfo(undefined, "[soroban] retrying read after transient failure", {
++          methodName,
++          attempt,
++          delayMs: Math.round(delayMs),
++          error: error instanceof Error ? error.message : String(error),
++        });
++      },
++    },
++  );
++}
++
++function validateOwnerAddress(ownerAddress: string): void {
++  if (!ownerAddress || ownerAddress.trim().length < 5) {
++    throw new BackendError({
++      code: "BAD_REQUEST",
++      message: "Invalid owner address.",
++      status: 400,
++      details: { ownerAddress },
++    });
++  }
++}
++
++export async function createCommitmentOnChain(
++  params: CreateCommitmentOnChainParams,
++  loggingContext?: LoggingContext,
++): Promise<CreateCommitmentOnChainResult> {
++  try {
++    validateOwnerAddress(params.ownerAddress);
++    const invocation = await invokeContractMethod(
++      getContractId("commitmentCore"),
++      "create_commitment",
++      [
++        new Address(params.ownerAddress).toScVal(),
++        nativeToScVal(params.asset),
++        nativeToScVal(params.amount),
++        nativeToScVal(params.durationDays),
++        nativeToScVal(params.maxLossBps),
++        nativeToScVal(params.metadata ?? {}),
++      ],
++      "write",
++    );
++
++    // Increment successful actions counter on successful commitment creation
++    const countersAdapter = getCountersAdapter();
++    void countersAdapter.incrementSuccessfulActions(); // Fire and forget for metrics
++
++    void cache.delete(CacheKey.userCommitments(params.ownerAddress));
++
++    return parseCreateCommitmentResult(invocation.value, invocation.txHash);
++  } catch (error) {
++    // Increment chain failures counter on blockchain operation failures
++    const countersAdapter = getCountersAdapter();
++    void countersAdapter.incrementChainFailures(); // Fire and forget for metrics
++
++    throw normalizeBackendError(error, {
++      code: "BLOCKCHAIN_CALL_FAILED",
++      message: "Unable to create commitment on chain.",
++      status: 502,
++      details: { method: "create_commitment" },
++    });
++  }
++}
++
++export async function getCommitmentFromChain(
++  commitmentId: string,
++  loggingContext?: LoggingContext,
++): Promise<ChainCommitment> {
++  try {
++    if (!commitmentId) {
++      throw new BackendError({
++        code: "BAD_REQUEST",
++        message: "Missing commitment id.",
++        status: 400,
++      });
++    }
++
++    const cacheKey = CacheKey.commitment(commitmentId);
++    const cached = await cache.get<ChainCommitment>(cacheKey);
++    if (cached !== null) {
++      logInfo(loggingContext?.requestId, "[cache] hit commitment", { commitmentId });
++      return cached;
++    }
++    logInfo(loggingContext?.requestId, "[cache] miss commitment", { commitmentId });
++
++    // Read call: wrapped with bounded retry-and-backoff for transient failures.
++    const invocation = await invokeReadContractMethod(
++      getContractId("commitmentCore"),
++      "get_commitment",
++      [commitmentId],
++    );
++
++    // Increment successful actions counter on successful chain read
++    const countersAdapter = getCountersAdapter();
++    void countersAdapter.incrementSuccessfulActions(); // Fire and forget for metrics
++
++    const commitment = {
++      ...parseChainCommitment(invocation.value),
++      contractVersion: invocation.version ?? getBackendConfig().activeVersion,
++    };
++    await cache.set(cacheKey, commitment, CacheTTL.COMMITMENT_DETAIL);
++    return commitment;
++  } catch (error) {
++    // Increment chain failures counter on blockchain operation failures.
++    // Reached only after read retries (if any) have been exhausted.
++    const countersAdapter = getCountersAdapter();
++    void countersAdapter.incrementChainFailures(); // Fire and forget for metrics
++
++    throw normalizeBackendError(error, {
++      code: "BLOCKCHAIN_CALL_FAILED",
++      message: "Unable to fetch commitment from chain.",
++      status: 502,
++      details: { method: "get_commitment", commitmentId },
++    });
++  }
++}
++
++export async function getUserCommitmentsFromChain(
++  ownerAddress: string,
++  loggingContext?: LoggingContext,
++): Promise<ChainCommitment[]> {
++  try {
++    validateOwnerAddress(ownerAddress);
++
++    const cacheKey = CacheKey.userCommitments(ownerAddress);
++    const cached = await cache.get<ChainCommitment[]>(cacheKey);
++    if (cached !== null) {
++      logInfo(loggingContext?.requestId, "[cache] hit user-commitments", { ownerAddress });
++      return cached;
++    }
++    logInfo(loggingContext?.requestId, "[cache] miss user-commitments", { ownerAddress });
++
++    const contractId = getContractId("commitmentCore");
++
++    try {
++      // Optimistic probe. `get_user_commitments` may not exist on every
++      // deployed contract, and its failure is expected and handled by the
++      // id-based fallback below — so it is deliberately NOT retried. Retrying
++      // an expected failure would only add latency. Genuine transient errors
++      // are still covered: the fallback `get_user_commitment_ids` read and the
++      // per-id `getCommitmentFromChain` reads each go through
++      // `invokeReadContractMethod` and so are retried.
++      const directResult = await invokeContractMethod(
++        contractId,
++        "get_user_commitments",
++        [ownerAddress],
++        "read",
++      );
++      const commitments = parseCommitmentList(directResult.value);
++      if (commitments.length > 0) {
++        await cache.set(cacheKey, commitments, CacheTTL.USER_COMMITMENTS);
++        // Increment successful actions counter on successful chain read
++        const countersAdapter = getCountersAdapter();
++        void countersAdapter.incrementSuccessfulActions();
++        return commitments;
++      }
++    } catch (error) {
++      if (!(error instanceof BackendError)) {
++        throw error;
++      }
++    }
++
++    // Read call: wrapped with bounded retry-and-backoff for transient failures.
++    const idsResult = await invokeReadContractMethod(
++      contractId,
++      "get_user_commitment_ids",
++      [ownerAddress],
++    );
++    const commitmentIds = Array.isArray(idsResult.value)
++      ? idsResult.value.map((id) => asString(id)).filter(Boolean)
++      : [];
++    const commitments = await Promise.all(
++      commitmentIds.map((commitmentId) => getCommitmentFromChain(commitmentId, loggingContext)),
++    );
++
++    await cache.set(cacheKey, commitments, CacheTTL.USER_COMMITMENTS);
++    // Increment successful actions counter on successful chain read
++    const countersAdapter = getCountersAdapter();
++    void countersAdapter.incrementSuccessfulActions();
++    return commitments;
++  } catch (error) {
++    // Increment chain failures counter on blockchain operation failures.
++    // Reached only after read retries (if any) have been exhausted.
++    const countersAdapter = getCountersAdapter();
++    void countersAdapter.incrementChainFailures();
++
++    throw normalizeBackendError(error, {
++      code: "BLOCKCHAIN_CALL_FAILED",
++      message: "Unable to fetch user commitments from chain.",
++      status: 502,
++      details: { method: "get_user_commitments", ownerAddress, requestId: loggingContext?.requestId },
++    });
++  }
++}
++
++export async function recordAttestationOnChain(
++  params: RecordAttestationOnChainParams,
++  loggingContext?: LoggingContext,
++): Promise<RecordAttestationOnChainResult> {
++  try {
++    if (!params.commitmentId) {
++      throw new BackendError({
++        code: "BAD_REQUEST",
++        message: "Missing commitment id for attestation.",
++        status: 400,
++      });
++    }
++
++    // Snapshot ownerAddress from cache before writing so we can invalidate the
++    // user-commitments list even though attestation params don't carry it.
++    const cachedCommitment = await cache.get<ChainCommitment>(
++      CacheKey.commitment(params.commitmentId),
++    );
++
++    const invocation = await invokeContractMethod(
++      getContractId("attestationEngine"),
++      "record_attestation",
++      [
++        nativeToScVal(params.commitmentId),
++        new Address(params.attestorAddress).toScVal(),
++        nativeToScVal(params.complianceScore / ANALYTICS_SCALE),
++        nativeToScVal(params.violation),
++        nativeToScVal(params.feeEarned ?? "0"),
++        nativeToScVal(params.timestamp ?? new Date().toISOString()),
++        nativeToScVal(params.details ?? {}),
++      ],
++      "write",
++    );
++
++    // Increment successful actions counter on successful attestation recording
++    const countersAdapter = getCountersAdapter();
++    void countersAdapter.incrementSuccessfulActions(); // Fire and forget for metrics
++
++    void cache.delete(CacheKey.commitment(params.commitmentId));
++    if (cachedCommitment?.ownerAddress) {
++      void cache.delete(
++        CacheKey.userCommitments(cachedCommitment.ownerAddress),
++      );
++    }
++
++    // Add logging context to payload if needed
++    const eventPayload = { ...params, requestId: loggingContext?.requestId };
++    // (Potentially emit an event here)
++
++    return parseAttestationResult(invocation.value, invocation.txHash);
++  } catch (error) {
++    // Increment chain failures counter on blockchain operation failures
++    const countersAdapter = getCountersAdapter();
++    void countersAdapter.incrementChainFailures(); // Fire and forget for metrics
++
++    throw normalizeBackendError(error, {
++      code: "BLOCKCHAIN_CALL_FAILED",
++      message: "Unable to record attestation on chain.",
++      status: 502,
++      details: {
++        method: "record_attestation",
++        commitmentId: params.commitmentId,
++      },
++    });
++  }
++}
++
++export async function settleCommitmentOnChain(
++  params: SettleCommitmentOnChainParams,
++  loggingContext?: LoggingContext,
++): Promise<SettleCommitmentOnChainResult> {
++  try {
++    if (!params.commitmentId) {
++      throw new BackendError({
++        code: "BAD_REQUEST",
++        message: "Missing commitment id for settlement.",
++        status: 400,
++      });
++    }
++
++    // First, get the commitment to check if it's matured
++    const commitment = await getCommitmentFromChain(params.commitmentId, loggingContext);
++
++    // Check if commitment is matured (expired or can be settled)
++    if (commitment.status === "SETTLED") {
++      throw new BackendError({
++        code: "CONFLICT" as BackendErrorCode,
++        message: "Commitment has already been settled.",
++        status: 409,
++      });
++    }
++
++    if (commitment.status === "ACTIVE") {
++      // Invariant: An active commitment can only be settled if it has matured.
++      // If expiresAt is present, we check if the current time is past the expiry time.
++      // If expiresAt is missing, we err on the side of safety and block settlement
++      // to prevent un-matured commitments from being settled prematurely.
++      if (commitment.expiresAt) {
++        const expiryTime = new Date(commitment.expiresAt).getTime();
++        const now = new Date().getTime();
++        if (now < expiryTime) {
++          throw new BackendError({
++            code: "NOT_MATURED",
++            message: "Commitment has not matured yet and cannot be settled.",
++            status: 400,
++          });
++        }
++      } else {
++        throw new BackendError({
++          code: "NOT_MATURED",
++          message: "Commitment maturity information is missing. Cannot settle.",
++          status: 400,
++        });
++      }
++    }
++
++    // Call the settlement function on the contract
++    const invocation = await invokeContractMethod(
++      getContractId("commitmentCore"),
++      "settle_commitment",
++      [
++        nativeToScVal(params.commitmentId),
++        new Address(params.callerAddress ?? commitment.ownerAddress).toScVal(),
++      ],
++      "write",
++    );
++    // This method is intentionally aligned with the escrow contract alias in
++    // contracts/escrow/src/lib.rs so the backend can invoke settled releases
++    // using the expected ABI shape.
++
++    // Increment successful actions counter on successful settlement
++    const countersAdapter = getCountersAdapter();
++    void countersAdapter.incrementSuccessfulActions(); // Fire and forget for metrics
++
++    void cache.delete(CacheKey.commitment(params.commitmentId));
++    if (commitment.ownerAddress) {
++      void cache.delete(CacheKey.userCommitments(commitment.ownerAddress));
++    }
++
++    // Parse the settlement result
++    const result = asRecord(invocation.value);
++    const settlementAmount = asString(result.settlementAmount, "0");
++    const finalStatus = asString(result.finalStatus, "SETTLED");
++
++    return {
++      settlementAmount,
++      finalStatus,
++      txHash: invocation.txHash,
++      reference: invocation.txHash
++        ? undefined
++        : "TODO_CHAIN_CALL_SETTLE_COMMITMENT",
++    };
++  } catch (error) {
++    // Increment chain failures counter on blockchain operation failures
++    const countersAdapter = getCountersAdapter();
++    void countersAdapter.incrementChainFailures(); // Fire and forget for metrics
++
++    throw normalizeBackendError(error, {
++      code: "BLOCKCHAIN_CALL_FAILED",
++      message: "Unable to settle commitment on chain.",
++      status: 502,
++      details: {
++        method: "settle_commitment",
++        commitmentId: params.commitmentId,
++        requestId: loggingContext?.requestId,
++      },
++    });
++  }
++}
++
++export async function fundEscrowOnChain(
++  params: FundEscrowOnChainParams,
++): Promise<FundEscrowOnChainResult> {
++  try {
++    if (!params.commitmentId) {
++      throw new BackendError({
++        code: "BAD_REQUEST",
++        message: "Missing commitment id for funding.",
++        status: 400,
++      });
++    }
++
++    if (params.callerAddress) {
++      validateOwnerAddress(params.callerAddress);
++    }
++
++    const commitment = await getCommitmentFromChain(params.commitmentId);
++
++    if (!commitment) {
++      throw new BackendError({
++        code: "NOT_FOUND",
++        message: "Commitment not found.",
++        status: 404,
++        details: { commitmentId: params.commitmentId },
++      });
++    }
++
++    if (commitment.status !== "CREATED") {
++      throw new BackendError({
++        code: "CONFLICT",
++        message: "Only created commitments can be funded.",
++        status: 409,
++        details: { commitmentId: params.commitmentId, status: commitment.status },
++      });
++    }
++
++    const callerAddress = params.callerAddress ?? commitment.ownerAddress;
++    if (!callerAddress || callerAddress !== commitment.ownerAddress) {
++      throw new BackendError({
++        code: "FORBIDDEN",
++        message: "Only the commitment owner may fund this commitment.",
++        status: 403,
++        details: { commitmentId: params.commitmentId, callerAddress },
++      });
++    }
++
++    const invocation = await invokeContractMethod(
++      getContractId("commitmentCore"),
++      "fund_escrow",
++      [
++        nativeToScVal(params.commitmentId),
++        new Address(callerAddress).toScVal(),
++      ],
++      "write",
++    );
++
++    const countersAdapter = getCountersAdapter();
++    void countersAdapter.incrementSuccessfulActions();
++
++    void cache.delete(CacheKey.commitment(params.commitmentId));
++    if (commitment.ownerAddress) {
++      void cache.delete(CacheKey.userCommitments(commitment.ownerAddress));
++    }
++
++    return {
++      commitmentId: params.commitmentId,
++      txHash: invocation.txHash,
++      contractVersion: invocation.version,
++      reference: invocation.txHash ? undefined : "TODO_CHAIN_CALL_FUND_ESCROW",
++    };
++  } catch (error) {
++    const countersAdapter = getCountersAdapter();
++    void countersAdapter.incrementChainFailures();
++
++    throw normalizeBackendError(error, {
++      code: "BLOCKCHAIN_CALL_FAILED",
++      message: "Unable to fund escrow on chain.",
++      status: 502,
++      details: {
++        method: "fund_escrow",
++        commitmentId: params.commitmentId,
++      },
++    });
++  }
++}
++
++export async function earlyExitCommitmentOnChain(
++  params: EarlyExitCommitmentOnChainParams,
++  loggingContext?: LoggingContext,
++): Promise<EarlyExitCommitmentOnChainResult> {
++  try {
++    if (!params.commitmentId) {
++      throw new BackendError({
++        code: "BAD_REQUEST",
++        message: "Missing commitment id for early exit.",
++        status: 400,
++      });
++    }
++
++    const commitment = await getCommitmentFromChain(params.commitmentId, loggingContext);
++
++    if (commitment.status === "SETTLED") {
++      throw new BackendError({
++        code: "CONFLICT",
++        message:
++          "Commitment has already been settled and cannot be exited early.",
++        status: 409,
++      });
++    }
++
++    if (commitment.status === "EARLY_EXIT") {
++      throw new BackendError({
++        code: "CONFLICT",
++        message: "Commitment has already been exited early.",
++        status: 409,
++      });
++    }
++
++    if (commitment.status === "VIOLATED") {
++      throw new BackendError({
++        code: "CONFLICT",
++        message: "Commitment has been violated and cannot be exited early.",
++        status: 409,
++      });
++    }
++
++    const invocation = await invokeContractMethod(
++      getContractId("commitmentCore"),
++      "early_exit_commitment",
++      [params.commitmentId, params.callerAddress ?? commitment.ownerAddress],
++      "write",
++    );
++
++    const result = asRecord(invocation.value);
++    const exitAmount = asString(result.exitAmount, "0");
++    const penaltyAmount = asString(result.penaltyAmount, "0");
++    const finalStatus = asString(result.finalStatus, "EARLY_EXIT");
++
++    return {
++      exitAmount,
++      penaltyAmount,
++      finalStatus,
++      txHash: invocation.txHash,
++      contractVersion: invocation.version,
++      reference: invocation.txHash ? undefined : `TODO_CHAIN_CALL_EARLY_EXIT`,
++    };
++  } catch (error) {
++    throw normalizeBackendError(error, {
++      code: "BLOCKCHAIN_CALL_FAILED",
++      message: "Unable to exit commitment early on chain.",
++      status: 502,
++      details: {
++        method: "early_exit_commitment",
++        commitmentId: params.commitmentId,
++      },
++    });
++  }
++}
++
++export async function openDisputeOnChain(
++  params: DisputeOnChainParams,
++): Promise<DisputeOnChainResult> {
++  try {
++    if (!params.commitmentId) {
++      throw new BackendError({
++        code: "BAD_REQUEST",
++        message: "Missing commitment id for dispute.",
++        status: 400,
++      });
++    }
++
++    const commitment = await getCommitmentFromChain(params.commitmentId);
++
++    if (commitment.status === "SETTLED" || commitment.status === "EARLY_EXIT") {
++      throw new BackendError({
++        code: "CONFLICT",
++        message: "Cannot dispute a commitment that is already settled or exited.",
++        status: 409,
++      });
++    }
++
++    if (commitment.status === "DISPUTED") {
++      throw new BackendError({
++        code: "CONFLICT",
++        message: "Commitment is already in dispute.",
++        status: 409,
++      });
++    }
++
++    const invocation = await invokeContractMethod(
++      getContractId("commitmentCore"),
++      "early_exit_commitment",
++      [params.commitmentId, params.callerAddress ?? commitment.ownerAddress],
++      "write",
++    );
++
++    const result = asRecord(invocation.value);
++    const disputeId = asString(result.disputeId ?? result.id) || `dsp-${params.commitmentId}`;
++    const status = asString(result.finalStatus, "DISPUTED");
++
++    await cache.delete(CacheKey.commitment(params.commitmentId));
++    if (commitment.ownerAddress) {
++      await cache.delete(CacheKey.userCommitments(commitment.ownerAddress));
++    }
++
++    return {
++      commitmentId: params.commitmentId,
++      disputeId,
++      status,
++      txHash: invocation.txHash,
++      disputedAt: new Date().toISOString(),
++    };
++  } catch (error) {
++    throw normalizeBackendError(error, {
++      code: "BLOCKCHAIN_CALL_FAILED",
++      message: "Unable to open dispute on chain.",
++      status: 502,
++      details: {
++        method: "early_exit_commitment",
++        commitmentId: params.commitmentId,
++      },
++    });
++  }
++}
++
++export async function resolveDisputeOnChain(
++  params: ResolveDisputeOnChainParams,
++): Promise<ResolveDisputeOnChainResult> {
++  try {
++    if (!params.commitmentId) {
++      throw new BackendError({
++        code: "BAD_REQUEST",
++        message: "Missing commitment id for dispute resolution.",
++        status: 400,
++      });
++    }
++
++    const commitment = await getCommitmentFromChain(params.commitmentId);
++
++    if (commitment.status !== "DISPUTED") {
++      throw new BackendError({
++        code: "CONFLICT",
++        message: "Can only resolve a commitment that is currently in dispute.",
++        status: 409,
++      });
++    }
++
++    const invocation = await invokeContractMethod(
++      getContractId("commitmentCore"),
++      "resolve_dispute",
++      [params.commitmentId, params.resolution, params.notes ?? ""],
++      "write",
++    );
++
++    const result = asRecord(invocation.value);
++    const disputeId = asString(result.disputeId ?? result.id);
++    const finalStatus = asString(result.finalStatus, "ACTIVE");
++
++    // Status changed — invalidate detail and owner list.
++    await cache.delete(CacheKey.commitment(params.commitmentId));
++    if (commitment.ownerAddress) {
++      await cache.delete(CacheKey.userCommitments(commitment.ownerAddress));
++    }
++    logInfo(undefined, "[cache] invalidated commitment after dispute resolution", {
++      commitmentId: params.commitmentId,
++    });
++
++    return {
++      commitmentId: params.commitmentId,
++      disputeId: disputeId || `dsp-${params.commitmentId}`,
++      resolution: params.resolution,
++      finalStatus,
++      txHash: invocation.txHash,
++      resolvedAt: new Date().toISOString(),
++    };
++  } catch (error) {
++    throw normalizeBackendError(error, {
++      code: "BLOCKCHAIN_CALL_FAILED",
++      message: "Unable to resolve dispute on chain.",
++      status: 502,
++      details: {
++        method: "resolve_dispute",
++        commitmentId: params.commitmentId,
++        requestId: loggingContext?.requestId,
++      },
++    });
++  }
++}


### PR DESCRIPTION
Fixes #1602

route.ts already imports ChainCommitment (not Commitment), so the issue as
filed was stale. The real break: @/lib/backend/services/contracts.ts was
deleted along with 15 of its transitive deps in 1ecce7d2, an unrelated-looking
commit that wiped ~2500 files from master. This restores that closure from the
last commit where it built cleanly, plus a few latent type errors in
contracts.ts that would've failed tsc --noEmit regardless (undefined
FundEscrowOnChain* types, undefined READ_RETRY_CONFIG, a stray
normalizeContractError call, a mistyped openDisputeOnChain return).

Scope: only the files route.ts + commitmentHistory.ts need to compile — not a
full revert of 1ecce7d2. That commit likely needs a maintainer's attention
beyond this PR.