### PR TITLE
feat: detect marketplace watchlist alerts

### DIFF
--- a/src/components/marketplace/SavedListingsRail.tsx
+++ b/src/components/marketplace/SavedListingsRail.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+export interface SavedListing {
+  id: string;
+  title: string;
+  price: string;
+  status?: 'Active' | 'Sold' | 'Cancelled';
+}
+
+export function SavedListingsRail({
+  listings,
+  savedIds,
+  onRemove,
+  onSelect,
+}: {
+  listings: SavedListing[];
+  savedIds: ReadonlySet<string>;
+  onRemove: (id: string) => void;
+  onSelect?: (id: string) => void;
+}) {
+  const saved = listings.filter((listing) => savedIds.has(listing.id));
+  if (saved.length === 0) return null;
+
+  return (
+    <section aria-label="Saved listings" className="mb-6 rounded-xl border border-white/10 p-4">
+      <h2 className="mb-3 text-sm font-semibold text-white">Saved</h2>
+      <ul className="flex gap-3 overflow-x-auto">
+        {saved.map((listing) => (
+          <li key={listing.id} className="min-w-44 rounded-lg bg-white/5 p-3 text-sm text-white">
+            <button type="button" onClick={() => onSelect?.(listing.id)} className="block text-left">
+              <span className="block font-medium">{listing.title}</span>
+              <span className="block text-white/60">{listing.price}</span>
+              {listing.status && listing.status !== 'Active' && (
+                <span className="block text-xs text-amber-300">{listing.status}</span>
+              )}
+            </button>
+            <button
+              type="button"
+              aria-label={`Remove ${listing.title} from saved listings`}
+              onClick={() => onRemove(listing.id)}
+              className="mt-2 text-xs text-cyan-300 underline"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/hooks/useMarketplaceAlerts.test.ts
+++ b/src/hooks/useMarketplaceAlerts.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { detectMarketplaceAlerts, type MarketplaceSnapshot } from './useMarketplaceAlerts';
+
+const oldListing: MarketplaceSnapshot = {
+  id: 'listing-1',
+  title: 'Safe commitment',
+  price: 100,
+  status: 'Active',
+};
+
+describe('detectMarketplaceAlerts', () => {
+  it('detects price drops and sold transitions only for watched listings', () => {
+    const alerts = detectMarketplaceAlerts(
+      new Map([[oldListing.id, oldListing]]),
+      [{ ...oldListing, price: 80, status: 'Sold' }],
+      new Set(['listing-1']),
+    );
+
+    expect(alerts.map((alert) => alert.type)).toEqual(['price-drop', 'status-change']);
+  });
+
+  it('ignores untracked listings and unchanged states', () => {
+    expect(
+      detectMarketplaceAlerts(
+        new Map([[oldListing.id, oldListing]]),
+        [{ ...oldListing }],
+        new Set(),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/src/hooks/useMarketplaceAlerts.ts
+++ b/src/hooks/useMarketplaceAlerts.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface MarketplaceSnapshot {
+  id: string;
+  title: string;
+  price: number;
+  status: 'Active' | 'Sold' | 'Cancelled';
+}
+
+export interface MarketplaceAlert {
+  key: string;
+  listingId: string;
+  message: string;
+  type: 'price-drop' | 'status-change';
+}
+
+export function detectMarketplaceAlerts(
+  previous: ReadonlyMap<string, MarketplaceSnapshot>,
+  current: readonly MarketplaceSnapshot[],
+  watchedIds: ReadonlySet<string>,
+): MarketplaceAlert[] {
+  return current.flatMap((listing) => {
+    if (!watchedIds.has(listing.id)) return [];
+    const old = previous.get(listing.id);
+    if (!old) return [];
+    const alerts: MarketplaceAlert[] = [];
+    if (listing.price < old.price) {
+      alerts.push({
+        key: `${listing.id}:price:${listing.price}`,
+        listingId: listing.id,
+        message: `${listing.title} dropped in price.`,
+        type: 'price-drop',
+      });
+    }
+    if (listing.status !== old.status && listing.status !== 'Active') {
+      alerts.push({
+        key: `${listing.id}:status:${listing.status}`,
+        listingId: listing.id,
+        message: `${listing.title} is now ${listing.status.toLowerCase()}.`,
+        type: 'status-change',
+      });
+    }
+    return alerts;
+  });
+}
+
+export function useMarketplaceAlerts(
+  listings: readonly MarketplaceSnapshot[],
+  watchedIds: ReadonlySet<string>,
+  notify: (alert: MarketplaceAlert) => void,
+) {
+  const previousRef = useRef(new Map<string, MarketplaceSnapshot>());
+  const seenRef = useRef(new Set<string>());
+  const [mutedIds, setMutedIds] = useState<Set<string>>(() => {
+    try {
+      return new Set(JSON.parse(localStorage.getItem('commitlabs:marketplace-alert-mutes') ?? '[]'));
+    } catch {
+      return new Set();
+    }
+  });
+
+  useEffect(() => {
+    const alerts = detectMarketplaceAlerts(previousRef.current, listings, watchedIds);
+    alerts.forEach((alert) => {
+      if (!mutedIds.has(alert.listingId) && !seenRef.current.has(alert.key)) {
+        seenRef.current.add(alert.key);
+        notify(alert);
+      }
+    });
+    previousRef.current = new Map(listings.map((listing) => [listing.id, listing]));
+  }, [listings, mutedIds, notify, watchedIds]);
+
+  const setMuted = useCallback((listingId: string, muted: boolean) => {
+    setMutedIds((current) => {
+      const next = new Set(current);
+      if (muted) next.add(listingId);
+      else next.delete(listingId);
+      localStorage.setItem('commitlabs:marketplace-alert-mutes', JSON.stringify([...next]));
+      return next;
+    });
+  }, []);
+
+  return { mutedIds, setMuted };
+}

--- a/src/hooks/useMarketplaceWatchlist.test.ts
+++ b/src/hooks/useMarketplaceWatchlist.test.ts
@@ -1,0 +1,22 @@
+/** @vitest-environment happy-dom */
+
+import { describe, expect, it } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  MARKETPLACE_WATCHLIST_KEY,
+  useMarketplaceWatchlist,
+} from './useMarketplaceWatchlist';
+
+describe('useMarketplaceWatchlist', () => {
+  it('restores and persists saved listing ids', () => {
+    localStorage.setItem(MARKETPLACE_WATCHLIST_KEY, JSON.stringify(['listing-1']));
+    const { result } = renderHook(() => useMarketplaceWatchlist());
+
+    expect(result.current.isSaved('listing-1')).toBe(true);
+    act(() => result.current.toggle('listing-2'));
+    expect(JSON.parse(localStorage.getItem(MARKETPLACE_WATCHLIST_KEY) ?? '[]')).toEqual([
+      'listing-1',
+      'listing-2',
+    ]);
+  });
+});

--- a/src/hooks/useMarketplaceWatchlist.ts
+++ b/src/hooks/useMarketplaceWatchlist.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export const MARKETPLACE_WATCHLIST_KEY = 'commitlabs:marketplace-watchlist';
+
+function readWatchlist(): string[] {
+  try {
+    const value: unknown = JSON.parse(window.localStorage.getItem(MARKETPLACE_WATCHLIST_KEY) ?? '[]');
+    return Array.isArray(value) ? value.filter((id): id is string => typeof id === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+export function useMarketplaceWatchlist() {
+  const [savedIds, setSavedIds] = useState<string[]>([]);
+
+  useEffect(() => setSavedIds(readWatchlist()), []);
+
+  useEffect(() => {
+    window.localStorage.setItem(MARKETPLACE_WATCHLIST_KEY, JSON.stringify(savedIds));
+  }, [savedIds]);
+
+  const toggle = useCallback((listingId: string) => {
+    setSavedIds((current) =>
+      current.includes(listingId)
+        ? current.filter((id) => id !== listingId)
+        : [...current, listingId],
+    );
+  }, []);
+
+  const isSaved = useCallback((listingId: string) => savedIds.includes(listingId), [savedIds]);
+  const savedSet = useMemo(() => new Set(savedIds), [savedIds]);
+
+  return { savedIds, savedSet, isSaved, toggle };
+}


### PR DESCRIPTION
Closes #936

Add deduplicated price-drop and sold/cancelled status detection for watched listings, with persisted per-listing mute state and a notification callback for the existing toast/notification layer. This branch builds on the watchlist primitives from #935.

Validation: git diff --check passed. The targeted test could not run because this checkout has no installed vitest binary.