### PR TITLE
feat: keyboard shortcuts help overlay opened with ?

### DIFF
--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -1,0 +1,52 @@
+# Keyboard Shortcuts Help Overlay
+
+A discoverable reference for the app's global keyboard shortcuts, opened
+with `?` (Shift+/) from anywhere -- except while a form field is focused.
+
+## Architecture
+
+- **`GLOBAL_SHORTCUTS`** (`src/lib/shortcuts.ts`) -- a single typed registry
+  of `{ keys, description, group }` entries. This is the source of truth: add
+  an entry here whenever a new global shortcut is introduced elsewhere in the
+  app (e.g. the command palette's `Cmd/Ctrl+K`), so the overlay can never
+  drift out of sync with real bindings.
+- **`KeyboardShortcutsOverlay`** (`src/components/shell/KeyboardShortcutsOverlay.tsx`)
+  -- listens globally for `?`, and renders the registry (grouped by
+  `group`) in the shared `Dialog` primitive. Mount it once per page (or
+  once in a shell component that's always mounted); it listens on `window`
+  regardless of where it's rendered in the tree.
+
+## Usage
+
+```tsx
+import { KeyboardShortcutsOverlay } from '@/components/shell/KeyboardShortcutsOverlay';
+
+export default function SomePage() {
+  return (
+    <main>
+      <KeyboardShortcutsOverlay />
+      {/* ... */}
+    </main>
+  );
+}
+```
+
+## Behavior
+
+- `?` is ignored while an `<input>`, `<textarea>`, `<select>`, or any
+  `contenteditable` element is focused, so typing a literal `?` in a form
+  field never triggers it.
+- Rendered in the shared `Dialog` primitive: full focus trap, `Escape` to
+  close, background made `inert`, focus restored to whatever was focused
+  before opening.
+- Respects `prefers-reduced-motion` -- inherited from `Dialog`, which
+  disables its open/close transition classes when the user has that
+  preference set.
+
+## Testing
+
+See `src/components/shell/KeyboardShortcutsOverlay.test.tsx`: renders
+nothing initially, opens on `?` when nothing is focused, ignores `?` while
+an input/textarea/contenteditable is focused, closes on `Escape` and via the
+Close button, restores focus on close, and renders the registry grouped by
+section. See `src/lib/shortcuts.test.ts` for the grouping helper.

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -31,6 +31,7 @@ import { KPICard } from '@/components/KPICard';
 import { useWallet } from '@/hooks/useWallet';
 import AnalyticsTrendLineChart from '@/components/analytics/AnalyticsTrendLineChart';
 import AnalyticsTrendBarChart from '@/components/analytics/AnalyticsTrendBarChart';
+import { KeyboardShortcutsOverlay } from '@/components/shell/KeyboardShortcutsOverlay';
 
 // ============================================================================
 // TYPES
@@ -529,10 +530,9 @@ export default function AnalyticsPage() {
     setView(mode);
   };
 
-  const isAnyLoading = userState === 'loading' || protocolState === 'loading';
-
   return (
     <main id="main-content" className="min-h-screen bg-[#0a0a0a]">
+      <KeyboardShortcutsOverlay />
       {/* Header */}
       <header className="sticky top-0 z-10 bg-[#0a0a0a]/90 backdrop-blur-sm border-b border-[#1a1a1a]">
         <div className="px-6 sm:px-10 lg:px-16 py-4 flex items-center justify-between gap-4 flex-wrap">

--- a/src/components/shell/KeyboardShortcutsOverlay.test.tsx
+++ b/src/components/shell/KeyboardShortcutsOverlay.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { KeyboardShortcutsOverlay } from '@/components/shell/KeyboardShortcutsOverlay';
+
+describe('KeyboardShortcutsOverlay', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders nothing initially', () => {
+    render(<KeyboardShortcutsOverlay />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('opens when "?" is pressed and nothing is focused', () => {
+    render(<KeyboardShortcutsOverlay />);
+    document.body.focus();
+
+    fireEvent.keyDown(window, { key: '?' });
+
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText('Keyboard shortcuts')).toBeTruthy();
+  });
+
+  it('ignores "?" while an <input> is focused', () => {
+    render(
+      <>
+        <input aria-label="Some field" />
+        <KeyboardShortcutsOverlay />
+      </>
+    );
+
+    const input = screen.getByLabelText('Some field');
+    input.focus();
+    fireEvent.keyDown(input, { key: '?' });
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('ignores "?" while a <textarea> is focused', () => {
+    render(
+      <>
+        <textarea aria-label="Notes" />
+        <KeyboardShortcutsOverlay />
+      </>
+    );
+
+    const textarea = screen.getByLabelText('Notes');
+    textarea.focus();
+    fireEvent.keyDown(textarea, { key: '?' });
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('ignores "?" while a contenteditable element is focused', () => {
+    render(
+      <>
+        <div contentEditable data-testid="editable" />
+        <KeyboardShortcutsOverlay />
+      </>
+    );
+
+    const editable = screen.getByTestId('editable');
+    editable.focus();
+    fireEvent.keyDown(editable, { key: '?' });
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('closes on Escape', () => {
+    render(<KeyboardShortcutsOverlay />);
+    fireEvent.keyDown(window, { key: '?' });
+    expect(screen.getByRole('dialog')).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('closes via the Close button', () => {
+    render(<KeyboardShortcutsOverlay />);
+    fireEvent.keyDown(window, { key: '?' });
+
+    fireEvent.click(screen.getByText('Close'));
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('restores focus to the previously-focused element on close', async () => {
+    render(
+      <>
+        <button data-testid="trigger">Trigger</button>
+        <KeyboardShortcutsOverlay />
+      </>
+    );
+
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    fireEvent.keyDown(window, { key: '?' });
+    // Dialog moves focus inside itself asynchronously (a short setTimeout).
+    await waitFor(() => expect(document.activeElement).not.toBe(trigger));
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('renders shortcuts grouped by section', () => {
+    render(<KeyboardShortcutsOverlay />);
+    fireEvent.keyDown(window, { key: '?' });
+
+    expect(screen.getByRole('region', { name: 'Navigation' })).toBeTruthy();
+    expect(screen.getByRole('region', { name: 'Dialogs' })).toBeTruthy();
+    expect(screen.getByText('Open the command palette')).toBeTruthy();
+    expect(screen.getByText('Close the open dialog or overlay')).toBeTruthy();
+  });
+});

--- a/src/components/shell/KeyboardShortcutsOverlay.tsx
+++ b/src/components/shell/KeyboardShortcutsOverlay.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Dialog } from '@/components/ui/Dialog';
+import { GLOBAL_SHORTCUTS, groupShortcuts } from '@/lib/shortcuts';
+
+const EDITABLE_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (EDITABLE_TAGS.has(target.tagName)) return true;
+  return target.isContentEditable;
+}
+
+/**
+ * Global keyboard-shortcuts reference, opened with `?` (Shift+/) from
+ * anywhere -- except while an input, textarea, select, or contenteditable
+ * element is focused, so typing a literal "?" in a form field never
+ * triggers it.
+ *
+ * Mount this once per app (e.g. in the root layout, or on any always-mounted
+ * shell component); it listens globally regardless of where it's rendered.
+ */
+export function KeyboardShortcutsOverlay() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== '?') return;
+      if (isEditableTarget(event.target)) return;
+      event.preventDefault();
+      setIsOpen(true);
+    }
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  const close = () => setIsOpen(false);
+  const grouped = groupShortcuts(GLOBAL_SHORTCUTS);
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={close}
+      labelledById="keyboard-shortcuts-title"
+      className="w-full max-w-md rounded-2xl border border-[rgba(0,212,255,0.3)] bg-[#0a0a0b] p-6 text-white shadow-[0_0_30px_rgba(0,212,255,0.15)]"
+    >
+      <h2 id="keyboard-shortcuts-title" className="text-lg font-semibold">
+        Keyboard shortcuts
+      </h2>
+
+      <div className="mt-4 space-y-5">
+        {Array.from(grouped.entries()).map(([group, entries]) => (
+          <section key={group} aria-label={group}>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-white/40">{group}</h3>
+            <dl className="mt-2 space-y-2">
+              {entries.map((entry) => (
+                <div key={entry.keys} className="flex items-center justify-between text-sm">
+                  <dt className="text-white/70">{entry.description}</dt>
+                  <dd className="rounded border border-white/15 bg-white/5 px-2 py-0.5 font-mono text-xs text-[#0ff0fc]">
+                    {entry.keys}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={close}
+        className="mt-6 w-full rounded-lg border border-white/20 py-2 text-sm font-medium hover:border-white/40"
+      >
+        Close
+      </button>
+    </Dialog>
+  );
+}
+
+export default KeyboardShortcutsOverlay;

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { groupShortcuts, type ShortcutEntry } from '@/lib/shortcuts';
+
+describe('groupShortcuts', () => {
+  it('groups entries by their group field, preserving order within each group', () => {
+    const entries: ShortcutEntry[] = [
+      { keys: 'A', description: 'a', group: 'X' },
+      { keys: 'B', description: 'b', group: 'Y' },
+      { keys: 'C', description: 'c', group: 'X' },
+    ];
+
+    const grouped = groupShortcuts(entries);
+
+    expect(Array.from(grouped.keys())).toEqual(['X', 'Y']);
+    expect(grouped.get('X')?.map((e) => e.keys)).toEqual(['A', 'C']);
+    expect(grouped.get('Y')?.map((e) => e.keys)).toEqual(['B']);
+  });
+
+  it('returns an empty map for an empty list', () => {
+    expect(groupShortcuts([]).size).toBe(0);
+  });
+});

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,0 +1,53 @@
+export interface ShortcutEntry {
+  /** Display label for the key combination, e.g. "⌘K". */
+  keys: string;
+  description: string;
+  group: string;
+}
+
+/**
+ * Single source of truth for global keyboard shortcuts, so the help overlay
+ * (`KeyboardShortcutsOverlay`) can never drift out of sync with the actual
+ * bindings. When a new global shortcut is added elsewhere in the app, add
+ * an entry here too.
+ */
+export const GLOBAL_SHORTCUTS: ShortcutEntry[] = [
+  {
+    keys: '⌘K / Ctrl+K',
+    description: 'Open the command palette',
+    group: 'Navigation',
+  },
+  {
+    keys: '?',
+    description: 'Show this shortcuts overlay',
+    group: 'Navigation',
+  },
+  {
+    keys: 'Esc',
+    description: 'Close the open dialog or overlay',
+    group: 'Dialogs',
+  },
+  {
+    keys: '↑ / ↓',
+    description: 'Move the highlighted item in a list or the command palette',
+    group: 'Dialogs',
+  },
+  {
+    keys: 'Enter',
+    description: 'Activate the highlighted item',
+    group: 'Dialogs',
+  },
+];
+
+export function groupShortcuts(entries: ShortcutEntry[]): Map<string, ShortcutEntry[]> {
+  const grouped = new Map<string, ShortcutEntry[]>();
+  for (const entry of entries) {
+    const existing = grouped.get(entry.group);
+    if (existing) {
+      existing.push(entry);
+    } else {
+      grouped.set(entry.group, [entry]);
+    }
+  }
+  return grouped;
+}


### PR DESCRIPTION
## Summary

**Context:** continuing the pattern from #924/#968/#918 -- this repo has a large amount of previously-deleted UI infrastructure (a prior incident deleted ~2,500 files / 170K lines). There's no `AppShellLayout` to mount a global overlay in yet (that's #922/#921's territory), so per maintainer guidance I'm building this as a small, self-contained, fresh component and mounting it on the Analytics page as a concrete integration point, same approach as #924's tour and #968's rail.

## What this adds

- **`GLOBAL_SHORTCUTS`** (`src/lib/shortcuts.ts`) -- a single typed registry (`{ keys, description, group }`) so the overlay can't drift out of sync with real bindings. Currently lists `Cmd/Ctrl+K` (the command palette from #918), `?` (this overlay), `Esc`, and arrow-key/Enter navigation (used by dialogs and the palette).
- **`KeyboardShortcutsOverlay`** -- listens globally for `?`, ignoring it while an `<input>`, `<textarea>`, `<select>`, or any `contenteditable` element is focused (so typing a literal `?` in a form field never triggers it). Renders the registry, grouped by section, in the shared `Dialog` primitive -- full focus trap, Escape to close, background `inert`, focus restored on close, `prefers-reduced-motion` respected (all inherited from `Dialog`, no new logic needed there).
- `docs/KEYBOARD_SHORTCUTS.md`.

## Testing

- `KeyboardShortcutsOverlay.test.tsx` -- 9 tests: renders nothing initially, opens on `?` with nothing focused, ignores `?` while input/textarea/contenteditable focused, closes on Escape and via the Close button, restores focus to the pre-open element on close, renders shortcuts grouped by section.
- `shortcuts.test.ts` -- 2 tests for the `groupShortcuts` helper (preserves order within group, handles an empty list).
- All 11 new tests pass. Confirmed via `git stash` A/B comparison that this diff adds zero new build errors and zero new test failures elsewhere (baseline: 22 failed test files / 37 failed tests / 488 passed, unchanged except my +11 passing).
- Also removes the same pre-existing unused `isAnyLoading` local in `analytics/page.tsx` that #924 touches (the pre-commit lint hook flags it on any touch of this file; one-line removal, no behavior change). If #924 merges first, this hunk will be a no-op on rebase.

Closes #919