### PR TITLE
feat: add seller marketplace filter

### DIFF
--- a/src/components/marketplace/MarketplaceFilters.test.tsx
+++ b/src/components/marketplace/MarketplaceFilters.test.tsx
@@ -1,0 +1,29 @@
+/** @vitest-environment happy-dom */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  filterListingsBySeller,
+  MarketplaceFilters,
+  truncateSellerAddress,
+} from './MarketplaceFilters';
+
+describe('MarketplaceFilters', () => {
+  it('filters and safely truncates seller addresses', () => {
+    const listings = [{ sellerAddress: 'GABC123456789' }, { sellerAddress: 'GXYZ987654321' }];
+    expect(filterListingsBySeller(listings, 'xyz')).toHaveLength(1);
+    expect(truncateSellerAddress('GABC123456789')).toBe('GABC12…4321');
+  });
+
+  it('emits seller changes and clear actions', () => {
+    const onSellerChange = vi.fn();
+    const onClear = vi.fn();
+    render(<MarketplaceFilters seller="GABC" onSellerChange={onSellerChange} onClear={onClear} />);
+    fireEvent.change(screen.getByRole('textbox', { name: 'Filter by seller' }), {
+      target: { value: 'GXYZ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Clear seller filter' }));
+    expect(onSellerChange).toHaveBeenCalledWith('GXYZ');
+    expect(onClear).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/marketplace/MarketplaceFilters.tsx
+++ b/src/components/marketplace/MarketplaceFilters.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+export interface SellerListing {
+  sellerAddress: string;
+}
+
+export function truncateSellerAddress(address: string, leading = 6, trailing = 4): string {
+  if (address.length <= leading + trailing + 1) return address;
+  return `${address.slice(0, leading)}…${address.slice(-trailing)}`;
+}
+
+export function filterListingsBySeller<T extends SellerListing>(
+  listings: readonly T[],
+  sellerQuery: string,
+): T[] {
+  const query = sellerQuery.trim().toLowerCase();
+  if (!query) return [...listings];
+  return listings.filter((listing) => listing.sellerAddress.toLowerCase().includes(query));
+}
+
+export function MarketplaceFilters({
+  seller,
+  onSellerChange,
+  onClear,
+}: {
+  seller: string;
+  onSellerChange: (value: string) => void;
+  onClear: () => void;
+}) {
+  return (
+    <div aria-label="Marketplace filters" className="flex flex-wrap items-end gap-3">
+      <label className="flex min-w-56 flex-col gap-1 text-sm text-white/70">
+        Seller
+        <input
+          value={seller}
+          onChange={(event) => onSellerChange(event.target.value)}
+          placeholder="Search seller address"
+          aria-label="Filter by seller"
+          className="rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-white outline-none focus:border-cyan-300"
+        />
+      </label>
+      {seller.trim() && (
+        <button type="button" onClick={onClear} className="text-sm text-cyan-300 underline">
+          Clear seller filter
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #937

Add an accessible seller filter primitive with case-insensitive matching, active clear behavior, and safe seller-address truncation for marketplace surfaces.

Validation: git diff --check passed. The targeted test could not run because this checkout has no installed vitest binary.