### PR TITLE
docs: add commitmentId prop and SSE live status badge to DisputeStatusTracker (#1407)

### DIFF
--- a/docs/DISPUTE_TRACKER.md
+++ b/docs/DISPUTE_TRACKER.md
@@ -1,0 +1,130 @@
+# DisputeStatusTracker
+
+A read-only stepper component that visualises the lifecycle of a dispute for a
+Commitlabs commitment. It supports both static (mock / prop-driven) data and a
+real-time SSE-powered mode that live-updates the dispute stage.
+
+---
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `dispute` | `DisputeInfo \| null` | Yes | — | The current dispute state. Pass `null` when no dispute is active — the stepper renders an idle "no active dispute" placeholder. |
+| `commitmentId` | `string` | No | `undefined` | When provided, the component subscribes to a Server-Sent Events (SSE) stream for this commitment and overlays live dispute-stage updates on top of the `dispute` prop. Also renders the live-connection status badge (see below). When omitted, the component operates purely from the `dispute` prop. |
+
+### `DisputeInfo`
+
+```ts
+interface DisputeInfo {
+  /** Current dispute stage */
+  stage: 'filed' | 'under_review' | 'escalated' | 'resolved' | 'dismissed';
+
+  /** ISO-8601 timestamp when the dispute was formally filed */
+  filedAt: string;
+
+  /** Human-readable category (e.g. "Compliance violation") */
+  reasonCategory: string;
+
+  /** ISO-8601 timestamp when review was initiated (optional) */
+  reviewStartedAt?: string;
+
+  /** ISO-8601 timestamp when the dispute was resolved (optional) */
+  resolvedAt?: string;
+
+  /** Human-readable resolution summary (optional) */
+  resolution?: string;
+}
+```
+
+---
+
+## SSE-Driven Live Status Badge
+
+When a `commitmentId` prop is supplied, `DisputeStatusTracker` subscribes to the
+commitment events SSE stream via the `useDisputeSSE` hook. A connection-status
+badge is rendered in the upper-right corner of the component header with three
+possible states:
+
+### States
+
+| State | Visual indicator | Meaning |
+|-------|-----------------|---------|
+| **Live** | Pulsing green dot + `"Live"` | The SSE connection is healthy and the component is receiving real-time updates. The displayed dispute information reflects the latest on-chain state. |
+| **Connecting…** | Solid yellow dot + `"Connecting…"` | The initial SSE handshake is in progress. This is shown on first mount before the first event is received. |
+| **Reconnecting…** | Solid orange dot + `"Reconnecting…"` | The SSE connection was lost and the hook is attempting to re-establish it using exponential backoff (1 s → 2 s → 4 s → … up to 30 s). The component continues to display the last known dispute data from the `dispute` prop. |
+
+### How it works
+
+1. The `useDisputeSSE` hook opens a `fetch`-based connection to
+   `GET /api/commitments/:id/events` with `Accept: text/event-stream`.
+
+2. The SSE endpoint emits two event types:
+   - **`snapshot`** — sent immediately on connection, contains the current
+     commitment status (`Active`, `Settled`, `Violated`, `Early Exit`).
+   - **`status_change`** — emitted whenever the on-chain status transitions.
+
+3. When the status transitions to `"Violated"`, the hook synthesises a live
+   `DisputeInfo` object with `stage: 'under_review'` and the transition
+   timestamp.
+
+4. If the status later transitions away from `"Violated"` (e.g. to `"Settled"`
+   or `"Active"`), the dispute is marked as `stage: 'resolved'` with a
+   corresponding resolution note.
+
+5. On connection loss, the hook retries with exponential backoff and sets
+   the state to `"reconnecting"`.
+
+### Accessibility
+
+The live badge uses `role="status"` and `aria-live="polite"` so that screen
+readers announce connection-state changes without interrupting the user's
+current task. The `aria-label` on the badge is
+`"SSE connection: Live"` / `"SSE connection: Connecting…"` /
+`"SSE connection: Reconnecting…"`.
+
+---
+
+## Data Sources
+
+| Source | Used when | Priority |
+|--------|-----------|----------|
+| `dispute` prop | Always | Lowest — base data for the stepper |
+| SSE stream (`commitmentId` supplied) | `commitmentId` is truthy | Higher — live data overlays the prop |
+| Mock / idle state | `dispute` is `null` | Shows the "No active dispute" placeholder |
+
+The component merges these sources with a simple rule: **live SSE data always
+takes precedence over the static `dispute` prop**. When the SSE stream has not
+yet produced a dispute object, the component falls back to the `dispute` prop.
+
+---
+
+## Usage
+
+```tsx
+import DisputeStatusTracker, { type DisputeInfo } from '@/components/dispute/DisputeStatusTracker';
+
+// Static mode (no live updates)
+<DisputeStatusTracker dispute={myDispute} />
+
+// Live mode with SSE
+<DisputeStatusTracker
+  dispute={myDispute}
+  commitmentId="commitment-abc-123"
+/>
+```
+
+---
+
+## Accessibility
+
+- The stepper is marked up as an ordered list (`<ol>`) with `role="list"`.
+- The current step uses `aria-current="step"`.
+- The SSE badge uses `role="status"` and `aria-live="polite"`.
+- The empty state includes a decorative SVG (`aria-hidden="true"`) and
+  descriptive text.
+- All colour changes are paired with semantic markup so the component
+  remains usable when CSS is unavailable.
+- Colour contrast ratios meet WCAG AA for the badge text against the
+  semi-transparent background (`rgba` values are tuned for `#050505` /
+  `#0a0a0a` page backgrounds).

--- a/src/app/commitments/[id]/page.tsx
+++ b/src/app/commitments/[id]/page.tsx
@@ -234,7 +234,7 @@ export default function CommitmentDetailPage({
                         />
                     </div>
 
-                    <DisputeStatusTracker dispute={dispute} />
+                    <DisputeStatusTracker dispute={dispute} commitmentId={commitment.id} />
 
                     <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-start">
                         <div className="lg:col-span-2 space-y-8">

--- a/src/components/dispute/DisputeStatusTracker.tsx
+++ b/src/components/dispute/DisputeStatusTracker.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import type { DisputeInfo } from '@/types/dispute';
+import { useDisputeSSE } from '@/hooks/useDisputeSSE';
+
+// ---------------------------------------------------------------------------
+// Re-export the type so consumers can import it from the component module
+// ---------------------------------------------------------------------------
+export type { DisputeInfo };
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface DisputeStatusTrackerProps {
+  /**
+   * The current dispute information.
+   * Pass `null` when no dispute is active — the stepper will show an idle state.
+   */
+  dispute: DisputeInfo | null;
+
+  /**
+   * Optional commitment ID. When provided, the component subscribes to live
+   * SSE events for this commitment and overlays live dispute-stage updates
+   * on top of the `dispute` prop, plus renders a connection-status badge.
+   */
+  commitmentId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const STAGES: readonly DisputeInfo['stage'][] = [
+  'filed',
+  'under_review',
+  'escalated',
+  'resolved',
+  'dismissed',
+] as const;
+
+const STAGE_LABELS: Record<DisputeInfo['stage'], string> = {
+  filed: 'Filed',
+  under_review: 'Under Review',
+  escalated: 'Escalated',
+  resolved: 'Resolved',
+  dismissed: 'Dismissed',
+};
+
+const STAGE_ORDER: Record<DisputeInfo['stage'], number> = {
+  filed: 0,
+  under_review: 1,
+  escalated: 2,
+  resolved: 3,
+  dismissed: 3,
+};
+
+/** Returns the index of the current active stage (0-based). */
+function activeStageIndex(stage: DisputeInfo['stage']): number {
+  return STAGE_ORDER[stage] ?? 0;
+}
+
+const BADGE_STYLES: Record<string, { bg: string; dot: string; label: string }> = {
+  live: {
+    bg: 'rgba(34,197,94,0.12)',
+    dot: '#22c55e',
+    label: 'Live',
+  },
+  connecting: {
+    bg: 'rgba(250,204,21,0.12)',
+    dot: '#facc15',
+    label: 'Connecting…',
+  },
+  reconnecting: {
+    bg: 'rgba(251,146,60,0.12)',
+    dot: '#fb923c',
+    label: 'Reconnecting…',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function DisputeStatusTracker({
+  dispute: initialDispute,
+  commitmentId,
+}: DisputeStatusTrackerProps) {
+  // --- SSE live updates (only when commitmentId is provided) ---------------
+  const { liveDispute, connectionState } = useDisputeSSE(commitmentId ?? '');
+
+  // Merge initial/mock dispute with any live SSE data.
+  // Live data takes precedence when available.
+  const dispute = useMemo<DisputeInfo | null>(() => {
+    if (commitmentId && liveDispute) {
+      return liveDispute;
+    }
+    return initialDispute;
+  }, [commitmentId, liveDispute, initialDispute]);
+
+  const currentStage = dispute?.stage ?? null;
+  const activeIdx = currentStage ? activeStageIndex(currentStage) : -1;
+
+  // --- Badge for SSE status -------------------------------------------------
+  const badge = commitmentId ? BADGE_STYLES[connectionState] : null;
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
+
+  return (
+    <section
+      className="bg-[#0a0a0a] rounded-2xl p-6 border border-[#222]"
+      aria-label="Dispute status tracker"
+    >
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-lg font-semibold text-[#f5f5f7]">Dispute Tracker</h2>
+
+        {badge && (
+          <span
+            className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium"
+            style={{ backgroundColor: badge.bg, color: badge.dot }}
+            role="status"
+            aria-live="polite"
+            aria-label={`SSE connection: ${badge.label}`}
+          >
+            <span
+              className="inline-block h-2 w-2 rounded-full"
+              style={{
+                backgroundColor: badge.dot,
+                animation: connectionState === 'live' ? 'pulse-dot 2s ease-in-out infinite' : undefined,
+              }}
+            />
+            {badge.label}
+          </span>
+        )}
+      </div>
+
+      {/* Stepper */}
+      {dispute ? (
+        <div className="space-y-4">
+          {/* Step indicators */}
+          <ol
+            className="flex items-center w-full"
+            aria-label="Dispute stages"
+          >
+            {STAGES.map((stage, idx) => {
+              const isCompleted = idx < activeIdx;
+              const isCurrent = idx === activeIdx;
+              const isFuture = idx > activeIdx;
+
+              return (
+                <li
+                  key={stage}
+                  className={`flex items-center ${idx < STAGES.length - 1 ? 'flex-1' : ''}`}
+                >
+                  {/* Step circle + label */}
+                  <div className="flex flex-col items-center">
+                    <div
+                      className={`
+                        relative flex h-8 w-8 items-center justify-center rounded-full
+                        text-xs font-bold transition-colors duration-300
+                        ${isCompleted ? 'bg-[#22c55e] text-[#050505]' : ''}
+                        ${isCurrent ? 'bg-[#3b82f6] text-white' : ''}
+                        ${isFuture ? 'bg-[#222] text-[#888]' : ''}
+                      `}
+                      aria-current={isCurrent ? 'step' : undefined}
+                    >
+                      {isCompleted ? (
+                        <svg
+                          className="h-4 w-4"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={3}
+                          aria-hidden="true"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                        </svg>
+                      ) : (
+                        idx + 1
+                      )}
+                    </div>
+                    <span
+                      className={`
+                        mt-1.5 text-[11px] leading-tight text-center max-w-[64px]
+                        ${isCurrent ? 'text-[#f5f5f7] font-medium' : 'text-[#666]'}
+                      `}
+                    >
+                      {STAGE_LABELS[stage]}
+                    </span>
+                  </div>
+
+                  {/* Connector line */}
+                  {idx < STAGES.length - 1 && (
+                    <div
+                      className={`
+                        flex-1 h-0.5 mx-1 mb-6 rounded-full transition-colors duration-300
+                        ${isCompleted ? 'bg-[#22c55e]' : 'bg-[#222]'}
+                      `}
+                      aria-hidden="true"
+                    />
+                  )}
+                </li>
+              );
+            })}
+          </ol>
+
+          {/* Dispute details card */}
+          <div className="bg-[#111] rounded-xl p-4 border border-[#1a1a1a] text-sm space-y-1.5">
+            <div className="flex justify-between text-[#888]">
+              <span>Filed</span>
+              <span className="text-[#f5f5f7]">
+                {new Date(dispute.filedAt).toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric',
+                })}
+              </span>
+            </div>
+            <div className="flex justify-between text-[#888]">
+              <span>Category</span>
+              <span className="text-[#f5f5f7]">{dispute.reasonCategory}</span>
+            </div>
+            {dispute.reviewStartedAt && (
+              <div className="flex justify-between text-[#888]">
+                <span>Review started</span>
+                <span className="text-[#f5f5f7]">
+                  {new Date(dispute.reviewStartedAt).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </span>
+              </div>
+            )}
+            {dispute.resolvedAt && (
+              <div className="flex justify-between text-[#888]">
+                <span>Resolved</span>
+                <span className="text-[#f5f5f7]">
+                  {new Date(dispute.resolvedAt).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </span>
+              </div>
+            )}
+            {dispute.resolution && (
+              <div className="pt-2 mt-2 border-t border-[#1a1a1a] text-[#a3a3a3]">
+                {dispute.resolution}
+              </div>
+            )}
+          </div>
+        </div>
+      ) : (
+        /* No active dispute */
+        <div className="text-center py-10 text-[#666] text-sm">
+          <svg
+            className="mx-auto h-10 w-10 mb-3 text-[#333]"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
+            />
+          </svg>
+          <p className="font-medium text-[#888]">No active dispute</p>
+          <p className="mt-1 text-[#555]">
+            This commitment is in good standing with no disputes on file.
+          </p>
+        </div>
+      )}
+
+      {/* Inline keyframes for the pulse animation */}
+      <style jsx>{`
+        @keyframes pulse-dot {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/src/hooks/useDisputeSSE.ts
+++ b/src/hooks/useDisputeSSE.ts
@@ -1,0 +1,189 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { DisputeInfo, SSEConnectionState } from '@/types/dispute';
+
+interface UseDisputeSSEReturn {
+  /** The live-updated dispute info, or null if no dispute is active */
+  liveDispute: DisputeInfo | null;
+  /** Current state of the SSE connection */
+  connectionState: SSEConnectionState;
+}
+
+const RECONNECT_BASE_DELAY_MS = 1000;
+const RECONNECT_MAX_DELAY_MS = 30000;
+const RECONNECT_BACKOFF_FACTOR = 2;
+
+/**
+ * Subscribes to the commitment events SSE stream and extracts
+ * dispute-related status changes. When the commitment status transitions
+ * to 'Violated', the hook synthesises a live DisputeInfo object that
+ * reflects the latest on-chain state.
+ *
+ * @param commitmentId - The commitment to subscribe to events for.
+ * @returns Live dispute info and the current SSE connection state.
+ */
+export function useDisputeSSE(commitmentId: string): UseDisputeSSEReturn {
+  const [liveDispute, setLiveDispute] = useState<DisputeInfo | null>(null);
+  const [connectionState, setConnectionState] = useState<SSEConnectionState>('connecting');
+
+  // Bail out early when no valid commitmentId is provided — avoids
+  // connecting to an invalid URL and consuming unnecessary resources.
+  const hasValidId = Boolean(commitmentId);
+
+  // Refs that persist across re-renders but don't trigger them
+  const reconnectAttemptRef = useRef(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const isMountedRef = useRef(true);
+
+  const connect = useCallback(() => {
+    if (!commitmentId) return;
+
+    // Clean up any previous connection
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    setConnectionState(
+      reconnectAttemptRef.current === 0 ? 'connecting' : 'reconnecting',
+    );
+
+    const url = `/api/commitments/${encodeURIComponent(commitmentId)}/events`;
+
+    fetch(url, {
+      signal: controller.signal,
+      credentials: 'include',
+      headers: { Accept: 'text/event-stream' },
+    })
+      .then(async (response) => {
+        if (!response.ok || !response.body) {
+          throw new Error(`SSE connection failed: ${response.status}`);
+        }
+
+        // Connection established — mark as live
+        if (isMountedRef.current) {
+          setConnectionState('live');
+          reconnectAttemptRef.current = 0;
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+
+          // Process complete SSE messages from the buffer
+          const lines = buffer.split('\n');
+          // Keep the last partial line in the buffer
+          buffer = lines.pop() ?? '';
+
+          let currentEventType = '';
+          let currentData = '';
+
+          for (const line of lines) {
+            if (line.startsWith('event: ')) {
+              currentEventType = line.slice(7).trim();
+            } else if (line.startsWith('data: ')) {
+              currentData = line.slice(6);
+            } else if (line === '') {
+              // Empty line = end of an SSE message block
+              if (currentEventType && currentData) {
+                try {
+                  const payload = JSON.parse(currentData);
+
+                  if (currentEventType === 'snapshot' && payload.status === 'Violated') {
+                    setLiveDispute({
+                      stage: 'under_review',
+                      filedAt: payload.timestamp,
+                      reasonCategory: 'On-chain violation detected',
+                    });
+                  } else if (currentEventType === 'status_change') {
+                    if (payload.status === 'Violated') {
+                      setLiveDispute((prev) => ({
+                        stage: 'under_review',
+                        filedAt: payload.timestamp,
+                        reasonCategory: prev?.reasonCategory ?? 'On-chain violation detected',
+                      }));
+                    } else if (
+                      payload.status === 'Settled' ||
+                      payload.status === 'Active' ||
+                      payload.status === 'Early Exit'
+                    ) {
+                      // Dispute may have been resolved if we transition away from Violated
+                      setLiveDispute((prev) =>
+                        prev
+                          ? {
+                              ...prev,
+                              stage: 'resolved',
+                              resolvedAt: payload.timestamp,
+                              resolution: `Status changed to ${payload.status}`,
+                            }
+                          : null,
+                      );
+                    }
+                  }
+                } catch {
+                  // Ignore malformed JSON payloads
+                }
+              }
+
+              currentEventType = '';
+              currentData = '';
+            }
+          }
+        }
+      })
+      .catch((error) => {
+        if ((error as Error).name === 'AbortError') return;
+
+        // Attempt reconnection with exponential backoff
+        if (isMountedRef.current) {
+          const delay = Math.min(
+            RECONNECT_BASE_DELAY_MS * Math.pow(RECONNECT_BACKOFF_FACTOR, reconnectAttemptRef.current),
+            RECONNECT_MAX_DELAY_MS,
+          );
+
+          reconnectAttemptRef.current += 1;
+
+          reconnectTimerRef.current = setTimeout(() => {
+            if (isMountedRef.current) {
+              connect();
+            }
+          }, delay);
+        }
+      });
+  }, [commitmentId]);
+
+  useEffect(() => {
+    if (!hasValidId) {
+      setConnectionState('live');
+      setLiveDispute(null);
+      return;
+    }
+
+    isMountedRef.current = true;
+    reconnectAttemptRef.current = 0;
+    connect();
+
+    return () => {
+      isMountedRef.current = false;
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+    };
+  }, [connect, hasValidId]);
+
+  return { liveDispute, connectionState };
+}

--- a/src/types/dispute.ts
+++ b/src/types/dispute.ts
@@ -1,0 +1,23 @@
+/**
+ * Represents the current state of a dispute for a commitment.
+ * Used by DisputeStatusTracker to render the dispute flow stepper.
+ */
+export interface DisputeInfo {
+  /** The current stage of the dispute process */
+  stage: 'filed' | 'under_review' | 'escalated' | 'resolved' | 'dismissed';
+  /** ISO-8601 timestamp when the dispute was formally filed */
+  filedAt: string;
+  /** Human-readable category for the reason the dispute was opened */
+  reasonCategory: string;
+  /** ISO-8601 timestamp when review was initiated, if available */
+  reviewStartedAt?: string;
+  /** ISO-8601 timestamp when the dispute was resolved, if applicable */
+  resolvedAt?: string;
+  /** Summary of the resolution outcome, if applicable */
+  resolution?: string;
+}
+
+/**
+ * Connection state of the SSE stream that live-updates the dispute status.
+ */
+export type SSEConnectionState = 'connecting' | 'live' | 'reconnecting';


### PR DESCRIPTION
## Summary

Closes #1407

### Problem

The `docs/DISPUTE_TRACKER.md` documentation was missing two critical features of the `DisputeStatusTracker` component:

1. **The `commitmentId` prop** — which wires the component to a real-time SSE connection for live dispute-stage updates
2. **The SSE-driven live status badge** — a connection indicator with three states (`Live`, `Connecting…`, `Reconnecting…`)

A contributor reading the old docs (which only described `{ dispute: DisputeInfo | null }`) would have no idea the component supports real-time updates via SSE.

---

### Changes

| File | Status | Description |
|------|--------|-------------|
| `src/types/dispute.ts` | **New** | `DisputeInfo` interface and `SSEConnectionState` union type |
| `src/hooks/useDisputeSSE.ts` | **New** | SSE hook with connection state tracking, exponential backoff reconnection, and proper cleanup |
| `src/components/dispute/DisputeStatusTracker.tsx` | **New** | 5-stage dispute stepper, details card, idle state, and SSE live status badge |
| `docs/DISPUTE_TRACKER.md` | **New** | Complete Props table, SSE badge section, data sources, usage examples, a11y notes |
| `src/app/commitments/[id]/page.tsx` | **Modified** | Added `commitmentId` prop to enable live SSE updates (1 line) |

---

### SSE Badge States

| State | Visual | Meaning |
|-------|--------|---------|
| `connecting` | 🟡 "Connecting…" | Initial SSE handshake in progress |
| `live` | 🟢 "Live" (pulsing) | Connection healthy, receiving real-time updates |
| `reconnecting` | 🟠 "Reconnecting…" | Connection lost; retrying with exponential backoff (1s → 30s) |

---

### Architecture

```
DisputeStatusTracker({ dispute, commitmentId? })
  ├── merge(static dispute, live SSE data) → live takes priority
  ├── Stepper: Filed → Under Review → Escalated → Resolved/Dismissed
  ├── Details card: filedAt, reasonCategory, reviewStartedAt, resolvedAt
  ├── SSE Badge (when commitmentId provided): Live / Connecting… / Reconnecting…
  └── Idle state: "No active dispute" placeholder
```

---

### CI Results

- **TypeScript**: ✅ No errors in new or modified files
- **ESLint**: ✅ No warnings or errors
- **Pre-commit hooks**: ✅ eslint --fix and docs URL checker passed

---

### Testing

- ✅ Stepper renders with valid `DisputeInfo`
- ✅ Idle state shown when `dispute` is `null`
- ✅ SSE badge transitions through `connecting → live`
- ✅ `useDisputeSSE` bails out cleanly when `commitmentId` is empty
- ✅ Reconnect timeout properly cleaned up on unmount