### PR TITLE
ci: add /create, /settings, and /commitments/[id] to lighthouserc col…

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,37 @@
+{
+  "ci": {
+    "collect": {
+      "startServerCommand": "npm start",
+      "startServerReadyPattern": "ready on",
+      "startServerReadyTimeout": 30000,
+      "url": [
+        "http://localhost:3000/",
+        "http://localhost:3000/marketplace",
+        "http://localhost:3000/commitments",
+        "http://localhost:3000/create",
+        "http://localhost:3000/settings",
+        "http://localhost:3000/commitments/1"
+      ],
+      "numberOfRuns": 3,
+      "settings": {
+        "onlyCategories": ["performance", "accessibility", "best-practices", "seo"]
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.7 }],
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "categories:best-practices": ["error", { "minScore": 0.9 }],
+        "categories:seo": ["error", { "minScore": 0.9 }],
+        "first-contentful-paint": ["warn", { "maxNumericValue": 3000 }],
+        "largest-contentful-paint": ["warn", { "maxNumericValue": 4000 }],
+        "total-blocking-time": ["warn", { "maxNumericValue": 500 }],
+        "cumulative-layout-shift": ["warn", { "maxNumericValue": 0.15 }],
+        "interactive": ["warn", { "maxNumericValue": 5000 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
Closes #1617

### Summary of Changes

- Updated `lighthouserc.json` to add `/create`, `/settings`, and a representative `/commitments/1` detail page route to the `ci.collect.url` audit list.
- Ensures the CI accessibility gate (`categories:accessibility` with `minScore: 0.9`) actively audits high-density and critical user flows, preventing regressions on unmeasured routes.

### Verification

- Validated `lighthouserc.json` syntax and structure.
- Confirmed all required routes (`/`, `/marketplace`, `/commitments`, `/create`, `/settings`, `/commitments/1`) are present in `collect.url`.
