### PR TITLE
perf: fetch commitment history in parallel in RecentActivityFeed (Closes #1396)

### DIFF
--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,275 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+interface SkeletonProps {
+  className?: string;
+  width?: string | number;
+  height?: string | number;
+  rounded?: 'none' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
+  shimmer?: boolean;
+}
+
+/**
+ * Base skeleton component with reduced motion support
+ *
+ * Accessibility considerations:
+ * - Uses `prefers-reduced-motion` media query to disable animations
+ * - Provides static loading state for users with motion sensitivity
+ * - Includes aria-label for screen readers
+ */
+export function Skeleton({
+  className,
+  width,
+  height,
+  rounded = 'md',
+  shimmer = true,
+}: SkeletonProps) {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    // Check for reduced motion preference
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setPrefersReducedMotion(e.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  const borderRadius = {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    full: 'rounded-full',
+  }[rounded];
+
+  const style: React.CSSProperties = {};
+  if (width) style.width = typeof width === 'number' ? `${width}px` : width;
+  if (height) style.height = typeof height === 'number' ? `${height}px` : height;
+
+  return (
+    <div
+      className={cn('relative overflow-hidden bg-[#1a1a1a]', borderRadius, className)}
+      style={style}
+      aria-label="Loading content"
+      role="status"
+    >
+      {/* Base background */}
+      <div className="absolute inset-0 bg-gradient-to-r from-[#1a1a1a] via-[#222] to-[#1a1a1a]" />
+
+      {/* Shimmer effect with reduced motion support */}
+      {shimmer && !prefersReducedMotion && (
+        <div className="absolute inset-0 -translate-x-full animate-shimmer bg-gradient-to-r from-transparent via-[rgba(255,255,255,0.05)] to-transparent" />
+      )}
+
+      {/* Static loading indicator for reduced motion */}
+      {shimmer && prefersReducedMotion && (
+        <div className="absolute inset-0 bg-gradient-to-r from-[#1a1a1a] via-[#252525] to-[#1a1a1a]" />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Skeleton for commitment cards in the commitments list
+ */
+export function CommitmentCardSkeleton() {
+  return (
+    <div className="bg-[#0a0a0a] border border-[#222] rounded-xl p-5">
+      <div className="flex justify-between items-start mb-4">
+        <div className="space-y-2">
+          <Skeleton width={120} height={24} />
+          <Skeleton width={80} height={20} />
+        </div>
+        <Skeleton width={60} height={24} rounded="full" />
+      </div>
+
+      <div className="space-y-3 mb-6">
+        <div className="flex justify-between">
+          <Skeleton width={80} height={16} />
+          <Skeleton width={100} height={16} />
+        </div>
+        <div className="flex justify-between">
+          <Skeleton width={80} height={16} />
+          <Skeleton width={100} height={16} />
+        </div>
+        <div className="flex justify-between">
+          <Skeleton width={80} height={16} />
+          <Skeleton width={100} height={16} />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Skeleton width="100%" height={8} />
+        <div className="flex justify-between text-sm">
+          <Skeleton width={40} height={14} />
+          <Skeleton width={40} height={14} />
+        </div>
+      </div>
+
+      <div className="flex gap-3 mt-6">
+        <Skeleton width="100%" height={36} />
+        <Skeleton width="100%" height={36} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Skeleton for marketplace cards
+ */
+export function MarketplaceCardSkeleton() {
+  return (
+    <div className="bg-gradient-to-b from-[#0a0a0a] to-[#111] border border-[#222] rounded-xl p-5">
+      <div className="flex justify-between items-start mb-4">
+        <div className="space-y-2">
+          <Skeleton width={100} height={24} />
+          <Skeleton width={60} height={20} />
+        </div>
+        <Skeleton width={80} height={28} rounded="full" />
+      </div>
+
+      <div className="space-y-3 mb-6">
+        <div className="flex justify-between">
+          <Skeleton width={60} height={16} />
+          <Skeleton width={100} height={16} />
+        </div>
+        <div className="flex justify-between">
+          <Skeleton width={60} height={16} />
+          <Skeleton width={100} height={16} />
+        </div>
+        <div className="flex justify-between">
+          <Skeleton width={60} height={16} />
+          <Skeleton width={100} height={16} />
+        </div>
+        <div className="flex justify-between">
+          <Skeleton width={60} height={16} />
+          <Skeleton width={100} height={16} />
+        </div>
+      </div>
+
+      <div className="border-t border-[#222] pt-4">
+        <div className="flex justify-between items-center">
+          <Skeleton width={80} height={16} />
+          <Skeleton width={100} height={32} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Skeleton for health metrics charts
+ */
+export function HealthChartSkeleton() {
+  return (
+    <div className="bg-[#111] border border-[#222] rounded-xl p-6">
+      <div className="flex justify-between items-center mb-6">
+        <Skeleton width={120} height={28} />
+        <div className="flex gap-2">
+          <Skeleton width={80} height={32} rounded="lg" />
+          <Skeleton width={80} height={32} rounded="lg" />
+          <Skeleton width={80} height={32} rounded="lg" />
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex justify-between">
+          <Skeleton width={60} height={16} />
+          <Skeleton width={80} height={16} />
+        </div>
+
+        {/* Chart area */}
+        <div className="relative h-[300px]">
+          {/* Y-axis */}
+          <div className="absolute left-0 top-0 bottom-0 w-12 space-y-8">
+            {[...Array(5)].map((_, i) => (
+              <Skeleton key={i} width={40} height={1} />
+            ))}
+          </div>
+
+          {/* X-axis */}
+          <div className="absolute left-12 right-0 bottom-0 h-6 flex justify-between">
+            {[...Array(6)].map((_, i) => (
+              <Skeleton key={i} width={40} height={1} />
+            ))}
+          </div>
+
+          {/* Chart lines */}
+          <div className="absolute left-12 right-4 top-4 bottom-10">
+            <div className="relative h-full">
+              {/* Grid lines */}
+              {[...Array(4)].map((_, i) => (
+                <div
+                  key={i}
+                  className="absolute left-0 right-0 h-px bg-[#222]"
+                  style={{ top: `${(i + 1) * 25}%` }}
+                />
+              ))}
+
+              {/* Simulated chart line */}
+              <div className="absolute inset-0">
+                <svg width="100%" height="100%" className="overflow-visible">
+                  <path
+                    d="M0,80 C40,60 80,40 120,60 C160,80 200,40 240,20 C280,0 320,40 360,60"
+                    fill="none"
+                    stroke="#333"
+                    strokeWidth="2"
+                    strokeDasharray="5,5"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-center gap-6 mt-4">
+          <Skeleton width={120} height={20} />
+          <Skeleton width={120} height={20} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Skeleton for commitment stats
+ */
+export function CommitmentStatsSkeleton() {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {[...Array(4)].map((_, i) => (
+        <div key={i} className="bg-[#0a0a0a] border border-[#222] rounded-xl p-4">
+          <Skeleton width={80} height={16} className="mb-2" />
+          <Skeleton width={120} height={28} />
+          <Skeleton width={60} height={14} className="mt-2" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Skeleton for filters section
+ */
+export function FiltersSkeleton() {
+  return (
+    <div className="flex flex-wrap gap-4 p-4 bg-[#0a0a0a] border border-[#222] rounded-xl">
+      {[...Array(5)].map((_, i) => (
+        <Skeleton key={i} width={100} height={36} rounded="lg" />
+      ))}
+    </div>
+  );
+}

--- a/src/components/dashboard/RecentActivityFeed.test.tsx
+++ b/src/components/dashboard/RecentActivityFeed.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RecentActivityFeed } from './RecentActivityFeed';
+import { apiGet } from '@/lib/apiClient';
+import { Commitment } from '@/lib/types/domain';
+
+vi.mock('@/lib/apiClient', () => ({
+  apiGet: vi.fn(),
+}));
+
+const mockCommitments: Commitment[] = [
+  {
+    id: 'CMT-ABC123',
+    type: 'Safe',
+    status: 'Active',
+    asset: 'XLM',
+    amount: '50,000',
+    createdDate: 'Jan 10, 2026',
+    expiryDate: 'Feb 9, 2026',
+  },
+  {
+    id: 'CMT-XYZ789',
+    type: 'Balanced',
+    status: 'Active',
+    asset: 'USDC',
+    amount: '100,000',
+    createdDate: 'Dec 15, 2025',
+    expiryDate: 'Feb 13, 2026',
+  },
+];
+
+const mockedApiGet = vi.mocked(apiGet);
+
+describe('RecentActivityFeed', () => {
+  beforeEach(() => {
+    mockedApiGet.mockReset();
+  });
+
+  it('renders loading state initially', () => {
+    mockedApiGet.mockImplementation(() => new Promise(() => {}));
+
+    render(<RecentActivityFeed commitments={mockCommitments} />);
+
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+  });
+
+  it('renders empty state when no commitments', async () => {
+    render(<RecentActivityFeed commitments={[]} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No Recent Activity')).toBeInTheDocument();
+    });
+  });
+
+  it('renders mixed event types correctly', async () => {
+    mockedApiGet.mockImplementation((url: string) => {
+      if (url.includes('CMT-ABC123')) {
+        return Promise.resolve({
+          success: true,
+          data: {
+            events: [
+              {
+                eventId: 'created:CMT-ABC123',
+                kind: 'created',
+                occurredAt: new Date(Date.now() - 86400000).toISOString(),
+                payload: { asset: 'XLM', amount: '50,000' },
+              },
+              {
+                eventId: 'attestation:ATTR-001',
+                kind: 'attestation',
+                occurredAt: new Date(Date.now() - 3600000).toISOString(),
+                payload: { attestationId: 'ATTR-001', attestationType: 'health_check' },
+              },
+            ],
+          },
+        });
+      }
+      if (url.includes('CMT-XYZ789')) {
+        return Promise.resolve({
+          success: true,
+          data: {
+            events: [
+              {
+                eventId: 'settlement:CMT-XYZ789',
+                kind: 'settlement',
+                occurredAt: new Date(Date.now() - 7200000).toISOString(),
+                payload: { settlementAmount: '105,000' },
+              },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({ success: true, data: { events: [] } });
+    });
+
+    render(<RecentActivityFeed commitments={mockCommitments} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Recent Activity')).toBeInTheDocument();
+      expect(screen.getByText('Commitment Created')).toBeInTheDocument();
+      expect(screen.getByText('Attestation Recorded')).toBeInTheDocument();
+      expect(screen.getByText('Settlement Complete')).toBeInTheDocument();
+    });
+  });
+
+  it('caps feed length and shows view all', async () => {
+    const manyEvents = Array.from({ length: 10 }, (_, i) => ({
+      eventId: `event-${i}`,
+      kind: 'attestation' as const,
+      occurredAt: new Date(Date.now() - i * 3600000).toISOString(),
+      payload: { attestationId: `ATTR-${i}`, attestationType: 'health_check' },
+    }));
+
+    mockedApiGet.mockResolvedValue({
+      success: true,
+      data: { events: manyEvents },
+    });
+
+    render(<RecentActivityFeed commitments={mockCommitments} maxItems={5} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('View All Activity')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show view all when events <= maxItems', async () => {
+    const fewEvents = [
+      {
+        eventId: 'event-1',
+        kind: 'created' as const,
+        occurredAt: new Date().toISOString(),
+        payload: { asset: 'XLM', amount: '50,000' },
+      },
+    ];
+
+    mockedApiGet.mockResolvedValue({
+      success: true,
+      data: { events: fewEvents },
+    });
+
+    render(<RecentActivityFeed commitments={mockCommitments} maxItems={5} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('View All Activity')).not.toBeInTheDocument();
+    });
+  });
+
+  it('issues all per-commitment history requests concurrently', async () => {
+    const pendingResolvers: Array<(value: unknown) => void> = [];
+    mockedApiGet.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          pendingResolvers.push(resolve);
+        }),
+    );
+
+    render(<RecentActivityFeed commitments={mockCommitments} />);
+
+    // Every request must already be in flight before any of them resolves.
+    // A sequential loop would only issue the next request after the previous
+    // one settled, so both calls being issued here proves parallel issuance.
+    await waitFor(() => {
+      expect(mockedApiGet).toHaveBeenCalledTimes(mockCommitments.length);
+    });
+
+    expect(mockedApiGet).toHaveBeenCalledWith('/api/commitments/CMT-ABC123/history');
+    expect(mockedApiGet).toHaveBeenCalledWith('/api/commitments/CMT-XYZ789/history');
+
+    // Resolve all pending requests so loading finishes and the feed renders.
+    pendingResolvers.forEach((resolve) => resolve({ success: true, data: { events: [] } }));
+
+    await waitFor(() => {
+      expect(screen.getByText('No Recent Activity')).toBeInTheDocument();
+    });
+  });
+
+  it('still renders events from other commitments when one request fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      mockedApiGet.mockImplementation((url: string) => {
+        if (url.includes('CMT-ABC123')) {
+          return Promise.reject(new Error('network down'));
+        }
+        return Promise.resolve({
+          success: true,
+          data: {
+            events: [
+              {
+                eventId: 'settlement:CMT-XYZ789',
+                kind: 'settlement',
+                occurredAt: new Date().toISOString(),
+                payload: { settlementAmount: '105,000' },
+              },
+            ],
+          },
+        });
+      });
+
+      render(<RecentActivityFeed commitments={mockCommitments} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Settlement Complete')).toBeInTheDocument();
+      });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to load history for CMT-ABC123',
+        expect.any(Error),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});

--- a/src/components/dashboard/RecentActivityFeed.tsx
+++ b/src/components/dashboard/RecentActivityFeed.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { apiGet } from '@/lib/apiClient';
+import { Commitment, HistoryEvent, HistoryEventKind } from '@/lib/types/domain';
+import { Skeleton } from '@/components/Skeleton';
+
+type FeedEvent = HistoryEvent & {
+  commitmentId: string;
+};
+
+interface RecentActivityFeedProps {
+  commitments: Commitment[];
+  maxItems?: number;
+}
+
+function formatRelativeTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+  const diffWeeks = Math.floor(diffDays / 7);
+  const diffMonths = Math.floor(diffDays / 30);
+
+  if (diffSeconds < 60) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
+  if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+  if (diffWeeks < 4) return `${diffWeeks} week${diffWeeks === 1 ? '' : 's'} ago`;
+  if (diffMonths < 12) return `${diffMonths} month${diffMonths === 1 ? '' : 's'} ago`;
+  const diffYears = Math.floor(diffMonths / 12);
+  return `${diffYears} year${diffYears === 1 ? '' : 's'} ago`;
+}
+
+function getEventIcon(kind: HistoryEventKind) {
+  switch (kind) {
+    case 'created':
+      return (
+        <svg className="w-5 h-5 text-blue-400" viewBox="0 0 20 20" fill="none">
+          <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="2" />
+          <path d="M10 6v8M6 10h8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+      );
+    case 'attestation':
+      return (
+        <svg className="w-5 h-5 text-green-400" viewBox="0 0 20 20" fill="none">
+          <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="2" />
+          <path
+            d="M7 10l2 2 4-4"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    case 'early_exit':
+      return (
+        <svg className="w-5 h-5 text-orange-400" viewBox="0 0 20 20" fill="none">
+          <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="2" />
+          <path d="M7 10h6M10 7v6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+      );
+    case 'settlement':
+      return (
+        <svg className="w-5 h-5 text-purple-400" viewBox="0 0 20 20" fill="none">
+          <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="2" />
+          <path
+            d="M7 10l2 2 4-4"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    default:
+      return null;
+  }
+}
+
+function getEventTitle(event: FeedEvent): string {
+  switch (event.kind) {
+    case 'created':
+      return `Commitment Created`;
+    case 'attestation':
+      return `Attestation Recorded`;
+    case 'early_exit':
+      return `Early Exit`;
+    case 'settlement':
+      return `Settlement Complete`;
+    default:
+      return 'Event';
+  }
+}
+
+function getEventDescription(event: FeedEvent): string {
+  switch (event.kind) {
+    case 'created':
+      return `${event.payload.amount} ${event.payload.asset}`;
+    case 'attestation':
+      return event.payload.attestationType || 'Health check';
+    case 'early_exit':
+      return event.payload.exitedBy
+        ? `Exited by ${event.payload.exitedBy.slice(0, 8)}...`
+        : 'Early exit executed';
+    case 'settlement':
+      return event.payload.settlementAmount
+        ? `Settled: ${event.payload.settlementAmount}`
+        : 'Commitment settled';
+    default:
+      return '';
+  }
+}
+
+export function RecentActivityFeed({ commitments, maxItems = 5 }: RecentActivityFeedProps) {
+  const [events, setEvents] = useState<FeedEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadEvents() {
+      if (commitments.length === 0) {
+        setLoading(false);
+        return;
+      }
+
+      // Fetch every commitment's history in parallel. `Promise.allSettled`
+      // preserves the previous per-commitment try/catch-and-log behavior: a
+      // failed request for one commitment never blocks the others from
+      // rendering, so total time is ~max(latency) instead of N × latency.
+      const results = await Promise.allSettled(
+        commitments.map(async (commitment) => {
+          try {
+            const response = await apiGet<{ success: boolean; data: { events: HistoryEvent[] } }>(
+              `/api/commitments/${commitment.id}/history`,
+            );
+
+            if (response.success && response.data?.events) {
+              return response.data.events.map((event) => ({
+                ...event,
+                commitmentId: commitment.id,
+              }));
+            }
+            return [];
+          } catch (err) {
+            console.error(`Failed to load history for ${commitment.id}`, err);
+            return [];
+          }
+        }),
+      );
+
+      const allEvents: FeedEvent[] = results.flatMap((result) =>
+        result.status === 'fulfilled' ? result.value : [],
+      );
+
+      allEvents.sort((a, b) => new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime());
+
+      setEvents(allEvents);
+      setLoading(false);
+    }
+
+    loadEvents();
+  }, [commitments]);
+
+  if (loading) {
+    return (
+      <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+        <div className="p-4 border-b border-zinc-800">
+          <Skeleton className="h-6 w-40" />
+        </div>
+        <div className="p-4 space-y-4">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="flex items-start gap-4">
+              <Skeleton className="h-10 w-10 rounded-full" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-3 w-24" />
+              </div>
+              <Skeleton className="h-3 w-20" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const displayEvents = events.slice(0, maxItems);
+  const hasMore = events.length > maxItems;
+
+  if (displayEvents.length === 0) {
+    return (
+      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center">
+        <h3 className="text-lg font-medium text-white mb-2">No Recent Activity</h3>
+        <p className="text-zinc-400 text-sm">Activity from your commitments will appear here.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+      <div className="p-4 border-b border-zinc-800 flex items-center justify-between">
+        <h3 className="text-lg font-medium text-white">Recent Activity</h3>
+        <span className="text-xs font-semibold bg-zinc-800 text-zinc-400 px-2.5 py-1 rounded-full">
+          {events.length} events
+        </span>
+      </div>
+
+      <ul className="divide-y divide-zinc-800/50" aria-label="Recent activity">
+        {displayEvents.map((event) => (
+          <li key={event.eventId} className="p-4 hover:bg-zinc-800/50 transition-colors">
+            <div className="flex items-start gap-4">
+              <div className="flex-shrink-0 mt-1" aria-hidden="true">
+                {getEventIcon(event.kind)}
+              </div>
+              <div className="flex-1 min-w-0">
+                <Link
+                  href={`/commitments/${event.commitmentId}`}
+                  className="text-white font-medium hover:underline focus:outline-none focus:ring-2 focus:ring-zinc-500 rounded"
+                >
+                  {getEventTitle(event)}
+                </Link>
+                <p className="text-zinc-400 text-sm mt-1">
+                  {getEventDescription(event)} · Commitment {event.commitmentId.substring(0, 8)}
+                </p>
+              </div>
+              <time dateTime={event.occurredAt} className="text-zinc-500 text-xs whitespace-nowrap">
+                {formatRelativeTime(event.occurredAt)}
+              </time>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {hasMore && (
+        <div className="p-4 border-t border-zinc-800">
+          <Link
+            href="/commitments"
+            className="text-sm text-zinc-400 hover:text-white transition-colors inline-flex items-center gap-1"
+          >
+            View All Activity
+            <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M6 12l4-4-4-4"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,0 +1,10 @@
+export {
+  ApiClientError,
+  ApiError,
+  apiRequest,
+  apiGet,
+  apiPost,
+  apiPut,
+  apiDelete,
+} from './client/apiClient';
+export type { UiApiError } from '@/utils/errorHelpers';

--- a/src/lib/client/apiClient.ts
+++ b/src/lib/client/apiClient.ts
@@ -1,0 +1,231 @@
+import { z } from 'zod';
+import { ErrorBodySchema, OkBodySchema } from '@/lib/schemas/apiContracts';
+import { normalizeApiError, type UiApiError } from '@/utils/errorHelpers';
+import type { FailResponse, OkResponse } from '@/lib/backend/apiResponse';
+
+export class ApiClientError extends Error {
+  public readonly code: string;
+  public readonly status?: number;
+  public readonly details?: unknown;
+  public readonly retryAfterSeconds?: number;
+  public readonly correlationId?: string;
+  public readonly friendlyMessage: string;
+
+  constructor(error: UiApiError) {
+    super(error.message);
+    this.name = 'ApiClientError';
+    this.code = error.code;
+    if (error.status !== undefined) {
+      this.status = error.status;
+    }
+    if (error.details !== undefined) {
+      this.details = error.details;
+    }
+    if (error.retryAfterSeconds !== undefined) {
+      this.retryAfterSeconds = error.retryAfterSeconds;
+    }
+    if (error.correlationId !== undefined) {
+      this.correlationId = error.correlationId;
+    }
+    this.friendlyMessage = error.message;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ApiClientError);
+    }
+  }
+}
+
+export class ApiError extends ApiClientError {}
+
+function isErrorEnvelope(value: unknown): value is FailResponse {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<FailResponse> & Record<string, unknown>;
+  const hasFailure = candidate.success === false || candidate.ok === false;
+  const hasErrorShape =
+    typeof candidate.error?.code === 'string' && typeof candidate.error?.message === 'string';
+  return hasFailure && hasErrorShape;
+}
+
+function isSuccessEnvelope(value: unknown): value is OkResponse<unknown> {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<OkResponse<unknown>> & Record<string, unknown>;
+  const hasSuccess = candidate.success === true || candidate.ok === true;
+  return hasSuccess && ('data' in candidate || 'result' in candidate);
+}
+
+export function parseApiResponse<T>(payload: unknown): T {
+  if (isErrorEnvelope(payload)) {
+    const parsed = ErrorBodySchema.safeParse(payload);
+    if (parsed.success) {
+      throw new ApiError(
+        normalizeApiError(
+          {
+            code: parsed.data.error.code,
+            message: parsed.data.error.message,
+            details: parsed.data.error.details,
+          },
+          500,
+        ),
+      );
+    }
+  }
+
+  if (isSuccessEnvelope(payload)) {
+    const record = payload as unknown as Record<string, unknown>;
+    if ('data' in record) {
+      return record.data as T;
+    }
+
+    const parsed = OkBodySchema(z.any()).safeParse(payload);
+    if (parsed.success) {
+      return parsed.data.data as T;
+    }
+  }
+
+  return payload as T;
+}
+
+export async function apiRequest<T>(
+  input: string | URL | Request,
+  init?: RequestInit,
+  options?: { timeoutMs?: number },
+): Promise<T> {
+  const timeoutMs = options?.timeoutMs ?? 5000;
+  const controller = new AbortController();
+  const externalSignal = init?.signal;
+
+  const timeoutId = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+
+  const abortPromise = new Promise<never>((_, reject) => {
+    const onAbort = () => {
+      controller.abort();
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+
+    if (externalSignal) {
+      if (externalSignal.aborted) {
+        onAbort();
+        return;
+      }
+      externalSignal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    controller.signal.addEventListener('abort', onAbort, { once: true });
+  });
+
+  try {
+    const response = await Promise.race([
+      fetch(input, { ...init, signal: controller.signal }),
+      abortPromise,
+    ]);
+    clearTimeout(timeoutId);
+
+    let payload: unknown;
+    let isJson = true;
+    try {
+      payload = await response.json();
+    } catch {
+      isJson = false;
+      payload = null;
+    }
+
+    if (!response.ok) {
+      if (isJson && isErrorEnvelope(payload)) {
+        throw new ApiError(
+          normalizeApiError(
+            {
+              code: payload.error.code,
+              message: payload.error.message,
+              details: payload.error.details,
+              retryAfterSeconds: payload.error.retryAfterSeconds,
+              correlationId: payload.error.correlationId,
+            },
+            response.status,
+          ),
+        );
+      }
+
+      const contentType = response.headers.get('content-type') || '';
+      const statusText = `${response.status} ${response.statusText || 'Error'}`;
+
+      if (!isJson) {
+        throw new ApiError(
+          normalizeApiError(
+            new Error(
+              `Request failed with status ${statusText} (non-JSON response, content-type: ${contentType})`,
+            ),
+            response.status,
+          ),
+        );
+      }
+
+      throw new ApiError(
+        normalizeApiError(new Error(`Request failed with status ${statusText}`), response.status),
+      );
+    }
+
+    return parseApiResponse<T>(payload);
+  } catch (error) {
+    clearTimeout(timeoutId);
+
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new ApiError({
+        code: 'TIMEOUT',
+        message: 'The request was cancelled.',
+        status: 0,
+      });
+    }
+
+    throw new ApiError(normalizeApiError(error));
+  }
+}
+
+export function apiGet<T>(
+  url: string,
+  initOrTimeout?: RequestInit | number,
+  timeoutMs = 5000,
+): Promise<T> {
+  if (typeof initOrTimeout === 'number') {
+    return apiRequest<T>(url, { method: 'GET' }, { timeoutMs: initOrTimeout });
+  }
+
+  return apiRequest<T>(url, { method: 'GET', ...(initOrTimeout ?? {}) }, { timeoutMs });
+}
+
+export function apiPost<T>(url: string, body: unknown, timeoutMs = 5000): Promise<T> {
+  return apiRequest<T>(
+    url,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    { timeoutMs },
+  );
+}
+
+export function apiPut<T>(url: string, body: unknown, timeoutMs = 5000): Promise<T> {
+  return apiRequest<T>(
+    url,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    { timeoutMs },
+  );
+}
+
+export function apiDelete<T>(url: string, timeoutMs = 5000): Promise<T> {
+  return apiRequest<T>(url, { method: 'DELETE' }, { timeoutMs });
+}

--- a/src/utils/errorHelpers.ts
+++ b/src/utils/errorHelpers.ts
@@ -1,0 +1,195 @@
+import { ERROR_CODE_REGISTRY } from '../lib/backend/errorCodes';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ApiErrorResponse {
+  success: false;
+  error: {
+    code: number;
+    type: string;
+    message: string;
+    retryAfter?: number;
+    details?: string;
+  };
+}
+
+export interface UiApiError {
+  code: string;
+  message: string;
+  status?: number;
+  details?: unknown;
+  retryAfterSeconds?: number;
+  correlationId?: string;
+}
+
+// ─── Error Factories ──────────────────────────────────────────────────────────
+
+/**
+ * Creates an ApiErrorResponse for 429 Rate Limit Exceeded.
+ * Default message and status code are sourced from ERROR_CODE_REGISTRY.TOO_MANY_REQUESTS.
+ */
+export function rateLimitError(retryAfter = 60, details?: string): ApiErrorResponse {
+  const registryEntry = ERROR_CODE_REGISTRY.TOO_MANY_REQUESTS!;
+  return {
+    success: false,
+    error: {
+      code: registryEntry.statusCode,
+      type: 'RATE_LIMIT_EXCEEDED',
+      message: registryEntry.meaning,
+      retryAfter,
+      ...(details && process.env.NODE_ENV === 'development' ? { details } : {}),
+    },
+  };
+}
+
+/**
+ * Creates an ApiErrorResponse for 500 Internal Server Error.
+ * Default message and status code are sourced from ERROR_CODE_REGISTRY.INTERNAL_ERROR.
+ */
+export function internalServerError(details?: string): ApiErrorResponse {
+  const registryEntry = ERROR_CODE_REGISTRY.INTERNAL_ERROR!;
+  return {
+    success: false,
+    error: {
+      code: registryEntry.statusCode,
+      type: 'INTERNAL_SERVER_ERROR',
+      message: registryEntry.meaning,
+      ...(details && process.env.NODE_ENV === 'development' ? { details } : {}),
+    },
+  };
+}
+
+/**
+ * Creates an ApiErrorResponse for 502 Bad Gateway.
+ * Default message and status code are sourced from ERROR_CODE_REGISTRY.BAD_GATEWAY.
+ */
+export function badGatewayError(details?: string): ApiErrorResponse {
+  const registryEntry = ERROR_CODE_REGISTRY.BAD_GATEWAY!;
+  return {
+    success: false,
+    error: {
+      code: registryEntry.statusCode,
+      type: 'BAD_GATEWAY',
+      message: registryEntry.meaning,
+      ...(details && process.env.NODE_ENV === 'development' ? { details } : {}),
+    },
+  };
+}
+
+/**
+ * Creates an ApiErrorResponse for 503 Service Unavailable.
+ * Default message and status code are sourced from ERROR_CODE_REGISTRY.SERVICE_UNAVAILABLE.
+ */
+export function serviceUnavailableError(retryAfter = 30, details?: string): ApiErrorResponse {
+  const registryEntry = ERROR_CODE_REGISTRY.SERVICE_UNAVAILABLE!;
+  return {
+    success: false,
+    error: {
+      code: registryEntry.statusCode,
+      type: 'SERVICE_UNAVAILABLE',
+      message: registryEntry.meaning,
+      retryAfter,
+      ...(details && process.env.NODE_ENV === 'development' ? { details } : {}),
+    },
+  };
+}
+
+/**
+ * Creates an ApiErrorResponse for 504 Gateway Timeout.
+ * Default message and status code are sourced from ERROR_CODE_REGISTRY.GATEWAY_TIMEOUT.
+ */
+export function gatewayTimeoutError(details?: string): ApiErrorResponse {
+  const registryEntry = ERROR_CODE_REGISTRY.GATEWAY_TIMEOUT!;
+  return {
+    success: false,
+    error: {
+      code: registryEntry.statusCode,
+      type: 'GATEWAY_TIMEOUT',
+      message: registryEntry.meaning,
+      ...(details && process.env.NODE_ENV === 'development' ? { details } : {}),
+    },
+  };
+}
+
+// ─── Generic 5xx Resolver ─────────────────────────────────────────────────────
+
+export function resolveServerError(statusCode: number, details?: string): ApiErrorResponse {
+  switch (statusCode) {
+    case 502:
+      return badGatewayError(details);
+    case 503:
+      return serviceUnavailableError(30, details);
+    case 504:
+      return gatewayTimeoutError(details);
+    default:
+      return internalServerError(details);
+  }
+}
+
+// ─── HTTP Headers Helper ──────────────────────────────────────────────────────
+
+export function getErrorHeaders(error: ApiErrorResponse): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (error.error.retryAfter !== undefined) {
+    headers['Retry-After'] = String(error.error.retryAfter);
+  }
+
+  return headers;
+}
+
+export function normalizeApiError(error: unknown, status?: number): UiApiError {
+  const maybeErrorLike = error as Partial<UiApiError> & { code?: string; message?: string };
+  const codeFromError = typeof maybeErrorLike?.code === 'string' ? maybeErrorLike.code : undefined;
+  const messageFromError =
+    typeof maybeErrorLike?.message === 'string' ? maybeErrorLike.message : undefined;
+  const inboundMessage =
+    messageFromError ||
+    (error instanceof Error ? error.message : undefined) ||
+    'Something went wrong.';
+  const lower = inboundMessage.toLowerCase();
+
+  const code =
+    codeFromError?.toUpperCase() ||
+    (lower.includes('fetch') || lower.includes('network') ? 'NETWORK_ERROR' : undefined) ||
+    (lower.includes('timeout') || lower.includes('aborted') ? 'TIMEOUT' : undefined) ||
+    (lower.includes('not found') ? 'NOT_FOUND' : undefined) ||
+    (lower.includes('unauthorized') ? 'UNAUTHORIZED' : undefined) ||
+    (lower.includes('forbidden') ? 'FORBIDDEN' : undefined) ||
+    (lower.includes('rate limit') ? 'RATE_LIMIT_EXCEEDED' : undefined) ||
+    'REQUEST_FAILED';
+
+  const message =
+    code === 'NETWORK_ERROR'
+      ? 'We could not reach the server. Please try again.'
+      : code === 'TIMEOUT'
+        ? 'The request took too long. Please try again.'
+        : code === 'NOT_FOUND'
+          ? 'The requested resource was not found.'
+          : code === 'UNAUTHORIZED'
+            ? 'You are not authorized to perform that action.'
+            : code === 'FORBIDDEN'
+              ? 'You do not have permission to do that.'
+              : code === 'RATE_LIMIT_EXCEEDED'
+                ? 'Too many requests. Please wait before trying again.'
+                : inboundMessage;
+
+  // Only attach optional fields when they are actually defined, to satisfy
+  // `exactOptionalPropertyTypes` (no explicit `undefined` on optional props).
+  const result: UiApiError = { code, message };
+  if (status !== undefined) {
+    result.status = status;
+  }
+  if (maybeErrorLike?.details !== undefined) {
+    result.details = maybeErrorLike.details;
+  }
+  if (maybeErrorLike?.retryAfterSeconds !== undefined) {
+    result.retryAfterSeconds = maybeErrorLike.retryAfterSeconds;
+  }
+  if (maybeErrorLike?.correlationId !== undefined) {
+    result.correlationId = maybeErrorLike.correlationId;
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

Closes #1396

`RecentActivityFeed.tsx`'s `loadEvents` previously fetched per-commitment history **sequentially** in a `for`-loop:

```ts
for (const commitment of commitments) {
  // ... await apiGet(`/api/commitments/${commitment.id}/history`) ...
}
```

Each `/api/commitments/{id}/history` request had to complete before the next one started. For a user with **N** active commitments, the feed took roughly **N × single-request latency** to render (instead of `max(latency)`), and the loading skeleton stayed visible the entire time.

This PR replaces the sequential loop with `Promise.allSettled(commitments.map(...))`, which issues all per-commitment history requests **concurrently**, dropping feed render time from **N × latency** to **max(latency)** — the loading skeleton disappears as soon as the slowest single request resolves, not after the sum of all of them.

### Behavior preserved

- ✅ **Per-commitment try/catch-and-log**: each request keeps its own `try/catch` with `console.error` logging on failure (unchanged from the original), so one failing commitment never blocks or breaks the rest of the feed.
- ✅ **Empty-state semantics**: commitments that fail or return no events simply contribute no entries, and commitments that succeed still render — identical to before.
- ✅ **`Promise.allSettled`** (per the issue's acceptance criteria) guarantees the aggregate never rejects even if an individual request does, and we `flatMap` only fulfilled results.

## Changes

### `src/components/dashboard/RecentActivityFeed.tsx`
- Rewrote `loadEvents` to use `Promise.allSettled(commitments.map(async (commitment) => { ... }))` with the original per-commitment try/catch-and-log preserved inside each mapper.
- The mapper resolves to the commitment's enriched `FeedEvent[]` (or `[]` on failure); the outer `allSettled` result is flattened into a single event list.
- Adjusted the `FeedEvent` type to an intersection (`HistoryEvent & { commitmentId: string }`) so discriminated-union narrowing on `event.kind` still works.
- Removed a redundant `role="list"` on the `<ul>` to satisfy `jsx-a11y/no-redundant-roles`.

### `src/components/dashboard/RecentActivityFeed.test.tsx` (new)
Seven tests covering the feed, including:

- **Concurrency test** — asserts requests are issued **in parallel**: it mocks `apiGet` with never-resolving promises, renders the feed, and verifies all N requests are fired *before any promise resolves*. A sequential implementation could never pass this test, since the 2nd call would only fire after the 1st resolves.
- **Resilience test** — one commitment's request rejects (logged via `console.error`) while the other's succeeds; asserts the successful commitment's events still render.
- Rendering, loading, and empty-state tests.

### Restored support files (new against `upstream/master`)
These files exist in the intended feature but were **deleted from the repository by the destructive `1ecce7d2` commit** and never restored upstream — they currently **404 on `upstream/master`**:

- `src/lib/apiClient.ts`
- `src/lib/client/apiClient.ts`
- `src/utils/errorHelpers.ts`
- `src/components/Skeleton.tsx`

> ⚠️ Important context for reviewers: this PR is *not* adding new dead code. Upstream `useTestNotification.ts` already imports `apiRequest` from `@/lib/client/apiClient`, a module that **does not exist** on current `upstream/master` (verified via the GitHub contents API → 404). Restoring these files **repairs a broken import** on master. They are also transitive dependencies of `RecentActivityFeed.tsx` (`apiGet` ← `@/lib/apiClient` ← `./client/apiClient` ← `errorHelpers`).

## Type-safety fixes applied to the restored files

The restored files predate the repo's stricter `tsconfig.json` settings, so they were brought up to current standards:

- `client/apiClient.ts`: optional properties assigned conditionally to satisfy `exactOptionalPropertyTypes`.
- `errorHelpers.ts`: `normalizeApiError` builds its passthrough object with conditional field assignment (exact optional properties) and uses safe registry lookups under `noUncheckedIndexedAccess`.

## Motivation

For a user with N active commitments, the sequential loop renders the feed after the **sum** of all request latencies. With `Promise.allSettled`, it renders after the **maximum** single latency — a linear-to-constant improvement that matters most exactly when a user has many commitments (the loading skeleton stays visible for N× latency today).

## Testing

Run locally and passing:

- ✅ `npx prettier --check` on all 6 files
- ✅ `npx eslint` on all 6 files (0 errors)
- ✅ `npx vitest run src/components/dashboard/RecentActivityFeed.test.tsx` — **7/7 tests pass**, including the new concurrency + resilience tests
- ✅ `npx tsc --noEmit` — no errors in any of the changed files

> Note: the repo's full typecheck currently reports a **pre-existing, unrelated** error in `tests/components/MyCommitmentsGrid.perf.test.tsx` (module `MyCommitmentsGridSkeleton` missing — same upstream `1ecce7d2` deletion artifact, file absent from `upstream/master`). It is not caused by this PR and CI's typecheck job is configured with `continue-on-error: true`.

## Checklist

- [x] Sequential fetch replaced with `Promise.allSettled(commitments.map(...))`
- [x] Per-commitment try/catch-and-log behavior preserved
- [x] Test asserting requests are issued concurrently added
- [x] Formatting, lint, and unit tests pass locally
- [x] No errors introduced in the changed files by the full typecheck
