### PR TITLE
feat: route breadcrumbs for nested commitment routes

### DIFF
--- a/docs/BREADCRUMBS.md
+++ b/docs/BREADCRUMBS.md
@@ -1,0 +1,60 @@
+# Breadcrumbs
+
+An accessible breadcrumb trail derived from the current route's path
+segments, for nested routes like `/commitments/[id]`.
+
+## Usage
+
+```tsx
+import { Breadcrumbs } from '@/components/shell/Breadcrumbs';
+
+export default function CommitmentDetailPage() {
+  const commitment = getCommitmentById(params.id);
+  return (
+    <main>
+      <Breadcrumbs currentLabel={`${commitment.type} Commitment`} />
+      {/* ... */}
+    </main>
+  );
+}
+```
+
+## API
+
+```ts
+interface BreadcrumbsProps {
+  /**
+   * Overrides the label for the trailing path segment -- e.g. resolving a
+   * commitment id to a friendly label. Falls back to a readable version of
+   * the raw segment when omitted.
+   */
+  currentLabel?: string;
+}
+```
+
+## Behavior
+
+- Segments are derived from `usePathname()`, split on `/`.
+- **Hidden on top-level routes** (0 or 1 path segments -- e.g. `/`,
+  `/analytics`, `/create`), where a trail adds no navigational value.
+- Each non-final segment renders as a real `<Link>` (keyboard-focusable in
+  document order, no custom key handling needed).
+- The final segment is not a link -- it's the current page, marked
+  `aria-current="page"`, and is intentionally the only place a resolved
+  friendly label (`currentLabel`) is used. Intermediate segments always use
+  a readable version of the raw route segment (title-cased, `-`/`_` folded
+  to spaces).
+- **Id resolution fallback:** when `currentLabel` isn't provided and the
+  trailing segment looks like an opaque id (no separators, > 12 characters),
+  it's shown truncated (`9f2a7c3e…`) rather than the full raw string.
+  Shorter or hyphenated segments are title-cased instead (`overview-panel`
+  → "Overview Panel").
+- Renders as `<nav aria-label="Breadcrumb">` -- distinct from the page's
+  `<h1>`, so it never duplicates the page title.
+
+## Testing
+
+See `src/components/shell/Breadcrumbs.test.tsx`: hidden on root and
+top-level routes, renders a trail with correct hrefs for nested routes,
+marks the last segment `aria-current="page"` and non-linked, friendly-label
+override, truncated-id fallback, title-cased fallback for short segments.

--- a/src/app/commitments/[id]/page.tsx
+++ b/src/app/commitments/[id]/page.tsx
@@ -20,6 +20,7 @@ import { CommitmentStatusProvider, useCommitmentStatus } from '@/context/Commitm
 import { useShareLink } from '@/hooks/useShareLink';
 import { useToast } from '@/components/toast/ToastProvider';
 import { getAppExplorerNetwork } from './explorerNetwork';
+import { Breadcrumbs } from '@/components/shell/Breadcrumbs';
 
 // Mock Commitments
 const MOCK_COMMITMENTS: Record<
