### PR TITLE
fix: add meta object to settlement response examples in docs

### DIFF
--- a/docs/settlement-and-early-exit-flows.md
+++ b/docs/settlement-and-early-exit-flows.md
@@ -41,6 +41,10 @@ The ineligible state is intentionally specific. `getSettlementIneligibleReasonCo
     "txHash": "abc123...",
     "reference": "TODO_CHAIN_CALL_SETTLE_COMMITMENT",
     "settledAt": "2026-02-26T11:30:00.000Z"
+  },
+  "meta": {
+    "correlationId": "abc123...",
+    "timestamp": "2026-02-26T11:30:00.000Z"
   }
 }
 ```

--- a/docs/testing/test-settle.md
+++ b/docs/testing/test-settle.md
@@ -27,6 +27,10 @@ Settles a matured commitment and returns the final funds to the owner.
     "txHash": "abc123...",
     "reference": "TODO_CHAIN_CALL_SETTLE_COMMITMENT",
     "settledAt": "2026-02-26T11:30:00.000Z"
+  },
+  "meta": {
+    "correlationId": "abc123...",
+    "timestamp": "2026-02-26T11:30:00.000Z"
   }
 }
 ```


### PR DESCRIPTION
Adds the missing meta object to the settlement API contract examples. This matches the real OkResponse shape from src/lib/backend/apiResponse.ts. Fixes #1592