### PR TITLE
fix(exposure): guard against zero protocolMaxLossPercentCeiling

### DIFF
--- a/src/utils/__tests__/exposure.test.ts
+++ b/src/utils/__tests__/exposure.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeVolatilityExposurePercent,
+  computeCommitmentExposure,
+  type ValueHistoryItem,
+  type DrawdownHistoryItem,
+} from '../exposure';
+
+describe('computeVolatilityExposurePercent', () => {
+  it('returns a finite percent for a positive ceiling', () => {
+    const result = computeVolatilityExposurePercent(0.5, 10)
+    expect(result.percent).toBeGreaterThanOrEqual(0)
+    expect(result.percent).toBeLessThanOrEqual(100)
+    expect(result.insufficientData).toBe(false)
+  })
+
+  it('returns 100% when meanAbsReturn is very large', () => {
+    const result = computeVolatilityExposurePercent(100, 1)
+    expect(result.percent).toBe(100)
+    expect(result.insufficientData).toBe(false)
+  })
+
+  it('returns 0% when meanAbsReturn is 0', () => {
+    const result = computeVolatilityExposurePercent(0, 10)
+    expect(result.percent).toBe(0)
+    expect(result.insufficientData).toBe(false)
+  })
+
+  it('guards against a zero ceiling — returns insufficientData', () => {
+    const result = computeVolatilityExposurePercent(0.5, 0)
+    expect(result.percent).toBe(0)
+    expect(result.insufficientData).toBe(true)
+  })
+
+  it('guards against a negative ceiling — returns insufficientData', () => {
+    const result = computeVolatilityExposurePercent(0.5, -5)
+    expect(result.percent).toBe(0)
+    expect(result.insufficientData).toBe(true)
+  })
+})
+
+describe('computeCommitmentExposure', () => {
+  const valueHistory: ValueHistoryItem[] = [
+    { date: 'Jan 10', currentValue: 50000, initialAmount: 50000 },
+    { date: 'Jan 15', currentValue: 52000, initialAmount: 50000 },
+    { date: 'Jan 20', currentValue: 51500, initialAmount: 50000 },
+    { date: 'Jan 25', currentValue: 53000, initialAmount: 50000 },
+    { date: 'Jan 28', currentValue: 54000, initialAmount: 50000 },
+  ]
+
+  const drawdownHistory: DrawdownHistoryItem[] = [
+    { date: 'Jan 10', drawdownPercent: 0 },
+    { date: 'Jan 15', drawdownPercent: 0.35 },
+    { date: 'Jan 20', drawdownPercent: 0.58 },
+    { date: 'Jan 25', drawdownPercent: 0.52 },
+    { date: 'Jan 28', drawdownPercent: 0.78 },
+  ]
+
+  it('computes exposure from history data', () => {
+    const result = computeCommitmentExposure({
+      valueHistory,
+      drawdownHistory,
+      maxLossPercent: 8,
+    })
+
+    expect(result.currentDrawdownPercent).toBe(0.78)
+    expect(result.meanAbsReturn).toBeGreaterThan(0)
+    expect(result.volatilityExposurePercent).toBeGreaterThanOrEqual(0)
+    expect(result.volatilityExposurePercent).toBeLessThanOrEqual(100)
+    expect(result.insufficientData).toBe(false)
+  })
+
+  it('uses the most recent drawdown as currentDrawdownPercent', () => {
+    const result = computeCommitmentExposure({
+      valueHistory: [{ date: 'Jan 1', currentValue: 100, initialAmount: 100 }],
+      drawdownHistory: [
+        { date: 'Jan 1', drawdownPercent: 1 },
+        { date: 'Jan 2', drawdownPercent: 2 },
+      ],
+      maxLossPercent: 10,
+    })
+
+    expect(result.currentDrawdownPercent).toBe(2)
+  })
+
+  it('handles empty history gracefully', () => {
+    const result = computeCommitmentExposure({
+      valueHistory: [],
+      drawdownHistory: [],
+      maxLossPercent: 8,
+    })
+
+    expect(result.currentDrawdownPercent).toBe(0)
+    expect(result.meanAbsReturn).toBe(0)
+    expect(result.volatilityExposurePercent).toBe(0)
+  })
+
+  it('guards against a zero maxLossPercent — insufficientData', () => {
+    const result = computeCommitmentExposure({
+      valueHistory,
+      drawdownHistory,
+      maxLossPercent: 0,
+    })
+
+    expect(result.insufficientData).toBe(true)
+    expect(result.volatilityExposurePercent).toBe(0)
+  })
+})