@@ -218,7 +219,9 @@ export default function CommitmentDetailPage({
         <CommitmentStatusProvider commitmentId={commitment.id}>
             <main id="main-content" className="min-h-screen bg-[#050505] text-[#f5f5f7] p-4 sm:p-8 lg:p-12">
                 <div className="max-w-7xl mx-auto space-y-8">
-                    
+
+                    <Breadcrumbs currentLabel={`${commitment.type} Commitment`} />
+
                     <CommitmentDetailHeaderWithStatus
                         commitmentId={commitment.id}
                         commitmentType={commitment.type}

--- a/src/components/shell/Breadcrumbs.test.tsx
+++ b/src/components/shell/Breadcrumbs.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { Breadcrumbs } from '@/components/shell/Breadcrumbs';
+
+const usePathnameMock = vi.fn<() => string>();
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => usePathnameMock(),
+}));
+
+describe('Breadcrumbs', () => {
+  afterEach(() => {
+    cleanup();
+    usePathnameMock.mockReset();
+  });
+
+  it('renders nothing on the root route', () => {
+    usePathnameMock.mockReturnValue('/');
+    const { container } = render(<Breadcrumbs />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing on a top-level route', () => {
+    usePathnameMock.mockReturnValue('/analytics');
+    const { container } = render(<Breadcrumbs />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a trail for a nested route', () => {
+    usePathnameMock.mockReturnValue('/commitments/abc123');
+    render(<Breadcrumbs />);
+
+    const nav = screen.getByRole('navigation', { name: 'Breadcrumb' });
+    expect(nav).toBeTruthy();
+
+    const link = screen.getByRole('link', { name: 'Commitments' });
+    expect(link.getAttribute('href')).toBe('/commitments');
+  });
+
+  it('marks the last segment as the current page (not a link)', () => {
+    usePathnameMock.mockReturnValue('/commitments/abc123');
+    render(<Breadcrumbs />);
+
+    const current = screen.getByText('Abc123');
+    expect(current.getAttribute('aria-current')).toBe('page');
+    expect(current.tagName).not.toBe('A');
+  });
+
+  it('resolves the trailing segment to a friendly label when provided', () => {
+    usePathnameMock.mockReturnValue('/commitments/abc123');
+    render(<Breadcrumbs currentLabel="Balanced Commitment" />);
+
+    const current = screen.getByText('Balanced Commitment');
+    expect(current.getAttribute('aria-current')).toBe('page');
+    expect(screen.queryByText('abc123', { exact: false })).toBeNull();
+  });
+
+  it('falls back to a truncated raw id when no friendly label is available', () => {
+    usePathnameMock.mockReturnValue('/commitments/9f2a7c3e1b8d4f6a');
+    render(<Breadcrumbs />);
+
+    expect(screen.getByText('9f2a7c3e…')).toBeTruthy();
+  });
+
+  it('title-cases short, hyphenated raw segments', () => {
+    usePathnameMock.mockReturnValue('/commitments/overview-panel');
+    render(<Breadcrumbs />);
+
+    expect(screen.getByText('Overview Panel')).toBeTruthy();
+  });
+
+  it('links are real anchors, keyboard-focusable in document order', () => {
+    usePathnameMock.mockReturnValue('/commitments/abc123/history');
+    render(<Breadcrumbs />);
+
+    const links = screen.getAllByRole('link');
+    expect(links.map((l) => l.getAttribute('href'))).toEqual([
+      '/commitments',
+      '/commitments/abc123',
+    ]);
+  });
+});

--- a/src/components/shell/Breadcrumbs.tsx
+++ b/src/components/shell/Breadcrumbs.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export interface BreadcrumbsProps {
+  /**
+   * Overrides the label for the trailing path segment -- e.g. resolving a
+   * commitment id ("cmt-9f2a...") to a friendly label ("Balanced Commitment").
+   * Falls back to a readable version of the raw segment when omitted.
+   */
+  currentLabel?: string;
+}
+
+function readableSegment(segment: string): string {
+  const decoded = decodeURIComponent(segment);
+  // A long opaque id (no separators) is more useful truncated than titleized.
+  if (decoded.length > 12 && !/[-_\s]/.test(decoded)) {
+    return `${decoded.slice(0, 8)}…`;
+  }
+  return decoded
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((word) => word[0]?.toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * Accessible breadcrumb trail derived from the current route's path
+ * segments. Renders nothing on top-level routes (0 or 1 segments) where a
+ * trail adds no navigational value -- e.g. `/analytics`, `/create`.
+ */
+export function Breadcrumbs({ currentLabel }: BreadcrumbsProps) {
+  const pathname = usePathname() ?? '';
+  const segments = pathname.split('/').filter(Boolean);
+
+  if (segments.length < 2) return null;
+
+  const crumbs = segments.map((segment, index) => {
+    const href = `/${segments.slice(0, index + 1).join('/')}`;
+    const isLast = index === segments.length - 1;
+    const label = isLast && currentLabel ? currentLabel : readableSegment(segment);
+    return { href, label, isLast };
+  });
+
+  return (
+    <nav aria-label="Breadcrumb" data-testid="breadcrumbs">
+      <ol className="flex items-center flex-wrap gap-1 text-sm text-[#666]">
+        {crumbs.map((crumb) => (
+          <li key={crumb.href} className="flex items-center gap-1">
+            {crumb.isLast ? (
+              <span aria-current="page" className="text-white font-medium">
+                {crumb.label}
+              </span>
+            ) : (
+              <>
+                <Link
+                  href={crumb.href}
+                  className="hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0ff0fc] rounded"
+                >
+                  {crumb.label}
+                </Link>
+                <span aria-hidden="true" className="text-[#333]">
+                  /
+                </span>
+              </>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}
+
+export default Breadcrumbs;


### PR DESCRIPTION
## Summary

**Context:** same constraint noted on #924/#968/#918/#919 -- this repo has a large amount of previously-deleted UI infrastructure from a prior incident, and there's no `AppShellLayout` to mount a global breadcrumb region in yet. Per maintainer guidance, this is a small, standalone `Breadcrumbs` component wired into the one real nested route in the app (`/commitments/[id]`) rather than the app shell.

## What this adds

- **`Breadcrumbs`** (`src/components/shell/Breadcrumbs.tsx`) -- derives its trail from `usePathname()`.
  - **Hidden on top-level routes** (0 or 1 path segments -- `/`, `/analytics`, `/create`) where a trail adds no navigational value.
  - Non-final segments render as real `<Link>`s -- keyboard-focusable in normal document tab order, no custom key handling needed.
  - The final segment is `aria-current="page"`, never a link, and is the only place a resolved friendly label (`currentLabel` prop) applies -- so it never duplicates the page's `<h1>`.
  - Id-resolution fallback when no `currentLabel` is given: long opaque segments (no separators, >12 chars) are truncated (`9f2a7c3e…`); shorter/hyphenated segments are title-cased (`overview-panel` → "Overview Panel").
- Wired into the commitment detail page, passing the commitment's `type` as the friendly label for the trailing id (e.g. "Balanced Commitment").
- `docs/BREADCRUMBS.md`.

## Testing

- `Breadcrumbs.test.tsx` -- 8 tests: hidden on root route, hidden on top-level route, renders trail with correct `href`s for a nested route, marks the last segment `aria-current="page"` and non-linked, `currentLabel` override, truncated-id fallback, title-cased fallback for short segments, links are real anchors in document order.
- All 8 new tests pass. Confirmed via `git stash` A/B comparison that this diff adds zero new build errors and zero new test failures elsewhere (baseline: 22 failed test files / 37 failed tests / 488 passed, unchanged except my +8 passing).

Closes #922