### PR TITLE
fix(docs): rename ok -> success in API response docs to match actual code

### DIFF
--- a/docs/api-response-format.md
+++ b/docs/api-response-format.md
@@ -1,0 +1,263 @@
+# Standard JSON Response & Error Format
+
+**Reference:** [#105 - Standard JSON Response & Error Format](https://github.com/Commitlabs-Org/Commitlabs-Frontend/issues/105)
+
+All API routes in this project return a consistent JSON envelope so that the frontend and any consumers can handle responses uniformly.
+
+> **Canonical reference:** For the full response contract (including correlation IDs, metadata, testing patterns, and migration guide), see [unified-api-response-contract.md](./unified-api-response-contract.md).
+
+---
+
+## Success shape
+
+```json
+{
+  "success": true,
+  "data": { ... },
+  "meta": { "total": 42, "page": 1 }
+}
+```
+
+| Field     | Type                      | Always present | Description                              |
+|-----------|---------------------------|----------------|------------------------------------------|
+| `success` | `true`                    | ✅              | Discriminant — always `true` on success  |
+| `data`    | `T`                       | ✅              | The response payload                     |
+| `meta`    | `Record<string, unknown>` | ❌              | Optional pagination / extra context      |
+
+---
+
+## Error shape
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Commitment not found.",
+    "details": { ... }
+  }
+}
+```
+
+| Field           | Type      | Always present | Description                                      |
+|-----------------|-----------|----------------|--------------------------------------------------|
+| `success`       | `false`   | ✅              | Discriminant — always `false` on error           |
+| `error.code`    | `string`  | ✅              | Short machine-readable code (see table below)    |
+| `error.message` | `string`  | ✅              | Human-readable message safe for UI display       |
+| `error.details` | `unknown` | ❌              | Extra context (never expose sensitive data here) |
+
+---
+
+## Error codes
+
+| Code                   | HTTP status | Error class           |
+|------------------------|-------------|-----------------------|
+| `BAD_REQUEST`          | 400         | `BadRequestError`     |
+| `VALIDATION_ERROR`     | 400         | `ValidationError`     |
+| `UNAUTHORIZED`         | 401         | `UnauthorizedError`   |
+| `FORBIDDEN`            | 403         | `ForbiddenError`      |
+| `NOT_FOUND`            | 404         | `NotFoundError`       |
+| `CONFLICT`             | 409         | `ConflictError`       |
+| `TOO_MANY_REQUESTS`    | 429         | `TooManyRequestsError`|
+| `INTERNAL_ERROR`       | 500         | `InternalError`       |
+
+---
+
+## Validation errors (`VALIDATION_ERROR`)
+
+When a request fails Zod validation, the error response uses a canonical
+`fieldErrors` shape inside `error.details` so the UI can render field-level
+messages consistently:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid request data.",
+    "details": {
+      "fieldErrors": [
+        { "field": "user.profile.name", "message": "Expected string, received number" },
+        { "field": "items[0].qty",      "message": "Number must be greater than 0" },
+        { "field": "",                  "message": "Password and confirmation do not match" }
+      ]
+    }
+  }
+}
+```
+
+Rules for `field`:
+
+- Dot notation for nested object keys (`user.profile.name`).
+- Bracket notation for array indices (`items[0].qty`, `matrix[0][1]`).
+- An empty string (`""`) denotes a root-level issue (for example a
+  refinement applied to the whole body).
+- `(field, message)` pairs are deduplicated so the same message is never
+  rendered twice for the same field.
+
+### Producing a canonical validation error
+
+In any route wrapped with `withApiHandler`, convert the `ZodError` using
+`validationErrorFromZod`:
+
+```ts
+import { withApiHandler } from '@/lib/backend/withApiHandler';
+import { validationErrorFromZod } from '@/lib/backend/validationErrors';
+
+const BodySchema = z.object({ /* ... */ });
+
+export const POST = withApiHandler(async (req) => {
+    const parsed = BodySchema.safeParse(await req.json());
+    if (!parsed.success) {
+        throw validationErrorFromZod(parsed.error);
+    }
+    // ... happy path
+});
+```
+
+`mapZodErrorToFieldErrors(error)` is available if you need the
+`FieldError[]` list on its own (for logging, composition with other
+details, etc.).
+
+---
+
+## How to use
+
+### Returning a success response
+
+```ts
+import { ok } from '@/lib/backend/apiResponse';
+
+// Simple success
+return ok({ status: 'healthy' });
+// → { success: true, data: { status: 'healthy' } }
+
+// With meta (e.g. pagination)
+return ok(items, { total: 100, page: 2, pageSize: 20 });
+// → { success: true, data: [...], meta: { total: 100, page: 2, pageSize: 20 } }
+```
+
+> **Note:** The `ok()` helper function produces a response with `"success": true` in the JSON body. The function name `ok` and the JSON field name `success` are intentionally different — the function name is a convenience shorthand, while `success` is the canonical discriminant field in the response envelope.
+
+### Returning an error response
+
+```ts
+import { fail } from '@/lib/backend/apiResponse';
+
+return fail('NOT_FOUND', 'Commitment not found.', undefined, 404);
+// → { success: false, error: { code: 'NOT_FOUND', message: 'Commitment not found.' } }
+```
+
+### Using typed error classes (recommended)
+
+Throw a typed error inside any route wrapped with `withApiHandler` — it will be caught and converted into the correct error response automatically.
+
+```ts
+import { withApiHandler } from '@/lib/backend/withApiHandler';
+import { ok } from '@/lib/backend/apiResponse';
+import { NotFoundError, ValidationError } from '@/lib/backend/errors';
+
+export const GET = withApiHandler(async (req) => {
+    const commitment = await findCommitment(id);
+    if (!commitment) {
+        throw new NotFoundError('Commitment');
+        // → 404: { success: false, error: { code: 'NOT_FOUND', message: 'Commitment not found.' } }
+    }
+    return ok(commitment);
+});
+```
+
+Available error classes (all from `@/lib/backend/errors`):
+
+| Class                 | Default status |
+|-----------------------|----------------|
+| `BadRequestError`     | 400            |
+| `ValidationError`     | 400            |
+| `UnauthorizedError`   | 401            |
+| `ForbiddenError`      | 403            |
+| `NotFoundError`       | 404            |
+| `ConflictError`       | 409            |
+| `TooManyRequestsError`| 429            |
+| `InternalError`       | 500            |
+
+### Full route example (health check)
+
+```ts
+// src/app/api/health/route.ts
+import { withApiHandler } from '@/lib/backend/withApiHandler';
+import { ok } from '@/lib/backend/apiResponse';
+
+export const GET = withApiHandler(async () => {
+    return ok({ status: 'healthy' });
+    // GET /api/health → 200 { success: true, data: { status: 'healthy' } }
+});
+```
+
+---
+
+## Client-side Fetch Helper (`apiClient.ts`)
+
+A shared client-side fetch wrapper (`src/lib/apiClient.ts`) is available to make API requests with built-in:
+- **Request Timeout**: Aborts automatically after a timeout (default 5000ms).
+- **Consistent Envelope Parsing**: Automatically unwraps `{ success: true, data: T }` envelopes or parses standard error envelopes.
+- **Typed Errors**: Throws a subclass of `Error` called `ApiError` containing the API-returned error code, message, and details.
+
+### Basic Usage
+
+Use convenience methods like `apiGet`, `apiPost`, `apiPut`, or `apiDelete`:
+
+```ts
+import { apiGet, ApiError } from '@/lib/apiClient';
+
+interface Commitment {
+  id: string;
+  status: string;
+}
+
+async function loadData() {
+  try {
+    const commitments = await apiGet<Commitment[]>('/api/commitments');
+    console.log(commitments);
+  } catch (err) {
+    if (err instanceof ApiError) {
+      console.error(`API Error [${err.code}]: ${err.message}`);
+    } else {
+      console.error('Network or other error:', err);
+    }
+  }
+}
+```
+
+### Low-level Custom Requests
+
+You can use the generic `apiFetch` for other methods or custom configurations:
+
+```ts
+import { apiFetch } from '@/lib/apiClient';
+
+const data = await apiFetch<MyResponseType>(
+  '/api/custom-endpoint',
+  {
+    method: 'PATCH',
+    headers: { 'X-Custom-Header': 'value' },
+  },
+  10000 // custom 10s timeout
+);
+```
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/lib/apiClient.ts`            | Client-side API fetch client with timeout & typed errors |
+| `src/lib/backend/apiResponse.ts` | `ok()` and `fail()` response helpers |
+| `src/lib/backend/errors.ts`      | Typed error classes with HTTP status codes |
+| `src/lib/backend/withApiHandler.ts` | HOF that catches `ApiError` and calls `fail()` |
+| `docs/api-response-format.md`    | This document |
+
+---
+
+*Created as part of issue #105. Update this document when new error codes are introduced.*
+

--- a/docs/backend-error-codes.md
+++ b/docs/backend-error-codes.md
@@ -1,0 +1,744 @@
+# Backend Error Code Registry and Guidelines
+
+> Last Updated: April 2026
+>
+> This document describes the centralized backend error code registry, error response format, and guidelines for clients and developers.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Error Response Format](#error-response-format)
+- [Error Code Registry](#error-code-registry)
+  - [4xx Client Errors](#4xx-client-errors)
+  - [5xx Server Errors](#5xx-server-errors)
+  - [Domain-Specific Codes](#domain-specific-codes)
+- [Client Handling Strategies](#client-handling-strategies)
+- [Developer Guidelines](#developer-guidelines)
+- [Testing Error Codes](#testing-error-codes)
+
+## Overview
+
+The Commitlabs backend uses a **centralized error code registry** to ensure:
+
+✅ **Consistency** — All errors use registered codes (no ad-hoc codes)  
+✅ **Documentation** — Each code is documented with meaning and client guidance  
+✅ **Retrievability** — Errors include HTTP status, code, message, and optional details  
+✅ **Safety** — Registry is validated in tests to prevent regressions
+
+### Key Files
+
+- **Source of Truth**: [`src/lib/backend/errorCodes.ts`](../src/lib/backend/errorCodes.ts)
+  - `ERROR_CODE_REGISTRY` — Complete registry with all error code definitions
+  - `getErrorCodeDefinition()` — Retrieve definition by code
+  - `validateErrorCodeRegistry()` — Validate registry integrity
+- **Error Classes**: [`src/lib/backend/errors.ts`](../src/lib/backend/errors.ts)
+  - `ApiError` — Base class for all errors
+  - Typed subclasses: `BadRequestError`, `UnauthorizedError`, `ForbiddenError`, etc.
+
+## Error Response Format
+
+All API errors follow a **standardized JSON format**:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Email must be a valid email address.",
+    "details": {
+      "field": "email",
+      "constraint": "email_format"
+    }
+  }
+}
+```
+
+### Response Fields
+
+| Field           | Type    | Description                                                               |
+| --------------- | ------- | ------------------------------------------------------------------------- |
+| `success`       | boolean | Always `false` for errors.                                                |
+| `error.code`    | string  | Registered error code (from registry).                                    |
+| `error.message` | string  | Human-readable error message for display.                                 |
+| `error.details` | object  | Optional context-specific details (e.g., validation errors, resource ID). |
+
+### HTTP Status Codes
+
+All errors include an appropriate HTTP status code:
+
+- **4xx** — Client error (request is incorrect or not authorized)
+- **5xx** — Server error (server failed to process valid request)
+
+## Error Code Registry
+
+This is the complete registry of all error codes. Each code maps to:
+
+- **Meaning** — What the error represents
+- **Status Code** — HTTP status code
+- **Client Handling** — Recommended client strategy
+- **Retriable** — Whether the request can be safely retried
+- **Description** — When the error is triggered
+
+### 4xx Client Errors
+
+#### `BAD_REQUEST` (400)
+
+**Meaning**: The request was malformed or contains invalid syntax.
+
+**Triggered By**:
+
+- Malformed JSON body
+- Invalid content-type header
+- Missing required HTTP headers
+- Protocol violations
+
+**Client Handling**:
+
+```javascript
+// Check request headers, content-type, and method
+// Do not retry — the error will persist until request is fixed
+console.error("Check your request format and headers");
+```
+
+**Retriable**: ❌ No
+
+---
+
+#### `VALIDATION_ERROR` (400)
+
+**Meaning**: Request body or query parameters failed validation.
+
+**Triggered By**:
+
+- Missing required fields
+- Invalid field type (e.g., string instead of number)
+- Field value out of range
+- Format violations (email, date, etc.)
+
+**Example**:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid request data.",
+    "details": {
+      "errors": [
+        { "field": "commitment_amount", "message": "Must be greater than 0" },
+        { "field": "end_date", "message": "Must be after start date" }
+      ]
+    }
+  }
+}
+```
+
+**Client Handling**:
+
+```javascript
+// Display validation errors in form
+response.error.details.errors.forEach((err) => {
+  displayFieldError(err.field, err.message);
+});
+```
+
+**Retriable**: ❌ No
+
+---
+
+#### `UNAUTHORIZED` (401)
+
+**Meaning**: Authentication credentials are missing, invalid, or expired.
+
+**Triggered By**:
+
+- Missing `Authorization` header
+- Invalid JWT token (malformed, wrong signature)
+- Expired token
+- Revoked session
+
+**Example**:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "UNAUTHORIZED",
+    "message": "Authentication required.",
+    "details": { "reason": "token_expired" }
+  }
+}
+```
+
+**Client Handling**:
+
+```javascript
+// 1. Attempt token refresh if refresh_token is available
+const newToken = await refreshAuthToken();
+if (newToken) {
+  // Retry request with new token
+  return retryRequest();
+}
+
+// 2. If no refresh token, redirect to login
+redirectToLogin();
+```
+
+**Retriable**: ✅ Yes (after token refresh)
+
+---
+
+#### `FORBIDDEN` (403)
+
+**Meaning**: Authenticated but lacks permission to perform the action.
+
+**Triggered By**:
+
+- User lacks required role (e.g., admin-only endpoint)
+- User is not the resource owner
+- Required scope not granted
+
+**Example**:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "You do not have permission to perform this action.",
+    "details": { "required_role": "admin" }
+  }
+}
+```
+
+**Client Handling**:
+
+```javascript
+// Display permission denied message
+toast.error("You lack permission for this action.");
+
+// Log for audit purposes
+auditLog.warn("Unauthorized access attempt", {
+  action: "settle_commitment",
+  user_id: getCurrentUserId(),
+});
+
+// Do not retry
+```
+
+**Retriable**: ❌ No
+
+---
+
+#### `NOT_FOUND` (404)
+
+**Meaning**: The requested resource does not exist.
+
+**Triggered By**:
+
+- Resource ID doesn't match any record
+- Soft-deleted resource
+- Resource moved or removed
+
+**Example**:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Commitment not found.",
+    "details": { "commitment_id": "cm_12345" }
+  }
+}
+```
+
+**Client Handling**:
+
+```javascript
+// Display not found message
+displayNotFoundPage();
+
+// Offer navigation alternatives
+suggestSearchOrBackButton();
+
+// Do not retry
+```
+
+**Retriable**: ❌ No
+
+---
+
+#### `CONFLICT` (409)
+
+**Meaning**: Request conflicts with the current resource state.
+
+**Triggered By**:
+
+- Resource already exists (duplicate)
+- Commitment already settled
+- Resource locked by another user
+- Incompatible state transition
+
+**Example**:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "CONFLICT",
+    "message": "Commitment already settled.",
+    "details": { "settled_at": "2026-04-20T10:30:00Z" }
+  }
+}
+```
+
+**Client Handling**:
+
+```javascript
+// 1. Display conflict message with details
+showConflictDialog(response.error.details);
+
+// 2. Fetch latest resource state
+const latest = await fetchCommitment(id);
+
+// 3. Prompt user to retry or take alternative action
+promptUserToRefreshAndRetry();
+```
+
+**Retriable**: ✅ Yes (after fetching fresh state)
+
+---
+
+#### `UNPROCESSABLE_ENTITY` (422)
+
+**Meaning**: Request is syntactically valid but semantically unprocessable.
+
+**Triggered By**:
+
+- Constraint violations (e.g., insufficient balance)
+- Business rule violations (e.g., allocation exceeds limit)
+- Invalid amount ranges
+
+**Example**:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "UNPROCESSABLE_ENTITY",
+    "message": "Allocation exceeds maximum allowed percentage.",
+    "details": { "max_percentage": 100, "attempted": 150 }
+  }
+}
+```
+
+**Client Handling**:
+
+```javascript
+// Show detailed error explaining constraint
+showConstraintError(response.error.details);
+
+// Offer user guidance on how to fix
+suggestAlternatives(response.error.details);
+
+// Do not retry with same data
+```
+
+**Retriable**: ❌ No
+
+---
+
+### 5xx Server Errors
+
+#### `INTERNAL_ERROR` (500)
+
+**Meaning**: Unexpected server-side failure.
+
+**Triggered By**:
+
+- Unhandled exception
+- Database error
+- Logic error in request handler
+- Memory exhaustion
+
+**Example**:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "INTERNAL_ERROR",
+    "message": "An unexpected error occurred. Please try again later.",
+    "details": { "request_id": "req_abc123" }
+  }
+}
+```
+
+**Client Handling**:
+
+```javascript
+// Display generic message
+showErrorToast("Something went wrong. Please try again.");
+
+// Implement exponential backoff
+await backoffAndRetry({
+  maxAttempts: 3,
+  baseDelay: 1000,
+  maxDelay: 10000,
+});
+
+// Log request ID for support
+console.error("Request ID:", response.error.details.request_id);
+```
+
+**Retriable**: ✅ Yes (with exponential backoff)
+
+---
+
+#### `BAD_GATEWAY` (502)
+
+**Meaning**: Invalid response from upstream server or service.
+
+**Triggered By**:
+
+- Blockchain RPC error
+- Database connection error
+- Upstream service returns invalid response
+
+**Client Handling**:
+
+```javascript
+// Display service unavailable message
+showErrorToast("Service temporarily unavailable. Retrying...");
+
+// Implement exponential backoff
+await backoffAndRetry();
+```
+
+**Retriable**: ✅ Yes (with exponential backoff)
+
+---
+
+#### `SERVICE_UNAVAILABLE` (503)
+
+**Meaning**: Service is temporarily unavailable (maintenance, overload, or degradation).
+
+**Client Handling**:
+
+```javascript
+// Respect Retry-After header
+const retryAfter = getRetryAfterHeader();
+await delay(retryAfter);
+return retryRequest();
+```
+
+**Retriable**: ✅ Yes (respect Retry-After header)
+
+---
+
+#### `GATEWAY_TIMEOUT` (504)
+
+**Meaning**: Upstream service did not respond within the timeout window.
+
+**Triggered By**:
+
+- Blockchain node slow response
+- External API timeout
+- Long-running database query
+
+**Client Handling**:
+
+```javascript
+// Implement exponential backoff with longer timeout
+await backoffAndRetry({
+  timeout: 30000, // Increase from default
+  maxAttempts: 2,
+});
+```
+
+**Retriable**: ✅ Yes
+
+---
+
+### Domain-Specific Codes
+
+#### `BLOCKCHAIN_UNAVAILABLE` (503)
+
+**Meaning**: Blockchain service is temporarily unavailable.
+
+**Triggered By**:
+
+- RPC provider unreachable
+- Network connectivity issues
+- Blockchain node undergoing maintenance
+
+**Client Handling**:
+
+```javascript
+// Similar to SERVICE_UNAVAILABLE
+// Retry with exponential backoff
+```
+
+**Retriable**: ✅ Yes
+
+---
+
+#### `BLOCKCHAIN_CALL_FAILED` (500)
+
+**Meaning**: Blockchain operation failed (transaction reverted, execution error, etc.).
+
+**Triggered By**:
+
+- Smart contract revert
+- Invalid transaction parameters
+- Insufficient gas or balance
+- Logic error in blockchain operation
+
+**Example**:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "BLOCKCHAIN_CALL_FAILED",
+    "message": "Transaction reverted with reason: Insufficient balance.",
+    "details": {
+      "reason": "Insufficient balance",
+      "tx_hash": "0x..."
+    }
+  }
+}
+```
+
+**Client Handling**:
+
+```javascript
+// Display detailed blockchain error
+showBlockchainError(response.error.details);
+
+// Usually not retriable — user must fix underlying issue
+```
+
+The backend centralizes blockchain error normalization in `src/lib/backend/errors.ts` so contract invocation failures are classified consistently across the service layer.
+
+**Retriable**: ❌ No
+
+---
+
+## Client Handling Strategies
+
+### Exponential Backoff
+
+Implement exponential backoff for retriable 5xx errors:
+
+```javascript
+async function retryWithBackoff(fn, maxAttempts = 3) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt === maxAttempts || !isRetriable(error)) {
+        throw error;
+      }
+      const delay = Math.min(1000 * Math.pow(2, attempt - 1), 10000);
+      const jitter = Math.random() * 1000;
+      await new Promise((resolve) => setTimeout(resolve, delay + jitter));
+    }
+  }
+}
+```
+
+### Error Codes by Retriability
+
+**Retriable Errors** (4xx):
+
+- `UNAUTHORIZED` (after token refresh)
+- `CONFLICT` (after fetching fresh state)
+
+**Retriable Errors** (5xx):
+
+- `INTERNAL_ERROR`
+- `BAD_GATEWAY`
+- `SERVICE_UNAVAILABLE`
+- `GATEWAY_TIMEOUT`
+- `BLOCKCHAIN_UNAVAILABLE`
+
+**Non-Retriable Errors**:
+
+- `BAD_REQUEST`
+- `VALIDATION_ERROR`
+- `FORBIDDEN`
+- `NOT_FOUND`
+- `UNPROCESSABLE_ENTITY`
+- `BLOCKCHAIN_CALL_FAILED`
+
+## Developer Guidelines
+
+### Using Error Classes
+
+Always use typed error classes from `src/lib/backend/errors.ts`:
+
+```typescript
+import {
+  ValidationError,
+  NotFoundError,
+  ConflictError,
+  ForbiddenError,
+} from "@/lib/backend/errors";
+
+// ✅ Good: Throw typed error with context
+throw new ValidationError("Email must be unique.", {
+  field: "email",
+  value: userEmail,
+});
+
+throw new NotFoundError("Commitment", { commitmentId });
+
+throw new ConflictError("Commitment already settled.", {
+  settled_at: new Date().toISOString(),
+});
+
+// ❌ Bad: Ad-hoc error codes or messages
+throw new Error("Something is wrong"); // No error code!
+```
+
+### Enforcing Registry Usage
+
+All error codes **must** be registered in `ERROR_CODE_REGISTRY`. The registry is validated in tests:
+
+```typescript
+// In test suite
+import { validateErrorCodeRegistry } from "@/lib/backend/errorCodes";
+
+describe("Error Code Registry", () => {
+  it("should contain no duplicates", () => {
+    const validation = validateErrorCodeRegistry();
+    expect(validation.valid).toBe(true);
+    expect(validation.duplicates).toHaveLength(0);
+    expect(validation.errors).toHaveLength(0);
+  });
+});
+```
+
+### Adding New Error Codes
+
+To add a new error code:
+
+1. **Add to registry** in `src/lib/backend/errorCodes.ts`:
+
+   ```typescript
+   export const ERROR_CODE_REGISTRY: Record<string, ErrorCodeDefinition> = {
+     // ... existing codes
+     MY_NEW_ERROR: {
+       code: "MY_NEW_ERROR",
+       statusCode: 400,
+       meaning: "Clear description...",
+       clientHandling: "How clients should handle this...",
+       retriable: false,
+       description: "When this error is triggered...",
+     },
+   };
+   ```
+
+2. **Create typed error class** if needed in `src/lib/backend/errors.ts`:
+
+   ```typescript
+   export class MyNewError extends ApiError {
+     constructor(message = "Default message.", details?: unknown) {
+       super(message, "MY_NEW_ERROR", 400, details);
+       this.name = "MyNewError";
+     }
+   }
+   ```
+
+3. **Update documentation** in this file with explanation and examples.
+
+4. **Add tests** to ensure the code is registered and validated.
+
+## Testing Error Codes
+
+### Unit Test: Validate Registry
+
+```typescript
+// tests/lib/backend/errorCodes.test.ts
+import {
+  ERROR_CODE_REGISTRY,
+  validateErrorCodeRegistry,
+  getErrorCodesByStatus,
+} from "@/lib/backend/errorCodes";
+
+describe("ERROR_CODE_REGISTRY", () => {
+  it("should contain all required error codes", () => {
+    const requiredCodes = [
+      "BAD_REQUEST",
+      "VALIDATION_ERROR",
+      "UNAUTHORIZED",
+      "FORBIDDEN",
+      "NOT_FOUND",
+      "CONFLICT",
+      "UNPROCESSABLE_ENTITY",
+      "TOO_MANY_REQUESTS",
+      "INTERNAL_ERROR",
+      "BAD_GATEWAY",
+      "SERVICE_UNAVAILABLE",
+      "GATEWAY_TIMEOUT",
+    ];
+
+    requiredCodes.forEach((code) => {
+      expect(ERROR_CODE_REGISTRY[code]).toBeDefined();
+    });
+  });
+
+  it("should have no duplicate error codes", () => {
+    const validation = validateErrorCodeRegistry();
+    expect(validation.valid).toBe(true);
+    expect(validation.duplicates).toHaveLength(0);
+  });
+
+  it("should have all required fields in each definition", () => {
+    const validation = validateErrorCodeRegistry();
+    expect(validation.errors).toHaveLength(0);
+  });
+
+  it("should group codes by status correctly", () => {
+    const grouped = getErrorCodesByStatus();
+    expect(grouped[400]).toBeDefined(); // Client errors
+    expect(grouped[500]).toBeDefined(); // Server errors
+  });
+
+  it("should retrieve definition by code", () => {
+    const { getErrorCodeDefinition } = require("@/lib/backend/errorCodes");
+    const def = getErrorCodeDefinition("VALIDATION_ERROR");
+    expect(def.code).toBe("VALIDATION_ERROR");
+    expect(def.statusCode).toBe(400);
+    expect(def.retriable).toBe(false);
+  });
+});
+```
+
+### Integration Test: Error Responses
+
+```typescript
+// tests/api/sample.test.ts
+describe("API Error Responses", () => {
+  it("should return VALIDATION_ERROR for invalid input", async () => {
+    const response = await fetch("/api/commitments", {
+      method: "POST",
+      body: JSON.stringify({ amount: "invalid" }),
+    });
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.code).toBe("VALIDATION_ERROR");
+    expect(data.success).toBe(false);
+  });
+});
+```
+
+## References
+
+- **Error Code Registry**: [`src/lib/backend/errorCodes.ts`](../src/lib/backend/errorCodes.ts)
+- **Error Classes**: [`src/lib/backend/errors.ts`](../src/lib/backend/errors.ts)
+- **API Response Format**: [`src/lib/backend/apiResponse.ts`](../src/lib/backend/apiResponse.ts)
+- **Error Wrapper**: [`src/lib/backend/withApiHandler.ts`](../src/lib/backend/withApiHandler.ts)

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,430 @@
+# Rate Limit (429) and Server (5xx) Error Handling
+**Reference:** [#133 - Define consistent behavior for rate limit and server errors](https://github.com/Commitlabs-Org/Commitlabs-Frontend/issues/133)
+
+This document defines how the Commitlabs-Frontend backend responds to rate limiting (429) and server-side errors (5xx), and how developers should use the error helpers and `withApiHandler` wrapper.
+
+---
+
+## Overview
+
+All API routes in this project must use the `withApiHandler` wrapper from `src/utils/withApiHandler.ts`. This ensures that 429 and 5xx errors are always returned in a consistent JSON shape, with the correct HTTP status codes and headers — including `Retry-After` where appropriate.
+
+---
+
+## Standard Error Response Shape
+
+Every error response follows this structure:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": 429,
+    "type": "RATE_LIMIT_EXCEEDED",
+    "message": "Too many requests. Please wait before trying again.",
+    "retryAfter": 60
+  }
+}
+```
+
+| Field | Type | Always Present | Description |
+|-------|------|----------------|-------------|
+| `success` | `boolean` | ✅ | Always `false` for errors |
+| `error.code` | `number` | ✅ | HTTP status code |
+| `error.type` | `string` | ✅ | Machine-readable error type |
+| `error.message` | `string` | ✅ | Human-readable message safe for UI display |
+| `error.retryAfter` | `number` | ❌ | Seconds to wait — only on 429 and 503 |
+| `error.details` | `string` | ❌ | Internal detail — development mode only, never in production |
+
+---
+
+## Error Types Reference
+
+### 429 — Rate Limit Exceeded
+
+**When to use:** The client has sent too many requests in a given time window.
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": 429,
+    "type": "RATE_LIMIT_EXCEEDED",
+    "message": "Too many requests. Please wait before trying again.",
+    "retryAfter": 60
+  }
+}
+```
+
+**HTTP Headers returned:**
+```
+Content-Type: application/json
+Retry-After: 60
+```
+
+---
+
+### 500 — Internal Server Error
+
+**When to use:** An unexpected error occurred with no specific identifiable cause.
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": 500,
+    "type": "INTERNAL_SERVER_ERROR",
+    "message": "An unexpected error occurred. Please try again later."
+  }
+}
+```
+
+---
+
+### 502 — Bad Gateway
+
+**When to use:** An upstream service (e.g. Soroban RPC node) returned an invalid or unreadable response.
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": 502,
+    "type": "BAD_GATEWAY",
+    "message": "A upstream service returned an invalid response. Please try again later."
+  }
+}
+```
+
+---
+
+### 503 — Service Unavailable
+
+**When to use:** The service is temporarily down, overloaded, or undergoing maintenance.
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": 503,
+    "type": "SERVICE_UNAVAILABLE",
+    "message": "The service is temporarily unavailable. Please try again later.",
+    "retryAfter": 30
+  }
+}
+```
+
+**HTTP Headers returned:**
+```
+Content-Type: application/json
+Retry-After: 30
+```
+
+---
+
+### 504 — Gateway Timeout
+
+**When to use:** An upstream service (e.g. Soroban RPC) did not respond within the expected time.
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": 504,
+    "type": "GATEWAY_TIMEOUT",
+    "message": "The request timed out. Please try again."
+  }
+}
+```
+
+---
+
+## How to Use in API Routes
+
+### Basic Usage
+
+Wrap every API route handler with `withApiHandler`:
+
+```ts
+// src/app/api/commitments/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { withApiHandler } from "@/utils/withApiHandler";
+
+export const GET = withApiHandler(async (req: NextRequest) => {
+  // your normal handler logic here
+  const data = await fetchCommitments();
+  return NextResponse.json({ success: true, data });
+});
+```
+
+---
+
+### Triggering a 429 Response
+
+Throw a `RateLimitError` anywhere inside your handler:
+
+```ts
+import { withApiHandler, RateLimitError } from "@/utils/withApiHandler";
+
+export const POST = withApiHandler(async (req: NextRequest) => {
+  const isRateLimited = await checkRateLimit(req);
+
+  if (isRateLimited) {
+    throw new RateLimitError(120); // retry after 2 minutes
+  }
+
+  // continue with normal logic...
+});
+```
+
+---
+
+### Triggering a 5xx Response
+
+Throw a `ServerError` with the appropriate status code:
+
+```ts
+import { withApiHandler, ServerError } from "@/utils/withApiHandler";
+
+export const GET = withApiHandler(async (req: NextRequest) => {
+  try {
+    const result = await callSorobanRpc();
+    return NextResponse.json({ success: true, data: result });
+  } catch (err) {
+    // RPC node unreachable — respond with 502
+    throw new ServerError(502, "Soroban RPC node did not respond");
+  }
+});
+```
+
+---
+
+### Using Error Helpers Directly (Outside of withApiHandler)
+
+If you need to build an error response manually without the wrapper:
+
+```ts
+import { rateLimitError, resolveServerError, getErrorHeaders } from "@/utils/errorHelpers";
+import { NextResponse } from "next/server";
+
+// Manual 429
+const body = rateLimitError(60);
+const headers = getErrorHeaders(body);
+return NextResponse.json(body, { status: 429, headers });
+
+// Manual 5xx
+const body = resolveServerError(503);
+const headers = getErrorHeaders(body);
+return NextResponse.json(body, { status: 503, headers });
+```
+
+---
+
+## Retry-After Header
+
+The `Retry-After` HTTP header is automatically added by `withApiHandler` and `getErrorHeaders()` for:
+
+| Status Code | Default Retry-After |
+|-------------|---------------------|
+| 429 | 60 seconds |
+| 503 | 30 seconds |
+
+Clients and frontend code should read this header and wait the indicated number of seconds before retrying. Do not retry immediately on 429 or 503.
+
+---
+
+## Production vs Development
+
+The `details` field in the error response is **only included in development mode** (`NODE_ENV === "development"`). In production, this field is always omitted to avoid leaking internal system information to clients.
+
+| Environment | `details` field |
+|-------------|-----------------|
+| `development` | ✅ Included |
+| `production` | ❌ Omitted |
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/utils/errorHelpers.ts` | Error factory functions and HTTP header helpers |
+| `src/utils/withApiHandler.ts` | HOF wrapper for API routes — catches and translates all errors |
+| `docs/error-handling.md` | This document |
+
+---
+
+## Checklist for Reviewers
+
+When reviewing any PR that adds or modifies API routes, verify:
+
+- [ ] The route handler is wrapped with `withApiHandler`
+- [ ] Rate limiting throws `RateLimitError` — not a raw `NextResponse`
+- [ ] Upstream failures throw `ServerError` with the correct status code
+- [ ] No raw `500` responses are returned without going through the helpers
+- [ ] `details` is never hardcoded in production responses
+- [ ] `Retry-After` header is present on all 429 and 503 responses
+
+---
+
+---
+
+## Client Retry Strategy
+
+When a client receives a `429` or `503` response, it should not retry immediately. Use the `Retry-After` header value (in seconds) as guidance.
+
+### Recommended Retry Algorithm
+
+Use **exponential backoff with jitter** to avoid thundering herd:
+
+```ts
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit = {},
+  maxRetries = 5
+): Promise<Response> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(url, options);
+
+    if (response.status !== 429 && response.status !== 503) {
+      return response;
+    }
+
+    if (attempt === maxRetries) {
+      throw new Error(`Exceeded max retries after ${maxRetries} attempts`);
+    }
+
+    const retryAfter = response.headers.get('Retry-After');
+    let waitMs: number;
+
+    if (retryAfter) {
+      // Honor the server-specified delay
+      waitMs = Number(retryAfter) * 1000;
+    } else {
+      // Exponential backoff: 1s, 2s, 4s, 8s, 16s (capped)
+      waitMs = Math.min(1000 * 2 ** attempt, 16_000);
+    }
+
+    // Add ±20% jitter to prevent synchronized retries
+    const jitter = waitMs * (0.8 + Math.random() * 0.4);
+    await new Promise((resolve) => setTimeout(resolve, jitter));
+  }
+
+  throw new Error('Unreachable');
+}
+```
+
+### Retry Decision Matrix
+
+| Status | Should Retry | Strategy |
+|--------|-------------|----------|
+| 400 | No | Fix request first |
+| 401 | No | Re-authenticate |
+| 403 | No | Check permissions |
+| 404 | No | Resource doesn't exist |
+| 409 | No | Resolve conflict first |
+| 429 | Yes | Wait `Retry-After`, then backoff |
+| 500 | Yes | Exponential backoff |
+| 502 | Yes | Exponential backoff |
+| 503 | Yes | Wait `Retry-After`, then backoff |
+| 504 | Yes | Exponential backoff |
+
+### Frontend Integration
+
+```ts
+// Example: wrapper that auto-retries on 429/503
+async function apiRequest(url: string, init?: RequestInit) {
+  const res = await fetch(url, init);
+
+  if (res.status === 429 || res.status === 503) {
+    const retryAfter = res.headers.get('Retry-After');
+    const delay = retryAfter ? Number(retryAfter) * 1000 : 1000;
+    await new Promise((r) => setTimeout(r, delay));
+    return apiRequest(url, init); // retry once
+  }
+
+  return res;
+}
+```
+
+---
+
+## Transaction Error Recovery Mapping
+
+`src/app/transaction-error/page.tsx` maps backend-normalized chain errors into three user-facing recovery categories. The page keeps the shared `ErrorLayout` and `ErrorButton` shell, focuses the `<h1>` on load, and always provides both a `Try Again` path and a `Go to Dashboard` path.
+
+| UI category | Backend codes | Recovery behavior |
+|-------------|---------------|-------------------|
+| `rejected` | `VALIDATION_ERROR`, `BAD_REQUEST`, `UNPROCESSABLE_ENTITY`, `CONFLICT`, `SIGNATURE_INVALID`, `USER_REJECTED` | Explain that the transaction was not accepted, prompt the user to review wallet approval, parameters, and current commitment state, then try again. |
+| `timed-out` | `GATEWAY_TIMEOUT`, `RPC_TIMEOUT`, `BLOCKCHAIN_UNAVAILABLE`, `SERVICE_UNAVAILABLE` | Treat the transaction outcome as unknown. If a hash is available, point the user to Stellar Expert before retrying so the same signed transaction is not resubmitted blindly. |
+| `failed` | `BLOCKCHAIN_CALL_FAILED`, `BAD_GATEWAY`, `INTERNAL_ERROR`, unknown codes | Explain that execution or upstream chain handling failed, show the normalized code, and let the user retry after checking balance, fees, and contract state. |
+
+The backend source of truth remains `src/lib/backend/errorCodes.ts` and the Soroban normalization in `src/lib/backend/services/contracts.ts`. When adding a new normalized chain error, update this table and the page mapping together.
+
+---
+
+*This document was created as part of issue #133. Update it as new error types are introduced.*
+
+---
+
+## Client Error Reporting
+
+**Reference:** [#792 – Add a client error boundary with structured error reporting](https://github.com/Commitlabs-Org/Commitlabs-Frontend/issues/792)
+
+`src/lib/observability/reportError.ts` centralises client-side error capture into a tested, redaction-aware reporter that is called automatically by the Next.js route error boundary (`src/app/error.tsx`).
+
+### Structured record
+
+Every captured error produces a `ClientErrorRecord`:
+
+```ts
+interface ClientErrorRecord {
+  message: string        // redacted error message
+  digest: string | undefined  // Next.js error digest (if available)
+  route: string          // window.location.pathname at time of error
+  timestamp: string      // ISO 8601 UTC timestamp
+  stack?: string         // stack trace — omitted in production
+}
+```
+
+### Redaction
+
+The `message` field is scanned for `key=value` / `key: value` patterns. Any key matching the sensitive denylist is replaced with `[REDACTED]` before the record leaves the browser.
+
+Sensitive keys: `token`, `authorization`, `password`, `secret`, `key`, `privatekey`, `publickey`, `mnemonic`, `seed`, `auth`, `bearer`, `apikey`, `api_key`, `session`, `cookie`, `csrf`, `signature`, `nonce`.
+
+### Transport (pluggable)
+
+The default transport writes to `console.error`. Replace it before your app mounts with `setErrorTransport`:
+
+```ts
+import { setErrorTransport } from '@/lib/observability/reportError'
+
+// Wire up your observability sink (Sentry, Datadog, custom ingest…)
+setErrorTransport((record) => {
+  fetch('/api/client-errors', {
+    method: 'POST',
+    body: JSON.stringify(record),
+  })
+})
+```
+
+No runtime dependency is added — the transport is a plain function and the default is a console call.
+
+### How it is wired
+
+`src/app/error.tsx` calls `reportError` inside a `useEffect` that re-runs whenever the `error` prop changes:
+
+```ts
+useEffect(() => {
+  reportError(error, window.location.pathname)
+}, [error])
+```
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `src/lib/observability/reportError.ts` | Reporter, `ClientErrorRecord` type, `setErrorTransport` |
+| `src/lib/observability/__tests__/reportError.test.ts` | Unit tests (transport, redaction, stack-trace behaviour) |
+| `src/app/error.tsx` | Route error boundary — calls `reportError` on mount/update |

--- a/docs/settlement-and-early-exit-flows.md
+++ b/docs/settlement-and-early-exit-flows.md
@@ -1,0 +1,96 @@
+# Settlement and Early Exit UI Flows
+
+This document describes the user-facing settlement and early-exit flows in the CommitLabs frontend. It ties the visible states to the modal components and API routes so product, frontend, and API changes stay aligned.
+
+## Source Files
+
+- `src/components/modals/SettlementModal.tsx`
+- `src/components/CommitmentEarlyExitModal/CommitmentEarlyExitModal.tsx`
+- [test-settle.md](testing/test-settle.md)
+- Settlement endpoints: `POST /api/commitments/[id]/settle` and settlement preview/status routes when present in the commitment detail flow
+- Early-exit endpoints: `POST /api/commitments/[id]/early-exit` and `POST /api/commitments/[id]/early-exit/preview`
+
+## Settlement Flow
+
+The settlement UI represents two high-level states through `SettlementModalState`:
+
+- `ineligible`: settlement cannot be completed yet or cannot be retried for the current commitment state.
+- `settled`: settlement completed and the UI can show the final `settlementAmount`.
+
+The ineligible state is intentionally specific. `getSettlementIneligibleReasonCopy(reason)` maps backend or orchestration copy into a stable reason category, tone, badge, title, message, and CTA label. Keep this mapping synchronized with API error messages so users see actionable guidance instead of a generic failure.
+
+| Category | Tone | User Meaning | Typical Next Action |
+| --- | --- | --- | --- |
+| `not_matured` | `temporary` | The commitment has not reached maturity yet. | Return later and retry settlement after maturity. |
+| `already_settled` | `terminal` | Settlement already completed for this commitment. | Review the settlement details rather than retrying. |
+| `disputed` | `terminal` | A dispute or violation state prevents normal settlement. | Review the commitment detail page for dispute handling. |
+| `early_exit` | `terminal` | The commitment was already closed by early exit. | Review exit details; do not offer settlement again. |
+| `unknown` | `unknown` | The UI could not classify the backend reason. | Show a review-oriented message and avoid destructive action. |
+
+### Settlement API Contract
+
+`POST /api/commitments/[id]/settle` settles a matured commitment and returns final funds to the owner. [test-settle.md](testing/test-settle.md) documents the current response shape:
+
+```json
+{
+  "success": true,
+  "data": {
+    "commitmentId": "test-id",
+    "settlementAmount": "1000.50",
+    "finalStatus": "SETTLED",
+    "txHash": "abc123...",
+    "reference": "TODO_CHAIN_CALL_SETTLE_COMMITMENT",
+    "settledAt": "2026-02-26T11:30:00.000Z"
+  }
+}
+```
+
+Expected error cases include:
+
+- `400 BAD_REQUEST`: commitment has not matured yet.
+- `409 CONFLICT`: commitment has already been settled.
+- `404 NOT_FOUND`: commitment id does not exist.
+
+When these messages change, update `getSettlementIneligibleReasonCopy` and this document in the same PR.
+
+## Early Exit Flow
+
+The early-exit modal is intentionally stricter than a normal confirmation dialog because it records an irreversible on-chain action and may deduct a penalty.
+
+The modal displays:
+
+- `originalAmount`: the committed amount before exit.
+- `penaltyPercent`: the penalty rate presented to the user.
+- `penaltyAmount`: the amount deducted immediately.
+- `netReceiveAmount`: the amount returned after the penalty.
+
+The confirmation safeguards are:
+
+1. The user must acknowledge the irreversible effects with the checkbox.
+2. The user must type the exact `commitmentId` into the confirmation field.
+3. The confirm button remains disabled until both safeguards pass.
+
+The warning copy should continue to communicate that the user loses the penalty amount immediately, the commitment is recorded as an early exit on-chain, the action cannot be reversed, and future yield is forfeited.
+
+### Penalty Preview and Grace Period
+
+Use the preview endpoint before showing final early-exit numbers. The preview response should drive the modal fields above so the user can compare the committed amount, penalty, and net refund before confirming. If the backend reports a penalty-free grace period, surface that as part of the preview state and keep the final confirmation copy consistent with the actual penalty displayed.
+
+### Early-Exit API Contract
+
+Use the preview route for read-only calculations and the execution route for the irreversible action:
+
+- `POST /api/commitments/[id]/early-exit/preview`: returns penalty and refund figures without changing commitment state.
+- `POST /api/commitments/[id]/early-exit`: records the early exit and returns the final transaction/result data.
+
+The execution endpoint should not be called until the modal safeguards are satisfied.
+
+## Documentation Maintenance Checklist
+
+Update this document when any of the following change:
+
+- Settlement API response shape or error messages.
+- `getSettlementIneligibleReasonCopy` categories, tones, badges, titles, messages, or CTAs.
+- Early-exit preview or execution endpoint paths.
+- Penalty, grace-period, or net-refund calculations.
+- Confirmation safeguards such as acknowledgement text or type-to-confirm behavior.

--- a/docs/testing/test-auth.md
+++ b/docs/testing/test-auth.md
@@ -1,0 +1,80 @@
+# Stellar Wallet Authentication Test
+
+This document demonstrates how to test the Stellar wallet authentication flow.
+
+## API Endpoints
+
+### 1. Get Nonce
+```
+POST /api/auth/nonce
+Content-Type: application/json
+
+{
+  "address": "GD5TIP5CKNSV7QZP2FGV6BOB7ZHQG4T4S5R6K4YZJ2MJJQ6XZM4XJQ5Z"
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "nonce": "a39ae240bfa1af0fee7c610cc37a6fa2",
+    "message": "Sign in to CommitLabs: a39ae240bfa1af0fee7c610cc37a6fa2",
+    "expiresAt": "2026-02-26T11:16:29.123Z"
+  }
+}
+```
+
+### 2. Verify Signature
+```
+POST /api/auth/verify
+Content-Type: application/json
+
+{
+  "address": "GD5TIP5CKNSV7QZP2FGV6BOB7ZHQG4T4S5R6K4YZJ2MJJQ6XZM4XJQ5Z",
+  "message": "Sign in to CommitLabs: a39ae240bfa1af0fee7c610cc37a6fa2",
+  "signature": "SIGNATURE_FROM_WALLET"
+}
+```
+
+**Success Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "verified": true,
+    "address": "GD5TIP5CKNSV7QZP2FGV6BOB7ZHQG4T4S5R6K4YZJ2MJJQ6XZM4XJQ5Z",
+    "message": "Signature verified successfully",
+    "sessionToken": "session_GD5TIP5CKNSV7QZP2FGV6BOB7ZHQG4T4S5R6K4YZJ2MJJQ6XZM4XJQ5Z_1740566185123",
+    "sessionType": "placeholder"
+  }
+}
+```
+
+## Testing with Freighter
+
+1. **Get a nonce** using the first endpoint
+2. **Sign the message** using Freighter wallet:
+   ```javascript
+   const result = await window.freighter.signMessage(message);
+   const signature = result.signature;
+   ```
+3. **Verify the signature** using the second endpoint
+
+## Security Features
+
+- **Rate limiting** on both endpoints
+- **Nonce expiration** (5 minutes)
+- **One-time use nonces** (consumed after verification)
+- **Message format validation**
+- **Address-to-nonce binding**
+
+## TODO Items
+
+- [ ] Replace in-memory nonce storage with Redis/database
+- [ ] Implement proper JWT session tokens
+- [ ] Add Stellar address format validation
+- [ ] Add comprehensive logging
+- [ ] Implement session management endpoints
+- [ ] Add CSRF protection for session-based auth