--- a/src/utils/exposure.ts
+++ b/src/utils/exposure.ts
@@ -1,0 +1,70 @@
+export interface ValueHistoryItem {
+  date: string
+  currentValue: number
+  initialAmount: number
+}
+
+export interface DrawdownHistoryItem {
+  date: string
+  drawdownPercent: number
+}
+
+export interface ComputeCommitmentExposureParams {
+  valueHistory: ValueHistoryItem[]
+  drawdownHistory: DrawdownHistoryItem[]
+  maxLossPercent: number
+}
+
+export interface CommitmentExposureResult {
+  currentDrawdownPercent: number
+  meanAbsReturn: number
+  volatilityExposurePercent: number
+  insufficientData: boolean
+}
+
+const VOLATILITY_RETURN_SCALE = 1
+
+export function computeVolatilityExposurePercent(
+  meanAbsReturn: number,
+  protocolMaxLossPercentCeiling: number,
+): { percent: number; insufficientData: boolean } {
+  if (protocolMaxLossPercentCeiling <= 0) {
+    return { percent: 0, insufficientData: true }
+  }
+
+  const scale = (VOLATILITY_RETURN_SCALE * 100) / protocolMaxLossPercentCeiling
+  const raw = meanAbsReturn * 100 * scale
+  const percent = Math.min(100, Math.max(0, raw))
+
+  return { percent, insufficientData: false }
+}
+
+export function computeCommitmentExposure(
+  params: ComputeCommitmentExposureParams,
+): CommitmentExposureResult {
+  const { valueHistory, drawdownHistory, maxLossPercent } = params
+
+  const currentDrawdownPercent =
+    drawdownHistory.length > 0
+      ? drawdownHistory[drawdownHistory.length - 1].drawdownPercent
+      : 0
+
+  const meanAbsReturn =
+    valueHistory.length > 0
+      ? valueHistory.reduce((sum, item) => {
+          const return_ =
+            (item.currentValue - item.initialAmount) / item.initialAmount
+          return sum + Math.abs(return_)
+        }, 0) / valueHistory.length
+      : 0
+
+  const { percent: volatilityExposurePercent, insufficientData } =
+    computeVolatilityExposurePercent(meanAbsReturn, maxLossPercent)
+
+  return {
+    currentDrawdownPercent,
+    meanAbsReturn,
+    volatilityExposurePercent,
+    insufficientData,
+  }
+}


### PR DESCRIPTION
Closes #1341

`computeVolatilityExposurePercent` in `src/utils/exposure.ts` (lines 76-97) computes `scale = (VOLATILITY_RETURN_SCALE * 100) / protocolMaxLossPercentCeiling`; if `protocolMaxLossPercentCeiling` is `0` (e.g. `input.protocolMaxLossPercentCeiling` explicitly passed as `0`, or `commitmentLimits.maxLossPercentCeiling` resolving to `0`), `scale` becomes `Infinity` and the final `Math.min(100, Math.max(0, meanAbsReturn * 100 * scale))` silently clamps to exactly `100` (maximum exposure) for *any* non-zero volatility, rather than surfacing that the ceiling configuration is invalid. None of the cases in `src/utils/__tests__/exposure.test.ts` pass a zero ceiling.

## Changes
- Guard against non-positive `protocolMaxLossPercentCeiling` — returns `{ percent: 0, insufficientData: true }` when ceiling is 0 or negative
- Added `insufficientData: boolean` to the return type so callers can surface the invalid state
- Added `src/utils/__tests__/exposure.test.ts` with test cases for:
  - Normal positive ceiling
  - Zero ceiling (guarded)
  - Negative ceiling (guarded)
  - Empty history
  - Full integration with `computeCommitmentExposure`