### PR TITLE
fix: replace hardcoded testnet explorer URL in PurchaseSuccessModal with buildExplorerUrl

### DIFF
--- a/src/components/modals/PurchaseSuccessModal.test.tsx
+++ b/src/components/modals/PurchaseSuccessModal.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import PurchaseSuccessModal from '@/components/modals/PurchaseSuccessModal';
+
+const DEFAULT_PROPS = {
+  isOpen: true,
+  onClose: vi.fn(),
+  commitmentId: '42',
+  commitmentType: 'Safe Commitment',
+  pricePaid: '1,000 USDC',
+  onViewCommitments: vi.fn(),
+};
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof PurchaseSuccessModal>> = {},
+) {
+  const props = { ...DEFAULT_PROPS, ...overrides };
+  const view = render(<PurchaseSuccessModal {...props} />);
+  return { props, ...view };
+}
+
+describe('PurchaseSuccessModal', () => {
+  beforeEach(() => {
+    // Mock clipboard API — navigator.clipboard is a non-writable getter so we
+    // must use defineProperty rather than Object.assign.
+    const clipboardMock = { writeText: vi.fn().mockResolvedValue(undefined) };
+    Object.defineProperty(navigator, 'clipboard', {
+      value: clipboardMock,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  it('renders nothing when isOpen is false', () => {
+    renderModal({ isOpen: false });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders the dialog when isOpen is true', () => {
+    renderModal();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+  });
+
+  it('shows the success heading', () => {
+    renderModal();
+    expect(screen.getByRole('heading', { name: 'Purchase Successful' })).toBeTruthy();
+  });
+
+  it('displays formatted commitment id', () => {
+    renderModal({ commitmentId: '7' });
+    expect(screen.getByText('#CMT-007')).toBeTruthy();
+  });
+
+  it('displays commitment type', () => {
+    renderModal({ commitmentType: 'Balanced Commitment' });
+    expect(screen.getByText('Balanced Commitment')).toBeTruthy();
+  });
+
+  it('displays price paid', () => {
+    renderModal({ pricePaid: '500 XLM' });
+    expect(screen.getByText('500 XLM')).toBeTruthy();
+  });
+
+  // ── Transaction hash ───────────────────────────────────────────────────────
+
+  it('shows truncated tx hash when provided', () => {
+    renderModal({ txHash: 'abcdefgh12345678ijklmnop87654321' });
+    // truncated: first 8 + '...' + last 8
+    expect(screen.getByText('abcdefgh...87654321')).toBeTruthy();
+  });
+
+  it('shows hash unavailable message when txHash is undefined', () => {
+    renderModal({ txHash: undefined });
+    expect(screen.getByText('Transaction hash unavailable.')).toBeTruthy();
+  });
+
+  it('shows explorer link with correct mainnet URL when txHash is provided', () => {
+    const txHash = 'a'.repeat(64);
+    renderModal({ txHash });
+    const link = screen.getByRole('link', { name: /View on Stellar Explorer/i });
+    expect(link).toBeTruthy();
+    expect((link as HTMLAnchorElement).href).toBe(
+      `https://stellar.expert/explorer/public/tx/${txHash}`,
+    );
+  });
+
+  it('shows explorer link with testnet URL when network="testnet"', () => {
+    const txHash = 'a'.repeat(64);
+    renderModal({ txHash, network: 'testnet' });
+    const link = screen.getByRole('link', { name: /View on Stellar Explorer/i });
+    expect(link).toBeTruthy();
+    expect((link as HTMLAnchorElement).href).toBe(
+      `https://stellar.expert/explorer/testnet/tx/${txHash}`,
+    );
+  });
+
+  it('does not show explorer link when txHash is absent', () => {
+    renderModal({ txHash: undefined });
+    expect(screen.queryByRole('link', { name: /View on Stellar Explorer/i })).toBeNull();
+  });
+
+  // ── Acceptance criteria: txHash fails validation ─────────────────────────
+
+  it('renders no explorer link when txHash fails buildExplorerUrl validation', () => {
+    // A short non-hex string is truthy but will fail TX_HASH_PATTERN validation
+    // in buildExplorerUrl, which expects exactly 64 hex characters.
+    renderModal({ txHash: 'short-invalid-hash' });
+    expect(screen.queryByRole('link', { name: /View on Stellar Explorer/i })).toBeNull();
+  });
+
+  // ── Copy hash ──────────────────────────────────────────────────────────────
+
+  it('copy button calls clipboard.writeText with full hash', async () => {
+    const hash = 'fullhashvalue1234567890abcdef00';
+    renderModal({ txHash: hash });
+    fireEvent.click(screen.getByRole('button', { name: 'Copy transaction hash' }));
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(hash);
+    });
+  });
+
+  it('shows "Copied!" status after copy', async () => {
+    renderModal({ txHash: 'abc123def456abc7' });
+    fireEvent.click(screen.getByRole('button', { name: 'Copy transaction hash' }));
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeTruthy();
+      expect(screen.getByRole('status').textContent).toBe('Copied!');
+    });
+  });
+
+  // ── Actions ────────────────────────────────────────────────────────────────
+
+  it('calls onViewCommitments when CTA button is clicked', () => {
+    const onViewCommitments = vi.fn();
+    renderModal({ onViewCommitments });
+    fireEvent.click(screen.getByRole('button', { name: /View in My Commitments/i }));
+    expect(onViewCommitments).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when Close button is clicked', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when X button is clicked', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Focus management ───────────────────────────────────────────────────────
+
+  it('dialog has aria-modal="true"', () => {
+    renderModal();
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('dialog is labelled by heading id', () => {
+    renderModal();
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'aria-labelledby',
+      'purchase-success-title',
+    );
+  });
+
+  it('dialog is described by description id', () => {
+    renderModal();
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'aria-describedby',
+      'purchase-success-description',
+    );
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────────────────
+
+  it('handles short txHash without truncation', () => {
+    renderModal({ txHash: 'short' });
+    // The hash is shown but shorter than 16 chars so no truncation occurs.
+    // However, because 'short' fails buildExplorerUrl validation, the explorer
+    // link will not render. The hash display should still work.
+    expect(screen.getByText('short')).toBeTruthy();
+  });
+
+  it('pads commitment id with leading zeros to 3 digits', () => {
+    renderModal({ commitmentId: '1' });
+    expect(screen.getByText('#CMT-001')).toBeTruthy();
+  });
+
+  it('does not show copy button when txHash is missing', () => {
+    renderModal({ txHash: undefined });
+    expect(screen.queryByRole('button', { name: 'Copy transaction hash' })).toBeNull();
+  });
+
+  it('defaults network to "public" when not provided', () => {
+    const txHash = 'b'.repeat(64);
+    renderModal({ txHash });
+    const link = screen.getByRole('link', { name: /View on Stellar Explorer/i });
+    expect((link as HTMLAnchorElement).href).toBe(
+      `https://stellar.expert/explorer/public/tx/${txHash}`,
+    );
+  });
+});

--- a/src/components/modals/PurchaseSuccessModal.tsx
+++ b/src/components/modals/PurchaseSuccessModal.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import { ArrowRight, CheckCircle, Copy, ExternalLink, X } from 'lucide-react';
+import { Dialog } from '@/components/ui/Dialog';
+import { buildExplorerUrl, type ExplorerNetwork } from '@/utils/explorerLinks';
+
+export interface PurchaseSuccessModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  commitmentId: string;
+  commitmentType: string;
+  pricePaid: string;
+  txHash?: string;
+  network?: ExplorerNetwork;
+  onViewCommitments: () => void;
+}
+
+function truncateHash(hash: string) {
+  if (hash.length <= 16) return hash;
+  return `${hash.slice(0, 8)}...${hash.slice(-8)}`;
+}
+
+export default function PurchaseSuccessModal({
+  isOpen,
+  onClose,
+  commitmentId,
+  commitmentType,
+  pricePaid,
+  txHash,
+  network = 'public',
+  onViewCommitments,
+}: PurchaseSuccessModalProps) {
+  const primaryButtonRef = useRef<HTMLButtonElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  function handleCopyHash() {
+    if (!txHash) return;
+    navigator.clipboard.writeText(txHash).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  const explorerUrl = buildExplorerUrl('tx', txHash, network);
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      initialFocusRef={primaryButtonRef}
+      labelledById="purchase-success-title"
+      describedById="purchase-success-description"
+      className="relative flex max-h-[100dvh] w-full max-w-[540px] flex-col overflow-y-auto rounded-[32px] border border-white/10 bg-[#0A0A0A] shadow-2xl sm:max-h-[90vh]"
+    >
+      <div className="absolute right-6 top-6 z-10">
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 transition-all hover:scale-105 hover:bg-white/10 active:scale-95"
+          aria-label="Close modal"
+        >
+          <X className="h-5 w-5 text-white/50" />
+        </button>
+      </div>
+
+      <div className="flex-1 px-6 pb-10 pt-12 sm:px-10">
+        {/* Header */}
+        <div className="mb-8 flex flex-col items-center">
+          <div className="relative mb-6 h-20 w-20 sm:h-24 sm:w-24">
+            <div className="absolute inset-0 rounded-full bg-[#0FF0FC] opacity-20 blur-2xl animate-pulse" />
+            <div className="relative z-10 flex h-full w-full items-center justify-center rounded-full border-2 border-[#0FF0FC] bg-[#0FF0FC]/10 shadow-[inset_0_0_20px_rgba(15,240,252,0.2)]">
+              <CheckCircle className="h-10 w-10 text-[#0FF0FC] sm:h-12 sm:w-12" strokeWidth={2.5} />
+            </div>
+          </div>
+          <div className="text-center">
+            <h2
+              id="purchase-success-title"
+              className="mb-2 text-[28px] font-bold leading-tight tracking-tight text-white sm:text-[32px]"
+            >
+              Purchase Successful
+            </h2>
+            <p
+              id="purchase-success-description"
+              className="mx-auto max-w-[340px] text-[15px] font-medium leading-relaxed text-white/50 sm:text-[16px]"
+            >
+              You now own this commitment. It has been transferred to your wallet.
+            </p>
+          </div>
+        </div>
+
+        {/* Ownership summary */}
+        <div className="group relative mb-6 overflow-hidden rounded-[24px] border border-white/[0.08] bg-white/[0.03] p-6 transition-colors hover:bg-white/[0.05]">
+          <div className="absolute -mr-12 -mt-12 right-0 top-0 h-24 w-24 rounded-full bg-[#0FF0FC] opacity-[0.02] blur-2xl transition-opacity group-hover:opacity-[0.04]" />
+          <dl className="space-y-3">
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-[13px] font-bold uppercase tracking-[0.15em] text-white/40">
+                Commitment
+              </dt>
+              <dd className="m-0 font-mono text-[14px] font-bold tracking-wider text-[#0FF0FC]">
+                #CMT-{commitmentId.padStart(3, '0')}
+              </dd>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-[13px] font-bold uppercase tracking-[0.15em] text-white/40">
+                Type
+              </dt>
+              <dd className="m-0 text-[14px] font-semibold text-white/90">
+                {commitmentType}
+              </dd>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-[13px] font-bold uppercase tracking-[0.15em] text-white/40">
+                Price Paid
+              </dt>
+              <dd className="m-0 text-[20px] font-bold text-white">
+                {pricePaid}
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        {/* Transaction hash */}
+        {txHash ? (
+          <div className="mb-8 rounded-[16px] border border-white/[0.08] bg-white/[0.03] p-4">
+            <div className="mb-2 text-[12px] font-bold uppercase tracking-[0.15em] text-white/40">
+              Transaction Hash
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="flex-1 truncate font-mono text-[13px] text-white/70">
+                {truncateHash(txHash)}
+              </span>
+              <button
+                type="button"
+                onClick={handleCopyHash}
+                aria-label="Copy transaction hash"
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/5 transition-all hover:bg-white/10 active:scale-95"
+              >
+                <Copy className="h-3.5 w-3.5 text-white/50" />
+              </button>
+            </div>
+            {copied && (
+              <p role="status" className="mt-1.5 text-[12px] text-[#0FF0FC]">
+                Copied!
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="mb-8 rounded-[16px] border border-white/[0.06] bg-white/[0.02] p-4 text-[13px] text-white/30">
+            Transaction hash unavailable.
+          </div>
+        )}
+
+        {/* CTAs */}
+        <div className="space-y-3">
+          <button
+            ref={primaryButtonRef}
+            type="button"
+            onClick={onViewCommitments}
+            className="flex w-full items-center justify-center gap-3 rounded-2xl bg-[#0FF0FC] py-4 text-[16px] font-bold text-black transition-all shadow-[0_0_30px_rgba(15,240,252,0.3)] hover:scale-[1.01] hover:bg-[#0FF0FC]/90 active:scale-[0.98]"
+          >
+            View in My Commitments
+            <ArrowRight className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-full rounded-2xl border border-white/10 bg-white/5 py-3.5 text-[14px] font-bold text-white transition-all hover:bg-white/10 active:scale-[0.98]"
+          >
+            Close
+          </button>
+        </div>
+
+        {/* Explorer link */}
+        {explorerUrl && (
+          <div className="mt-8 border-t border-white/5 pt-6">
+            <a
+              href={explorerUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex w-full items-center justify-center gap-2 py-1 text-[13px] text-white/30 transition-colors hover:text-[#0FF0FC]"
+            >
+              View on Stellar Explorer
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </div>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export interface DialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  labelledById?: string;
+  describedById?: string;
+  closeOnEscape?: boolean;
+  initialFocusRef?: React.RefObject<HTMLElement | null>;
+  children: React.ReactNode;
+  className?: string;
+  backdropClassName?: string;
+}
+
+export function Dialog({
+  isOpen,
+  onClose,
+  labelledById,
+  describedById,
+  closeOnEscape = true,
+  initialFocusRef,
+  children,
+  className = '',
+  backdropClassName = 'bg-black/80 p-4 backdrop-blur-md',
+}: DialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const [mounted, setMounted] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(mediaQuery.matches);
+    
+    const listener = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches);
+    mediaQuery.addEventListener('change', listener);
+    return () => {
+      setMounted(false);
+      mediaQuery.removeEventListener('change', listener);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    // Capture previous focus
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        if (closeOnEscape) {
+          event.preventDefault();
+          onClose();
+        }
+        return;
+      }
+
+      if (event.key === 'Tab' && dialogRef.current) {
+        const focusableElements = dialogRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+
+        if (focusableElements.length === 0) {
+          event.preventDefault();
+          return;
+        }
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (event.shiftKey && document.activeElement === firstElement) {
+          event.preventDefault();
+          lastElement.focus();
+        } else if (!event.shiftKey && document.activeElement === lastElement) {
+          event.preventDefault();
+          firstElement.focus();
+        }
+      }
+    };
+
+    const focusTimer = window.setTimeout(() => {
+      if (initialFocusRef?.current) {
+        initialFocusRef.current.focus();
+      } else if (dialogRef.current) {
+        const focusableElements = dialogRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusableElements.length > 0) {
+          focusableElements[0].focus();
+        } else {
+          dialogRef.current.focus();
+        }
+      }
+    }, 100);
+
+    document.addEventListener('keydown', handleKeyDown);
+    
+    // Scroll lock and inert implementation
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    
+    // Make sibling root elements inert for accessibility
+    const rootElements = Array.from(document.body.children).filter(
+      (child) => 
+        child.tagName !== 'SCRIPT' && 
+        child.tagName !== 'NOSCRIPT' && 
+        !child.hasAttribute('data-dialog-portal')
+    );
+    
+    rootElements.forEach((el) => {
+      el.setAttribute('inert', '');
+      el.setAttribute('aria-hidden', 'true');
+    });
+
+    return () => {
+      window.clearTimeout(focusTimer);
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = originalOverflow;
+      
+      rootElements.forEach((el) => {
+        el.removeAttribute('inert');
+        el.removeAttribute('aria-hidden');
+      });
+
+      // Restore focus
+      if (previousFocusRef.current && document.body.contains(previousFocusRef.current)) {
+        previousFocusRef.current.focus();
+      }
+    };
+  }, [isOpen, onClose, closeOnEscape, initialFocusRef]);
+
+  if (!isOpen || !mounted) return null;
+
+  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  const animationClasses = prefersReducedMotion ? '' : 'animate-in fade-in duration-300';
+  const slideClasses = prefersReducedMotion ? '' : 'animate-in slide-in-from-bottom-8 duration-500 ease-out';
+
+  // We trim the classes in case some are empty to avoid stray spaces, 
+  // though it's technically fine if they have spaces.
+  const finalBackdropClass = `fixed inset-0 z-[9999] flex items-center justify-center ${backdropClassName} ${animationClasses}`.trim();
+  const finalPanelClass = `${slideClasses} ${className}`.trim();
+
+  return createPortal(
+    <div
+      data-dialog-portal
+      data-testid="dialog-backdrop"
+      className={finalBackdropClass}
+      onClick={handleBackdropClick}
+      role="presentation"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={labelledById}
+        aria-describedby={describedById}
+        tabIndex={-1}
+        className={finalPanelClass}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the hardcoded testnet Stellar Explorer URL in `PurchaseSuccessModal` with the app's `buildExplorerUrl` utility function, which validates the transaction hash and respects the configured network.

## What Changed

- **src/components/modals/PurchaseSuccessModal.tsx** — New modal component that imports `buildExplorerUrl` from `@/utils/explorerLinks` and uses `buildExplorerUrl('tx', txHash, network)` instead of a hardcoded `https://stellar.expert/explorer/testnet/tx/${txHash}` string. Accepts an optional `network` prop defaulting to `'public'`.
- **src/components/modals/PurchaseSuccessModal.test.tsx** — 24 tests covering success path (mainnet + testnet), missing txHash, invalid txHash (acceptance criteria), copy-to-clipboard, button actions, focus management, and edge cases.
- **src/components/ui/Dialog.tsx** — New reusable accessible Dialog component (portal-based, focus trap, ESC close, aria attributes).

## Key Design Decisions

- Uses `buildExplorerUrl` which validates txHash against `TX_HASH_PATTERN` (64 hex chars) before constructing the URL.
- Explorer link is only rendered when `buildExplorerUrl` returns a truthy value — invalid/missing hashes automatically hide the link.
- Defaults network to `'public'` (mainnet) rather than testnet, matching the app's production configuration.

## Acceptance Criteria

- [x] Replace inline template string with `buildExplorerUrl('tx', txHash, network)`
- [x] Sourced from the app's actual configured network via `network` prop
- [x] No explorer link rendered when txHash fails validation
- [x] Test asserting no explorer link for invalid txHash
- [x] Success path tests for both mainnet and testnet URLs
- [x] Failure path tests for missing and invalid txHash

## Test Output

```
✓ src/components/modals/PurchaseSuccessModal.test.tsx (24 tests) 365ms
  Test Files  1 passed (1)
       Tests  24 passed (24)
```

## Follow-ups

None.

## Security Note

All externally-sourced identifiers go through `buildExplorerUrl` validation before URL construction, preventing URL injection via malformed tx hashes. Explorer links open with `rel="noopener noreferrer"`.

Closes #1399