--- a/docs/testing/test-settle.md
+++ b/docs/testing/test-settle.md
@@ -1,0 +1,95 @@
+# Commitment Settlement Endpoint Test
+
+## API Endpoint
+
+### POST /api/commitments/[id]/settle
+
+Settles a matured commitment and returns the final funds to the owner.
+
+## Request Format
+
+```json
+{
+  "callerAddress": "GD5TIP5CKNSV7QZP2FGV6BOB7ZHQG4T4S5R6K4YZJ2MJJQ6XZM4XJQ5Z" // optional
+}
+```
+
+## Response Format
+
+### Success Response (200)
+```json
+{
+  "success": true,
+  "data": {
+    "commitmentId": "test-id",
+    "settlementAmount": "1000.50",
+    "finalStatus": "SETTLED",
+    "txHash": "abc123...",
+    "reference": "TODO_CHAIN_CALL_SETTLE_COMMITMENT",
+    "settledAt": "2026-02-26T11:30:00.000Z"
+  }
+}
+```
+
+### Error Responses
+
+#### 400 - Bad Request (Non-mature commitment)
+```json
+{
+  "success": false,
+  "error": {
+    "code": "BAD_REQUEST",
+    "message": "Commitment has not matured yet and cannot be settled."
+  }
+}
+```
+
+#### 409 - Conflict (Already settled)
+```json
+{
+  "success": false,
+  "error": {
+    "code": "CONFLICT", 
+    "message": "Commitment has already been settled."
+  }
+}
+```
+
+#### 404 - Not Found
+```json
+{
+  "success": false,
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Commitment not found."
+  }
+}
+```
+
+## Features Implemented
+
+✅ **Maturity Validation**: Checks if commitment is expired/matured
+✅ **Status Validation**: Prevents settling already settled commitments  
+✅ **Rate Limiting**: Applied to prevent abuse
+✅ **Request Validation**: Validates JSON and input parameters
+✅ **Error Handling**: Proper error responses with appropriate status codes
+✅ **Logging**: Comprehensive logging for settlement attempts
+✅ **Standard Response Format**: Uses the shared API response format
+
+## Settlement Logic
+
+1. **Validate Request**: Check commitment ID and request body
+2. **Fetch Commitment**: Get commitment details from blockchain
+3. **Maturity Check**: Verify commitment can be settled (expired or matured)
+4. **Status Check**: Ensure commitment isn't already settled
+5. **Call Settlement**: Invoke `settle_commitment` on smart contract
+6. **Return Result**: Provide settlement amount and transaction details
+
+## TODO Items for Production
+
+- [ ] Add comprehensive Stellar address validation
+- [ ] Implement proper transaction fee handling
+- [ ] Add settlement deadline checks beyond just expiration
+- [ ] Implement settlement queue for high-volume scenarios
+- [ ] Add settlement history tracking
+- [ ] Implement settlement notification system

--- a/docs/unified-api-response-contract.md
+++ b/docs/unified-api-response-contract.md
@@ -1,0 +1,418 @@
+# Unified API Response Contract Documentation
+
+## Overview
+
+This document describes the unified API response contract implemented across all CommitLabs API endpoints. The contract ensures consistent response formats, proper error handling, and request correlation tracking.
+
+## Response Structure
+
+### Success Response
+
+All successful responses follow this structure:
+
+```json
+{
+  "success": true,
+  "data": { ... },
+  "meta": {
+    "correlationId": "string",
+    "timestamp": "ISO 8601 string",
+    "...": "additional metadata"
+  }
+}
+```
+
+**Fields:**
+- `success`: Always `true` for successful responses
+- `data`: The actual response payload (varies by endpoint)
+- `meta`: Metadata object containing:
+  - `correlationId`: Request correlation identifier for tracing
+  - `timestamp`: ISO 8601 timestamp of response generation
+  - Additional metadata fields as needed (pagination, totals, etc.)
+
+### Error Response
+
+All error responses follow this structure:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable error message",
+    "correlationId": "string",
+    "timestamp": "ISO 8601 string",
+    "details": { ... }
+  }
+}
+```
+
+**Fields:**
+- `success`: Always `false` for error responses
+- `error`: Error object containing:
+  - `code`: Machine-readable error code (see Error Codes section)
+  - `message`: Human-readable error description
+  - `correlationId`: Request correlation identifier
+  - `timestamp`: ISO 8601 timestamp of error occurrence
+  - `details`: Optional additional error context (omitted in production for sensitive errors)
+
+## Correlation IDs
+
+### Purpose
+
+Correlation IDs help track requests across services and logs, enabling:
+- Request tracing through the system
+- Debugging distributed workflows
+- Performance monitoring
+- Error correlation
+
+### Implementation
+
+- **Generation**: 32-character hexadecimal string (16 bytes of entropy)
+- **Extraction**: Priority order:
+  1. `x-correlation-id` header
+  2. `x-request-id` header (fallback)
+  3. Auto-generated if neither present
+- **Propagation**: Included in response headers and response body
+
+### Usage Examples
+
+**Client-side:**
+```javascript
+// Generate correlation ID for new request
+const correlationId = crypto.randomUUID().replace(/-/g, '');
+
+// Make request with correlation ID
+const response = await fetch('/api/endpoint', {
+  headers: {
+    'x-correlation-id': correlationId,
+    'content-type': 'application/json',
+  },
+});
+
+// Extract correlation ID from response
+const responseCorrelationId = response.headers.get('x-correlation-id');
+```
+
+**Server-side:**
+```typescript
+// Correlation ID automatically handled by withApiHandler
+export const GET = withApiHandler(async (req, context, correlationId) => {
+  // Use correlationId for logging
+  logger.info('Processing request', { correlationId });
+  
+  return ok(data, undefined, 200, correlationId);
+});
+```
+
+## Error Codes
+
+### Standard Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `BAD_REQUEST` | 400 | Malformed or invalid request |
+| `VALIDATION_ERROR` | 400 | Request validation failed |
+| `UNAUTHORIZED` | 401 | Authentication required or failed |
+| `FORBIDDEN` | 403 | Insufficient permissions |
+| `NOT_FOUND` | 404 | Resource not found |
+| `CONFLICT` | 409 | Resource conflict (duplicate, state mismatch) |
+| `TOO_MANY_REQUESTS` | 429 | Rate limit exceeded |
+| `UNPROCESSABLE_ENTITY` | 422 | Well-formed but semantically invalid request |
+| `INTERNAL_ERROR` | 500 | Unexpected server error |
+| `BAD_GATEWAY` | 502 | Upstream service failure |
+| `SERVICE_UNAVAILABLE` | 503 | Service temporarily unavailable |
+| `GATEWAY_TIMEOUT` | 504 | Upstream service timeout |
+
+### Domain-Specific Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `BLOCKCHAIN_CALL_FAILED` | 502 | Blockchain interaction failed |
+| `BLOCKCHAIN_UNAVAILABLE` | 503 | Blockchain service unavailable |
+| `NONCE_EXPIRED` | 400 | Authentication nonce expired |
+| `SIGNATURE_INVALID` | 400 | Cryptographic signature verification failed |
+
+## Implementation Guidelines
+
+### Route Handler Pattern
+
+All API routes must use the `withApiHandler` wrapper and follow this pattern:
+
+```typescript
+import { withApiHandler } from '@/lib/backend/withApiHandler';
+import { ok, fail } from '@/lib/backend/apiResponse';
+import { ValidationError } from '@/lib/backend/errors';
+
+export const GET = withApiHandler(async (req, context, correlationId) => {
+  // 1. Extract and validate inputs
+  const param = context.params.id;
+  if (!param) {
+    throw new ValidationError('Missing required parameter');
+  }
+
+  // 2. Process request
+  const result = await processRequest(param);
+
+  // 3. Return unified response
+  return ok(result, undefined, 200, correlationId);
+});
+```
+
+### Response Helpers
+
+#### Success Responses
+
+```typescript
+// Basic success response
+return ok(data, undefined, 200, correlationId);
+
+// Success with custom status
+return ok(data, undefined, 201, correlationId);
+
+// Success with metadata
+return ok(data, { total: 42, page: 1 }, 200, correlationId);
+
+// Success with status as second parameter
+return ok(data, 201, undefined, correlationId);
+```
+
+#### Error Responses
+
+```typescript
+// Let withApiHandler handle ApiError subclasses
+throw new ValidationError('Invalid input', { field: 'email' });
+
+// Manual error response (rarely needed)
+return fail('VALIDATION_ERROR', 'Invalid input', { field: 'email' }, 400, correlationId);
+```
+
+### Error Handling Strategy
+
+1. **Validation Errors**: Use `ValidationError` subclass
+2. **Authentication Errors**: Use `UnauthorizedError` subclass
+3. **Authorization Errors**: Use `ForbiddenError` subclass
+4. **Not Found**: Use `NotFoundError` subclass
+5. **Conflicts**: Use `ConflictError` subclass
+6. **Rate Limiting**: Use `TooManyRequestsError` subclass
+7. **Unknown Errors**: Let `withApiHandler` handle automatically
+
+## Migration Guide
+
+### Before (Mixed Patterns)
+
+```typescript
+// Old pattern 1: NextResponse.json
+return NextResponse.json({ data: result }, { status: 200 });
+
+// Old pattern 2: Custom response shape
+return Response.json({
+  success: true,
+  payload: result,
+  metadata: { timestamp: new Date() }
+});
+
+// Old pattern 3: Manual error handling
+return Response.json({
+  error: 'Something went wrong',
+  code: 'ERROR_500'
+}, { status: 500 });
+```
+
+### After (Unified Contract)
+
+```typescript
+// New unified pattern
+export const GET = withApiHandler(async (req, context, correlationId) => {
+  const result = await getData();
+  return ok(result, undefined, 200, correlationId);
+});
+
+// Errors handled automatically
+export const POST = withApiHandler(async (req, context, correlationId) => {
+  if (!req.body) {
+    throw new ValidationError('Request body required');
+  }
+  // ... processing
+});
+```
+
+## Testing Guidelines
+
+### Unit Testing Response Contract
+
+```typescript
+import { ok, fail, getCorrelationId } from '@/lib/backend/apiResponse';
+
+describe('Response Contract', () => {
+  it('should create proper success response', () => {
+    const correlationId = 'test-123';
+    const response = ok({ data: 'test' }, undefined, 200, correlationId);
+    
+    expect(response.headers.get('x-correlation-id')).toBe(correlationId);
+    
+    return response.json().then(json => {
+      expect(json.success).toBe(true);
+      expect(json.data).toEqual({ data: 'test' });
+      expect(json.meta.correlationId).toBe(correlationId);
+    });
+  });
+});
+```
+
+### Integration Testing Routes
+
+```typescript
+describe('API Contract Compliance', () => {
+  it('should follow contract for GET /api/endpoint', async () => {
+    const req = new NextRequest('http://localhost:3000/api/endpoint', {
+      headers: { 'x-correlation-id': 'test-456' }
+    });
+    
+    const response = await GET(req, { params: {} }, 'test-456');
+    
+    expect(response.headers.get('x-correlation-id')).toBe('test-456');
+    
+    const json = await response.json();
+    expect(json).toHaveProperty('success');
+    expect(json).toHaveProperty('meta.correlationId', 'test-456');
+    expect(json).toHaveProperty('meta.timestamp');
+  });
+});
+```
+
+## Security Considerations
+
+### Error Information Leakage
+
+- **Production**: Error details omitted for security-sensitive errors
+- **Development**: Full error details included for debugging
+- **Logging**: All errors logged with correlation IDs for internal tracking
+
+### Correlation ID Security
+
+- **Client-Generated**: Accept client-provided correlation IDs but validate format
+- **Server-Generated**: Use cryptographically secure random generation
+- **Header Injection**: Sanitize correlation ID extraction to prevent header injection
+
+### Response Header Security
+
+- **Correlation Headers**: Always included in responses for tracing
+- **Security Headers**: Maintained alongside correlation headers
+- **CORS**: Consider correlation ID implications for cross-origin requests
+
+## Performance Considerations
+
+### Correlation ID Overhead
+
+- **Generation**: Minimal overhead using Node.js crypto.randomBytes()
+- **Header Processing**: Negligible impact on request processing
+- **Memory**: Correlation IDs are short-lived strings
+
+### Response Serialization
+
+- **Consistent Structure**: Predictable JSON serialization performance
+- **Metadata Size**: Keep metadata minimal for better performance
+- **Timestamp Format**: ISO 8601 strings are efficient and standardized
+
+## Monitoring and Observability
+
+### Metrics to Track
+
+1. **Response Contract Compliance**: Percentage of responses following contract
+2. **Correlation ID Propagation**: Success rate of correlation ID tracking
+3. **Error Code Distribution**: Frequency of different error types
+4. **Response Times**: Performance impact of unified contract
+
+### Logging Integration
+
+```typescript
+// Enhanced logging with correlation ID
+logger.info('Request completed', {
+  correlationId,
+  endpoint: '/api/commitments',
+  duration: Date.now() - startTime,
+  statusCode: response.status,
+});
+
+// Error logging with full context
+logger.error('Request failed', error, {
+  correlationId,
+  endpoint: '/api/commitments',
+  statusCode: error.statusCode,
+  errorCode: error.code,
+});
+```
+
+## Best Practices
+
+### Do's
+
+- ✅ Always use `withApiHandler` for route handlers
+- ✅ Include correlation ID in all responses
+- ✅ Use appropriate `ApiError` subclasses
+- ✅ Keep error messages user-friendly
+- ✅ Add timestamps to all responses
+- ✅ Test both success and error scenarios
+
+### Don'ts
+
+- ❌ Return raw `NextResponse.json()` objects
+- ❌ Create custom response shapes
+- ❌ Expose internal error details to clients
+- ❌ Skip correlation ID propagation
+- ❌ Mix response patterns within the same API
+- ❌ Ignore error handling best practices
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Missing Correlation ID**: Check `withApiHandler` usage
+2. **Inconsistent Response Format**: Ensure all routes use `ok()`/`fail()` helpers
+3. **Error Not Propagating**: Verify `ApiError` subclass usage
+4. **Header Not Set**: Check response helper function calls
+
+### Debug Mode
+
+Enable debug logging for response contract issues:
+
+```bash
+DEBUG=api-response:* npm run dev
+```
+
+This will provide detailed logging for:
+- Correlation ID generation/extraction
+- Response contract validation
+- Error handling flow
+- Header processing
+
+## Future Enhancements
+
+### Planned Improvements
+
+1. **Response Validation**: Automatic contract validation middleware
+2. **Enhanced Metadata**: Structured metadata schemas per endpoint
+3. **Correlation Context**: Extended correlation context for distributed tracing
+4. **Performance Metrics**: Built-in response time tracking
+5. **API Documentation**: Auto-generated OpenAPI specs from contract
+
+### Extensibility
+
+The unified contract is designed to be extensible:
+- New metadata fields can be added without breaking changes
+- Additional error codes can be introduced as needed
+- Correlation ID format can evolve while maintaining compatibility
+- Response helpers can be extended for specialized use cases
+
+## Conclusion
+
+The unified API response contract provides a consistent, secure, and maintainable foundation for all CommitLabs API endpoints. By following this contract, developers ensure:
+
+- **Consistency**: Predictable response formats across all endpoints
+- **Observability**: Complete request tracing with correlation IDs
+- **Security**: Proper error handling without information leakage
+- **Maintainability**: Centralized response logic and error handling
+- **Testing**: Comprehensive test coverage for response patterns
+
+This contract serves as the foundation for reliable API communication and enables robust monitoring, debugging, and maintenance of the CommitLabs platform.


### PR DESCRIPTION
## Summary

Fixes #1597

Replaces all occurrences of `ok` with `success` in API response documentation files to match the actual code in `src/lib/backend/apiResponse.ts`, which uses `success` as the discriminant field.

## Problem

The API response utility generates JSON envelopes with `success: true/false`, but multiple documentation files still referenced `ok: true/false`. This happened because commit 1ecce7d2 ("add openapi.yaml documents") mass-deleted most backend files and docs, and subsequent restoration didn't fully reconcile the field name.

## Changes

- `docs/api-response-format.md`: Updated all examples, tables, and code samples from `ok` → `success`. Added clarification note that the `ok()` helper function name intentionally differs from the `success` JSON field.
- `docs/testing/test-settle.md`: Updated response examples.
- `docs/testing/test-auth.md`: Updated response examples.
- `docs/settlement-and-early-exit-flows.md`: Updated settlement API contract example.
- `docs/unified-api-response-contract.md`: Restored from history (already correctly uses `success`).
- `docs/backend-error-codes.md`: Restored from history (already correctly uses `success`).
- `docs/error-handling.md`: Restored from history.

## Verification

- All docs now consistently use `success` as the discriminant field.
- The `ok()` function name in code examples is preserved (it's the function name, not the field).
- No remaining `"ok"` references in any docs file (verified with grep).